### PR TITLE
Add gw sync, enhanced status, and AI workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ gw init ~/dev                                          # register repos director
 gw create my-feature -r svc-a,svc-b -b feat/login     # create workspace
 gw list                                                # list workspaces
 gw status my-feature                                   # git status across repos
+gw sync my-feature                                     # rebase all repos onto base branch
 gw go my-feature                                       # cd into workspace
 gw delete my-feature                                   # clean up
 ```
@@ -61,6 +62,18 @@ setup = "pnpm install"             # run after worktree creation
 ```toml
 setup = ["uv sync", "uv run pre-commit install"]
 ```
+
+## Works great with AI coding tools
+
+Worktrees mean isolation. That makes Grove a natural fit for tools like [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — spin up a workspace, let your AI agent work across repos without touching anything else, clean up when done:
+
+```bash
+gw create -p backend -b fix/auth-bug
+claude "fix the auth token expiry bug across svc-auth and api-gateway"
+gw delete fix-auth-bug
+```
+
+Grove copies your `CLAUDE.md` into new workspaces, so your agent gets project context from the start.
 
 ## What it does
 

--- a/src/grove/cli.py
+++ b/src/grove/cli.py
@@ -10,6 +10,8 @@ import typer
 
 from grove import __version__, config, discover, state, workspace
 from grove.console import console, error, info, make_table, success, warning
+from grove.git import pr_status as git_pr_status
+from grove.models import Workspace
 from grove.update import get_newer_version
 
 
@@ -353,20 +355,11 @@ def delete(
         raise typer.Exit(1)
 
 
-@app.command()
-def status(
-    name: str | None = typer.Argument(
-        None,
-        help="Workspace name (auto-detects from cwd)",
-        autocompletion=complete_workspace_name,
-    ),
-    verbose: bool = typer.Option(False, "--verbose", "-V", help="Show full git status output"),
-) -> None:
-    """Show git status across a workspace's repos."""
+def _resolve_workspace(name: str | None) -> Workspace:
+    """Resolve a workspace by name, cwd auto-detection, or interactive picker."""
     if name is None:
         ws = state.find_workspace_by_path(Path.cwd())
         if ws is None:
-            # Interactive fallback
             workspaces = state.load_workspaces()
             if not workspaces:
                 error("Not inside a workspace and no workspaces exist")
@@ -381,12 +374,61 @@ def status(
         if ws is None:
             error(f"Workspace [bold]{name}[/] not found")
             raise typer.Exit(1)
+    return ws
+
+
+def _format_drift(ahead: str, behind: str) -> str:
+    """Format ahead/behind counts for table display."""
+    if ahead == "-" or behind == "-":
+        return "[dim]-[/]"
+    return f"[green]{ahead}↑[/] [yellow]{behind}↓[/]"
+
+
+def _format_pr(pr_data: dict | None) -> str:
+    """Format PR info for table display."""
+    if pr_data is None:
+        return "[dim]—[/]"
+    number = pr_data.get("number", "?")
+    pr_state = pr_data.get("state", "OPEN")
+    review = pr_data.get("reviewDecision", "")
+
+    if pr_state == "MERGED":
+        return f"[magenta]#{number} (merged)[/]"
+    if pr_state == "CLOSED":
+        return f"[dim]#{number} (closed)[/]"
+
+    review_map = {
+        "APPROVED": "[green]approved[/]",
+        "CHANGES_REQUESTED": "[yellow]changes requested[/]",
+        "REVIEW_REQUIRED": "[dim]review required[/]",
+    }
+    review_text = review_map.get(review, "[dim]open[/]")
+    return f"#{number} ({review_text})"
+
+
+@app.command()
+def status(
+    name: str | None = typer.Argument(
+        None,
+        help="Workspace name (auto-detects from cwd)",
+        autocompletion=complete_workspace_name,
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-V", help="Show full git status output"),
+    show_pr: bool = typer.Option(False, "--pr", "-P", help="Show GitHub PR status (requires gh)"),
+) -> None:
+    """Show git status across a workspace's repos."""
+    ws = _resolve_workspace(name)
 
     console.print(f"[bold]Workspace:[/] {ws.name}  [dim]({ws.path})[/]")
     console.print()
 
     results = workspace.workspace_status(ws)
-    table = make_table("Repo", "Branch", "Status")
+
+    columns = ["Repo", "Branch", "↑↓", "Status"]
+    if show_pr:
+        columns.append("PR")
+    table = make_table(*columns)
+
     for r in results:
         raw_status = r["status"]
         if raw_status == "clean":
@@ -394,11 +436,17 @@ def status(
         elif raw_status.startswith("error:"):
             display = f"[red]{raw_status}[/]"
         else:
-            # Count changed files
             changed_count = len(raw_status.splitlines())
             display = f"[yellow]{changed_count} changed[/]"
 
-        table.add_row(r["repo"], r["branch"], display)
+        drift = _format_drift(r.get("ahead", "-"), r.get("behind", "-"))
+
+        row = [r["repo"], r["branch"], drift, display]
+        if show_pr:
+            pr_info = git_pr_status(ws.path / r["repo"])
+            row.append(_format_pr(pr_info))
+
+        table.add_row(*row)
     console.print(table)
 
     # Show full status when verbose
@@ -407,6 +455,39 @@ def status(
             if r["status"] not in ("clean", "") and not r["status"].startswith("error:"):
                 console.print(f"\n[bold cyan]{r['repo']}[/]")
                 console.print(r["status"])
+
+
+@app.command()
+def sync(
+    name: str | None = typer.Argument(
+        None,
+        help="Workspace name (auto-detects from cwd)",
+        autocompletion=complete_workspace_name,
+    ),
+) -> None:
+    """Sync workspace repos by rebasing onto their base branches."""
+    ws = _resolve_workspace(name)
+
+    console.print(f"[bold]Syncing:[/] {ws.name}")
+    console.print()
+
+    results = workspace.sync_workspace(ws)
+    for r in results:
+        result_text = r["result"]
+        base = r.get("base", "?")
+        if result_text == "up to date":
+            console.print(f"  [green]✓[/] {r['repo']}  [dim]already up to date[/]")
+        elif result_text.startswith("rebased"):
+            success(f"{r['repo']}  {result_text}")
+        elif result_text == "conflict":
+            error(
+                f"{r['repo']}  conflict — rebase aborted. "
+                f"To retry: cd {ws.path / r['repo']} && git rebase {base}"
+            )
+        elif result_text.startswith("skipped"):
+            warning(f"{r['repo']}  {result_text}")
+        else:
+            error(f"{r['repo']}  {result_text}")
 
 
 _BACK_TO_REPOS = "← back to repos dir"

--- a/src/grove/git.py
+++ b/src/grove/git.py
@@ -131,3 +131,49 @@ def current_branch(path: Path) -> str:
     """Get the current branch name."""
     result = _run(["branch", "--show-current"], cwd=path)
     return result.stdout.strip()
+
+
+def rebase_onto(path: Path, base: str) -> None:
+    """Rebase the current branch onto *base*."""
+    _run(["rebase", base], cwd=path)
+
+
+def rebase_abort(path: Path) -> None:
+    """Abort an in-progress rebase."""
+    _run(["rebase", "--abort"], cwd=path)
+
+
+def commits_ahead_behind(path: Path, upstream: str) -> tuple[int, int]:
+    """Return ``(ahead, behind)`` commit counts relative to *upstream*.
+
+    Uses ``git rev-list --left-right --count upstream...HEAD``.
+    """
+    result = _run(["rev-list", "--left-right", "--count", f"{upstream}...HEAD"], cwd=path)
+    parts = result.stdout.strip().split()
+    if len(parts) != 2:
+        raise GitError(f"Unexpected rev-list output: {result.stdout.strip()}")
+    try:
+        # left = upstream-only (behind), right = HEAD-only (ahead)
+        return int(parts[1]), int(parts[0])
+    except ValueError as e:
+        raise GitError(f"Could not parse rev-list output: {result.stdout.strip()}") from e
+
+
+def pr_status(path: Path) -> dict | None:
+    """Get PR info via GitHub CLI. Returns ``None`` if unavailable."""
+    import json
+    import shutil
+
+    if not shutil.which("gh"):
+        return None
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", "--json", "number,state,reviewDecision"],
+            cwd=path,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return json.loads(result.stdout)
+    except (subprocess.CalledProcessError, json.JSONDecodeError, OSError):
+        return None

--- a/src/grove/workspace.py
+++ b/src/grove/workspace.py
@@ -164,21 +164,121 @@ def delete_workspace(name: str) -> bool:
     return True
 
 
+def sync_workspace(workspace: Workspace) -> list[dict[str, str]]:
+    """Sync all repos by rebasing onto their base branches.
+
+    Returns list of ``{repo, base, result}`` dicts.
+    """
+    results: list[dict[str, str]] = []
+    for repo_wt in workspace.repos:
+        # Fetch latest
+        with console.status(f"Fetching [bold]{repo_wt.repo_name}[/]…"):
+            try:
+                git.fetch(repo_wt.worktree_path)
+            except GitError as e:
+                warning(f"Could not fetch {repo_wt.repo_name}: {e}")
+
+        # Determine base branch
+        base = git.repo_base_branch(repo_wt.source_repo)
+        if base is None:
+            try:
+                base = git.default_branch(repo_wt.source_repo)
+            except GitError:
+                results.append(
+                    {
+                        "repo": repo_wt.repo_name,
+                        "base": "?",
+                        "result": "error: could not determine base branch",
+                    }
+                )
+                continue
+
+        # Skip dirty worktrees — rebase on uncommitted changes is dangerous
+        status_text = git.repo_status(repo_wt.worktree_path)
+        if status_text:
+            results.append(
+                {
+                    "repo": repo_wt.repo_name,
+                    "base": base,
+                    "result": "skipped: uncommitted changes",
+                }
+            )
+            continue
+
+        # Check if rebase is needed
+        try:
+            _ahead, behind = git.commits_ahead_behind(repo_wt.worktree_path, base)
+        except GitError:
+            behind = -1  # unknown, attempt rebase anyway
+
+        if behind == 0:
+            results.append(
+                {
+                    "repo": repo_wt.repo_name,
+                    "base": base,
+                    "result": "up to date",
+                }
+            )
+            continue
+
+        # Rebase
+        with console.status(f"Rebasing [bold]{repo_wt.repo_name}[/] onto {base}…"):
+            try:
+                git.rebase_onto(repo_wt.worktree_path, base)
+                msg = f"rebased ({behind} new commits)" if behind > 0 else "rebased"
+                results.append(
+                    {
+                        "repo": repo_wt.repo_name,
+                        "base": base,
+                        "result": msg,
+                    }
+                )
+            except GitError:
+                # Abort failed rebase to leave worktree in a clean state
+                with contextlib.suppress(GitError):
+                    git.rebase_abort(repo_wt.worktree_path)
+                results.append(
+                    {
+                        "repo": repo_wt.repo_name,
+                        "base": base,
+                        "result": "conflict",
+                    }
+                )
+
+    return results
+
+
 def workspace_status(workspace: Workspace) -> list[dict[str, str]]:
     """Get status of all repos in a workspace.
 
-    Returns list of {repo, branch, status} dicts.
+    Returns list of ``{repo, branch, status, ahead, behind}`` dicts.
     """
     results: list[dict[str, str]] = []
     for repo_wt in workspace.repos:
         try:
             branch = git.current_branch(repo_wt.worktree_path)
             status_text = git.repo_status(repo_wt.worktree_path)
+
+            # Ahead/behind (best-effort — never crash status for this)
+            ahead_str = "-"
+            behind_str = "-"
+            try:
+                base = git.repo_base_branch(repo_wt.source_repo)
+                if base is None:
+                    base = git.default_branch(repo_wt.source_repo)
+                ahead, behind = git.commits_ahead_behind(repo_wt.worktree_path, base)
+                ahead_str = str(ahead)
+                behind_str = str(behind)
+            except Exception:
+                pass
+
             results.append(
                 {
                     "repo": repo_wt.repo_name,
                     "branch": branch,
                     "status": status_text or "clean",
+                    "ahead": ahead_str,
+                    "behind": behind_str,
                 }
             )
         except GitError as e:
@@ -187,6 +287,8 @@ def workspace_status(workspace: Workspace) -> list[dict[str, str]]:
                     "repo": repo_wt.repo_name,
                     "branch": "?",
                     "status": f"error: {e}",
+                    "ahead": "-",
+                    "behind": "-",
                 }
             )
     return results

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from typer.testing import CliRunner
 
-from grove.cli import _sanitize_name, app
+from grove.cli import _format_drift, _format_pr, _sanitize_name, app
 from grove.models import Config, Workspace
 
 runner = CliRunner()
@@ -42,6 +42,53 @@ class TestSanitizeName:
 
     def test_leading_slash(self):
         assert _sanitize_name("/feat") == "feat"
+
+
+class TestFormatDrift:
+    def test_with_numbers(self):
+        result = _format_drift("3", "1")
+        assert "3↑" in result
+        assert "1↓" in result
+
+    def test_zero(self):
+        result = _format_drift("0", "0")
+        assert "0↑" in result
+        assert "0↓" in result
+
+    def test_unknown(self):
+        result = _format_drift("-", "-")
+        assert "-" in result
+
+    def test_partial_unknown(self):
+        # If either is unknown, show dash
+        result = _format_drift("3", "-")
+        assert "-" in result
+
+
+class TestFormatPr:
+    def test_none(self):
+        result = _format_pr(None)
+        assert "—" in result
+
+    def test_open_approved(self):
+        result = _format_pr({"number": 42, "state": "OPEN", "reviewDecision": "APPROVED"})
+        assert "#42" in result
+        assert "approved" in result
+
+    def test_changes_requested(self):
+        result = _format_pr({"number": 10, "state": "OPEN", "reviewDecision": "CHANGES_REQUESTED"})
+        assert "#10" in result
+        assert "changes requested" in result
+
+    def test_merged(self):
+        result = _format_pr({"number": 99, "state": "MERGED", "reviewDecision": ""})
+        assert "#99" in result
+        assert "merged" in result
+
+    def test_open_no_review(self):
+        result = _format_pr({"number": 5, "state": "OPEN", "reviewDecision": ""})
+        assert "#5" in result
+        assert "open" in result
 
 
 class TestInit:
@@ -213,11 +260,61 @@ class TestStatus:
             patch("grove.cli.workspace.workspace_status") as mock_status,
         ):
             mock_status.return_value = [
-                {"repo": "svc-auth", "branch": "feat/test", "status": "clean"},
+                {
+                    "repo": "svc-auth",
+                    "branch": "feat/test",
+                    "status": "clean",
+                    "ahead": "0",
+                    "behind": "0",
+                },
             ]
             result = runner.invoke(app, ["status", "test-ws"])
         assert result.exit_code == 0
         assert "clean" in result.output
+        assert "0↑" in result.output
+        assert "0↓" in result.output
+
+    def test_ahead_behind_display(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with (
+            patch("grove.cli.workspace.workspace_status") as mock_status,
+        ):
+            mock_status.return_value = [
+                {
+                    "repo": "svc-auth",
+                    "branch": "feat/test",
+                    "status": "clean",
+                    "ahead": "3",
+                    "behind": "1",
+                },
+            ]
+            result = runner.invoke(app, ["status", "test-ws"])
+        assert result.exit_code == 0
+        assert "3↑" in result.output
+        assert "1↓" in result.output
+
+    def test_ahead_behind_unknown(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with (
+            patch("grove.cli.workspace.workspace_status") as mock_status,
+        ):
+            mock_status.return_value = [
+                {
+                    "repo": "svc-auth",
+                    "branch": "feat/test",
+                    "status": "clean",
+                    "ahead": "-",
+                    "behind": "-",
+                },
+            ]
+            result = runner.invoke(app, ["status", "test-ws"])
+        assert result.exit_code == 0
+        # Should show dash, not crash
+        assert "-" in result.output
 
     def test_verbose_shows_details(self, tmp_grove, sample_workspace):
         from grove import state
@@ -227,7 +324,13 @@ class TestStatus:
             patch("grove.cli.workspace.workspace_status") as mock_status,
         ):
             mock_status.return_value = [
-                {"repo": "svc-auth", "branch": "feat/test", "status": " M file.py\n?? new.txt"},
+                {
+                    "repo": "svc-auth",
+                    "branch": "feat/test",
+                    "status": " M file.py\n?? new.txt",
+                    "ahead": "1",
+                    "behind": "0",
+                },
             ]
             result = runner.invoke(app, ["status", "test-ws", "-V"])
         assert result.exit_code == 0
@@ -236,6 +339,119 @@ class TestStatus:
 
     def test_not_found(self, tmp_grove):
         result = runner.invoke(app, ["status", "nope"])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_pr_flag(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with (
+            patch("grove.cli.workspace.workspace_status") as mock_status,
+            patch("grove.cli.git_pr_status") as mock_pr,
+        ):
+            mock_status.return_value = [
+                {
+                    "repo": "svc-auth",
+                    "branch": "feat/test",
+                    "status": "clean",
+                    "ahead": "1",
+                    "behind": "0",
+                },
+            ]
+            mock_pr.return_value = {
+                "number": 42,
+                "state": "OPEN",
+                "reviewDecision": "APPROVED",
+            }
+            result = runner.invoke(app, ["status", "test-ws", "--pr"])
+        assert result.exit_code == 0
+        assert "#42" in result.output
+        assert "approved" in result.output
+
+    def test_pr_flag_no_pr(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with (
+            patch("grove.cli.workspace.workspace_status") as mock_status,
+            patch("grove.cli.git_pr_status", return_value=None),
+        ):
+            mock_status.return_value = [
+                {
+                    "repo": "svc-auth",
+                    "branch": "feat/test",
+                    "status": "clean",
+                    "ahead": "0",
+                    "behind": "0",
+                },
+            ]
+            result = runner.invoke(app, ["status", "test-ws", "--pr"])
+        assert result.exit_code == 0
+
+
+class TestSync:
+    def test_success_up_to_date(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with patch("grove.cli.workspace.sync_workspace") as mock_sync:
+            mock_sync.return_value = [
+                {"repo": "svc-auth", "base": "origin/main", "result": "up to date"},
+            ]
+            result = runner.invoke(app, ["sync", "test-ws"])
+        assert result.exit_code == 0
+        assert "up to date" in result.output
+
+    def test_success_rebased(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with patch("grove.cli.workspace.sync_workspace") as mock_sync:
+            mock_sync.return_value = [
+                {
+                    "repo": "svc-auth",
+                    "base": "origin/main",
+                    "result": "rebased (3 new commits)",
+                },
+            ]
+            result = runner.invoke(app, ["sync", "test-ws"])
+        assert result.exit_code == 0
+        assert "rebased" in result.output
+
+    def test_conflict_shows_instructions(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with patch("grove.cli.workspace.sync_workspace") as mock_sync:
+            mock_sync.return_value = [
+                {"repo": "svc-auth", "base": "origin/main", "result": "conflict"},
+            ]
+            result = runner.invoke(app, ["sync", "test-ws"])
+        assert result.exit_code == 0
+        assert "conflict" in result.output
+        # Rich may wrap the long path across lines, so check key parts separately
+        assert "rebase" in result.output
+        assert "origin/main" in result.output
+
+    def test_skipped_dirty(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with patch("grove.cli.workspace.sync_workspace") as mock_sync:
+            mock_sync.return_value = [
+                {
+                    "repo": "svc-auth",
+                    "base": "origin/main",
+                    "result": "skipped: uncommitted changes",
+                },
+            ]
+            result = runner.invoke(app, ["sync", "test-ws"])
+        assert result.exit_code == 0
+        assert "uncommitted" in result.output
+
+    def test_not_found(self, tmp_grove):
+        result = runner.invoke(app, ["sync", "nope"])
         assert result.exit_code == 1
         assert "not found" in result.output
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -119,6 +119,76 @@ class TestRepoBaseBranch:
         assert git.repo_base_branch(tmp_path) is None
 
 
+class TestRebaseOnto:
+    def test_success(self, mock_run):
+        git.rebase_onto(Path("/ws/repo"), "origin/main")
+        mock_run.assert_called_once_with(["rebase", "origin/main"], cwd=Path("/ws/repo"))
+
+    def test_failure(self, mock_run):
+        mock_run.side_effect = GitError("conflict")
+        with pytest.raises(GitError):
+            git.rebase_onto(Path("/ws/repo"), "origin/main")
+
+
+class TestRebaseAbort:
+    def test_success(self, mock_run):
+        git.rebase_abort(Path("/ws/repo"))
+        mock_run.assert_called_once_with(["rebase", "--abort"], cwd=Path("/ws/repo"))
+
+
+class TestCommitsAheadBehind:
+    def test_parses_output(self, mock_run):
+        # left=2 (behind), right=3 (ahead)
+        mock_run.return_value = MagicMock(stdout="2\t3\n")
+        ahead, behind = git.commits_ahead_behind(Path("/ws"), "origin/main")
+        assert ahead == 3
+        assert behind == 2
+        mock_run.assert_called_once_with(
+            ["rev-list", "--left-right", "--count", "origin/main...HEAD"],
+            cwd=Path("/ws"),
+        )
+
+    def test_zero_drift(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="0\t0\n")
+        ahead, behind = git.commits_ahead_behind(Path("/ws"), "origin/main")
+        assert ahead == 0
+        assert behind == 0
+
+    def test_git_failure(self, mock_run):
+        mock_run.side_effect = GitError("bad ref")
+        with pytest.raises(GitError):
+            git.commits_ahead_behind(Path("/ws"), "origin/nope")
+
+    def test_bad_output_raises(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="garbage\n")
+        with pytest.raises(GitError, match="Unexpected rev-list output"):
+            git.commits_ahead_behind(Path("/ws"), "origin/main")
+
+
+class TestPrStatus:
+    def test_returns_none_when_gh_missing(self):
+        with patch("shutil.which", return_value=None):
+            assert git.pr_status(Path("/ws")) is None
+
+    def test_returns_pr_data(self):
+        pr_json = '{"number": 42, "state": "OPEN", "reviewDecision": "APPROVED"}'
+        with (
+            patch("shutil.which", return_value="/usr/bin/gh"),
+            patch("subprocess.run") as mock_sub,
+        ):
+            mock_sub.return_value = MagicMock(stdout=pr_json, returncode=0)
+            result = git.pr_status(Path("/ws"))
+        assert result == {"number": 42, "state": "OPEN", "reviewDecision": "APPROVED"}
+
+    def test_returns_none_on_no_pr(self):
+        with (
+            patch("shutil.which", return_value="/usr/bin/gh"),
+            patch("subprocess.run") as mock_sub,
+        ):
+            mock_sub.side_effect = subprocess.CalledProcessError(1, "gh", stderr="no PR")
+            assert git.pr_status(Path("/ws")) is None
+
+
 class TestRunIntegration:
     """Test the actual _run function with subprocess mocking."""
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -203,6 +203,96 @@ class TestDeleteWorkspace:
         assert result is False
 
 
+class TestSyncWorkspace:
+    def test_up_to_date(self, tmp_grove, sample_workspace):
+        with (
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.repo_base_branch", return_value=None),
+            patch("grove.workspace.git.default_branch", return_value="origin/main"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(1, 0)),
+        ):
+            results = workspace.sync_workspace(sample_workspace)
+            assert len(results) == 1
+            assert results[0]["result"] == "up to date"
+
+    def test_successful_rebase(self, tmp_grove, sample_workspace):
+        with (
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.repo_base_branch", return_value="origin/stage"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(2, 3)),
+            patch("grove.workspace.git.rebase_onto") as mock_rebase,
+        ):
+            results = workspace.sync_workspace(sample_workspace)
+            assert len(results) == 1
+            assert results[0]["result"] == "rebased (3 new commits)"
+            assert results[0]["base"] == "origin/stage"
+            mock_rebase.assert_called_once()
+
+    def test_conflict_aborts_rebase(self, tmp_grove, sample_workspace):
+        with (
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.repo_base_branch", return_value=None),
+            patch("grove.workspace.git.default_branch", return_value="origin/main"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(1, 2)),
+            patch("grove.workspace.git.rebase_onto", side_effect=GitError("conflict")),
+            patch("grove.workspace.git.rebase_abort") as mock_abort,
+        ):
+            results = workspace.sync_workspace(sample_workspace)
+            assert results[0]["result"] == "conflict"
+            mock_abort.assert_called_once()
+
+    def test_skips_dirty_worktree(self, tmp_grove, sample_workspace):
+        with (
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.repo_base_branch", return_value=None),
+            patch("grove.workspace.git.default_branch", return_value="origin/main"),
+            patch("grove.workspace.git.repo_status", return_value=" M dirty.py"),
+        ):
+            results = workspace.sync_workspace(sample_workspace)
+            assert results[0]["result"] == "skipped: uncommitted changes"
+
+    def test_unknown_base_branch(self, tmp_grove, sample_workspace):
+        with (
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.repo_base_branch", return_value=None),
+            patch("grove.workspace.git.default_branch", side_effect=GitError("no HEAD")),
+        ):
+            results = workspace.sync_workspace(sample_workspace)
+            assert results[0]["base"] == "?"
+            assert "could not determine" in results[0]["result"]
+
+    def test_fetch_failure_continues(self, tmp_grove, sample_workspace):
+        """Sync should continue even if fetch fails (offline, etc)."""
+        with (
+            patch("grove.workspace.git.fetch", side_effect=GitError("network error")),
+            patch("grove.workspace.git.repo_base_branch", return_value=None),
+            patch("grove.workspace.git.default_branch", return_value="origin/main"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(0, 0)),
+        ):
+            results = workspace.sync_workspace(sample_workspace)
+            # Should still produce a result (up to date based on cached refs)
+            assert len(results) == 1
+            assert results[0]["result"] == "up to date"
+
+    def test_rebase_when_behind_unknown(self, tmp_grove, sample_workspace):
+        """When ahead/behind fails, still attempt rebase."""
+        with (
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.repo_base_branch", return_value=None),
+            patch("grove.workspace.git.default_branch", return_value="origin/main"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.commits_ahead_behind", side_effect=GitError("bad ref")),
+            patch("grove.workspace.git.rebase_onto") as mock_rebase,
+        ):
+            results = workspace.sync_workspace(sample_workspace)
+            assert results[0]["result"] == "rebased"
+            mock_rebase.assert_called_once()
+
+
 class TestWorkspaceStatus:
     def test_clean_repos(self, tmp_grove, sample_workspace):
         with (
@@ -213,6 +303,9 @@ class TestWorkspaceStatus:
             assert len(results) == 1
             assert results[0]["status"] == "clean"
             assert results[0]["branch"] == "feat/test"
+            # Ahead/behind should be present (may be "-" if git calls fail)
+            assert "ahead" in results[0]
+            assert "behind" in results[0]
 
     def test_modified_repo(self, tmp_grove, sample_workspace):
         with (
@@ -229,3 +322,29 @@ class TestWorkspaceStatus:
             results = workspace.workspace_status(sample_workspace)
             assert results[0]["branch"] == "?"
             assert "error" in results[0]["status"]
+            assert results[0]["ahead"] == "-"
+            assert results[0]["behind"] == "-"
+
+    def test_ahead_behind_populated(self, tmp_grove, sample_workspace):
+        with (
+            patch("grove.workspace.git.current_branch", return_value="feat/test"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.repo_base_branch", return_value="origin/main"),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(5, 2)),
+        ):
+            results = workspace.workspace_status(sample_workspace)
+            assert results[0]["ahead"] == "5"
+            assert results[0]["behind"] == "2"
+
+    def test_ahead_behind_fallback_on_failure(self, tmp_grove, sample_workspace):
+        with (
+            patch("grove.workspace.git.current_branch", return_value="feat/test"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.repo_base_branch", return_value=None),
+            patch("grove.workspace.git.default_branch", side_effect=GitError("no remote")),
+        ):
+            results = workspace.workspace_status(sample_workspace)
+            assert results[0]["ahead"] == "-"
+            assert results[0]["behind"] == "-"
+            # Status should still work fine
+            assert results[0]["status"] == "clean"


### PR DESCRIPTION
## Summary
- **`gw sync`** — rebase all workspace repos onto their base branches. Skips dirty worktrees, aborts and reports on conflict, respects `.grove.toml` base_branch overrides.
- **Enhanced `gw status`** — new ↑↓ column showing commits ahead/behind the base branch. Optional `--pr` / `-P` flag shows GitHub PR status via `gh` CLI.
- **README** — new "Works great with AI coding tools" section showing the Grove + Claude Code workflow, documented `sync` in usage.
- Extracted `_resolve_workspace` helper to deduplicate workspace lookup across `status` and `sync`.
- Added git primitives: `rebase_onto`, `rebase_abort`, `commits_ahead_behind`, `pr_status`.

## Test plan
- [x] 37 new tests covering all new functionality (124 total, all passing)
- [x] `just check` passes (lint + format + tests)
- [ ] Manual test: `gw sync` on a real workspace with repos behind their base branch
- [ ] Manual test: `gw status --pr` with and without `gh` installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)