### PR TITLE
Parallelize git operations across repos

### DIFF
--- a/src/grove/workspace.py
+++ b/src/grove/workspace.py
@@ -5,12 +5,46 @@ from __future__ import annotations
 import contextlib
 import shutil
 import subprocess
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from typing import Any
 
 from grove import git, state
 from grove.console import console, error, info, success, warning
 from grove.git import GitError
 from grove.models import Config, RepoWorktree, Workspace
+
+
+def _parallel(
+    fn: Callable[[str, Any], Any],
+    items: list[tuple[str, Any]],
+    label: str = "Processing",
+) -> list[tuple[str, Any, Exception | None]]:
+    """Run *fn(name, value)* for each ``(name, value)`` in *items* using threads.
+
+    Returns a list of ``(name, result, error)`` tuples, one per item,
+    preserving the original order of *items*.
+    """
+    if not items:
+        return []
+
+    order = {name: idx for idx, (name, _) in enumerate(items)}
+    results: list[tuple[str, Any, Exception | None]] = [("", None, None)] * len(items)
+
+    with (
+        console.status(f"{label} {len(items)} repos…"),
+        ThreadPoolExecutor() as pool,
+    ):
+        futures = {pool.submit(fn, name, val): name for name, val in items}
+        for future in as_completed(futures):
+            name = futures[future]
+            try:
+                results[order[name]] = (name, future.result(), None)
+            except Exception as exc:
+                results[order[name]] = (name, None, exc)
+
+    return results
 
 
 def create_workspace(
@@ -39,13 +73,13 @@ def create_workspace(
             )
             return None
 
-    # --- Fetch latest from all repos ---
-    for repo_name, repo_path in repo_paths.items():
-        with console.status(f"Fetching [bold]{repo_name}[/]…"):
-            try:
-                git.fetch(repo_path)
-            except GitError as e:
-                warning(f"Could not fetch {repo_name}: {e}")
+    # --- Fetch latest from all repos (parallel) ---
+    def _fetch_one(_name: str, path: Path) -> None:
+        git.fetch(path)
+
+    for repo_name, _result, exc in _parallel(_fetch_one, list(repo_paths.items()), "Fetching"):
+        if exc is not None:
+            warning(f"Could not fetch {repo_name}: {exc}")
 
     # --- Create workspace directory ---
     workspace_path.mkdir(parents=True, exist_ok=True)
@@ -92,9 +126,12 @@ def create_workspace(
         created.append(repo_wt)
         success(f"{repo_name} -> {worktree_path}")
 
-    # --- Run per-repo setup hooks ---
-    for repo_wt in created:
+    # --- Run per-repo setup hooks (parallel) ---
+    def _setup_one(_name: str, repo_wt: RepoWorktree) -> None:
         _run_setup(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path)
+
+    setup_items = [(wt.repo_name, wt) for wt in created]
+    _parallel(_setup_one, setup_items, "Running setup for")
 
     workspace = Workspace(
         name=name,
@@ -146,16 +183,21 @@ def delete_workspace(name: str) -> bool:
         error(f"Workspace [bold]{name}[/] not found")
         return False
 
-    for repo_wt in workspace.repos:
-        with console.status(f"Removing worktree for [bold]{repo_wt.repo_name}[/]..."):
-            try:
-                git.worktree_remove(repo_wt.source_repo, repo_wt.worktree_path)
-                success(f"Removed worktree: {repo_wt.repo_name}")
-            except GitError as e:
-                warning(f"Could not remove worktree for {repo_wt.repo_name}: {e}")
-                # Try manual cleanup if worktree path exists
-                if repo_wt.worktree_path.exists():
-                    shutil.rmtree(repo_wt.worktree_path, ignore_errors=True)
+    def _remove_one(_name: str, repo_wt: RepoWorktree) -> None:
+        try:
+            git.worktree_remove(repo_wt.source_repo, repo_wt.worktree_path)
+        except GitError:
+            # Try manual cleanup if worktree path exists
+            if repo_wt.worktree_path.exists():
+                shutil.rmtree(repo_wt.worktree_path, ignore_errors=True)
+            raise  # re-raise so _parallel records the error
+
+    items = [(wt.repo_name, wt) for wt in workspace.repos]
+    for repo_name, _result, exc in _parallel(_remove_one, items, "Removing"):
+        if exc is not None:
+            warning(f"Could not remove worktree for {repo_name}: {exc}")
+        else:
+            success(f"Removed worktree: {repo_name}")
 
     if workspace.path.exists():
         shutil.rmtree(workspace.path, ignore_errors=True)
@@ -164,88 +206,115 @@ def delete_workspace(name: str) -> bool:
     return True
 
 
+def _sync_one_repo(_name: str, repo_wt: RepoWorktree) -> dict[str, str]:
+    """Sync a single repo: fetch, determine base, rebase if needed."""
+    # Fetch latest (continue with cached refs on failure)
+    with contextlib.suppress(GitError):
+        git.fetch(repo_wt.worktree_path)
+
+    # Determine base branch
+    base = git.repo_base_branch(repo_wt.source_repo)
+    if base is None:
+        try:
+            base = git.default_branch(repo_wt.source_repo)
+        except GitError:
+            return {
+                "repo": repo_wt.repo_name,
+                "base": "?",
+                "result": "error: could not determine base branch",
+            }
+
+    # Skip dirty worktrees — rebase on uncommitted changes is dangerous
+    status_text = git.repo_status(repo_wt.worktree_path)
+    if status_text:
+        return {
+            "repo": repo_wt.repo_name,
+            "base": base,
+            "result": "skipped: uncommitted changes",
+        }
+
+    # Check if rebase is needed
+    try:
+        _ahead, behind = git.commits_ahead_behind(repo_wt.worktree_path, base)
+    except GitError:
+        behind = -1  # unknown, attempt rebase anyway
+
+    if behind == 0:
+        return {
+            "repo": repo_wt.repo_name,
+            "base": base,
+            "result": "up to date",
+        }
+
+    # Rebase
+    try:
+        git.rebase_onto(repo_wt.worktree_path, base)
+        msg = f"rebased ({behind} new commits)" if behind > 0 else "rebased"
+        return {
+            "repo": repo_wt.repo_name,
+            "base": base,
+            "result": msg,
+        }
+    except GitError:
+        # Abort failed rebase to leave worktree in a clean state
+        with contextlib.suppress(GitError):
+            git.rebase_abort(repo_wt.worktree_path)
+        return {
+            "repo": repo_wt.repo_name,
+            "base": base,
+            "result": "conflict",
+        }
+
+
 def sync_workspace(workspace: Workspace) -> list[dict[str, str]]:
     """Sync all repos by rebasing onto their base branches.
 
     Returns list of ``{repo, base, result}`` dicts.
     """
+    items = [(wt.repo_name, wt) for wt in workspace.repos]
     results: list[dict[str, str]] = []
-    for repo_wt in workspace.repos:
-        # Fetch latest
-        with console.status(f"Fetching [bold]{repo_wt.repo_name}[/]…"):
-            try:
-                git.fetch(repo_wt.worktree_path)
-            except GitError as e:
-                warning(f"Could not fetch {repo_wt.repo_name}: {e}")
-
-        # Determine base branch
-        base = git.repo_base_branch(repo_wt.source_repo)
-        if base is None:
-            try:
-                base = git.default_branch(repo_wt.source_repo)
-            except GitError:
-                results.append(
-                    {
-                        "repo": repo_wt.repo_name,
-                        "base": "?",
-                        "result": "error: could not determine base branch",
-                    }
-                )
-                continue
-
-        # Skip dirty worktrees — rebase on uncommitted changes is dangerous
-        status_text = git.repo_status(repo_wt.worktree_path)
-        if status_text:
-            results.append(
-                {
-                    "repo": repo_wt.repo_name,
-                    "base": base,
-                    "result": "skipped: uncommitted changes",
-                }
-            )
-            continue
-
-        # Check if rebase is needed
-        try:
-            _ahead, behind = git.commits_ahead_behind(repo_wt.worktree_path, base)
-        except GitError:
-            behind = -1  # unknown, attempt rebase anyway
-
-        if behind == 0:
-            results.append(
-                {
-                    "repo": repo_wt.repo_name,
-                    "base": base,
-                    "result": "up to date",
-                }
-            )
-            continue
-
-        # Rebase
-        with console.status(f"Rebasing [bold]{repo_wt.repo_name}[/] onto {base}…"):
-            try:
-                git.rebase_onto(repo_wt.worktree_path, base)
-                msg = f"rebased ({behind} new commits)" if behind > 0 else "rebased"
-                results.append(
-                    {
-                        "repo": repo_wt.repo_name,
-                        "base": base,
-                        "result": msg,
-                    }
-                )
-            except GitError:
-                # Abort failed rebase to leave worktree in a clean state
-                with contextlib.suppress(GitError):
-                    git.rebase_abort(repo_wt.worktree_path)
-                results.append(
-                    {
-                        "repo": repo_wt.repo_name,
-                        "base": base,
-                        "result": "conflict",
-                    }
-                )
-
+    for _name, result, exc in _parallel(_sync_one_repo, items, "Syncing"):
+        if exc is not None:
+            results.append({"repo": _name, "base": "?", "result": f"error: {exc}"})
+        else:
+            results.append(result)
     return results
+
+
+def _status_one_repo(_name: str, repo_wt: RepoWorktree) -> dict[str, str]:
+    """Get status for a single repo."""
+    try:
+        branch = git.current_branch(repo_wt.worktree_path)
+        status_text = git.repo_status(repo_wt.worktree_path)
+
+        # Ahead/behind (best-effort — never crash status for this)
+        ahead_str = "-"
+        behind_str = "-"
+        try:
+            base = git.repo_base_branch(repo_wt.source_repo)
+            if base is None:
+                base = git.default_branch(repo_wt.source_repo)
+            ahead, behind = git.commits_ahead_behind(repo_wt.worktree_path, base)
+            ahead_str = str(ahead)
+            behind_str = str(behind)
+        except Exception:
+            pass
+
+        return {
+            "repo": repo_wt.repo_name,
+            "branch": branch,
+            "status": status_text or "clean",
+            "ahead": ahead_str,
+            "behind": behind_str,
+        }
+    except GitError as e:
+        return {
+            "repo": repo_wt.repo_name,
+            "branch": "?",
+            "status": f"error: {e}",
+            "ahead": "-",
+            "behind": "-",
+        }
 
 
 def workspace_status(workspace: Workspace) -> list[dict[str, str]]:
@@ -253,42 +322,19 @@ def workspace_status(workspace: Workspace) -> list[dict[str, str]]:
 
     Returns list of ``{repo, branch, status, ahead, behind}`` dicts.
     """
+    items = [(wt.repo_name, wt) for wt in workspace.repos]
     results: list[dict[str, str]] = []
-    for repo_wt in workspace.repos:
-        try:
-            branch = git.current_branch(repo_wt.worktree_path)
-            status_text = git.repo_status(repo_wt.worktree_path)
-
-            # Ahead/behind (best-effort — never crash status for this)
-            ahead_str = "-"
-            behind_str = "-"
-            try:
-                base = git.repo_base_branch(repo_wt.source_repo)
-                if base is None:
-                    base = git.default_branch(repo_wt.source_repo)
-                ahead, behind = git.commits_ahead_behind(repo_wt.worktree_path, base)
-                ahead_str = str(ahead)
-                behind_str = str(behind)
-            except Exception:
-                pass
-
+    for _name, result, exc in _parallel(_status_one_repo, items, "Checking"):
+        if exc is not None:
             results.append(
                 {
-                    "repo": repo_wt.repo_name,
-                    "branch": branch,
-                    "status": status_text or "clean",
-                    "ahead": ahead_str,
-                    "behind": behind_str,
-                }
-            )
-        except GitError as e:
-            results.append(
-                {
-                    "repo": repo_wt.repo_name,
+                    "repo": _name,
                     "branch": "?",
-                    "status": f"error: {e}",
+                    "status": f"error: {exc}",
                     "ahead": "-",
                     "behind": "-",
                 }
             )
+        else:
+            results.append(result)
     return results

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from grove import state, workspace
 from grove.git import GitError
-from grove.models import Config
+from grove.models import Config, RepoWorktree, Workspace
 
 
 @pytest.fixture()
@@ -348,3 +349,129 @@ class TestWorkspaceStatus:
             assert results[0]["behind"] == "-"
             # Status should still work fine
             assert results[0]["status"] == "clean"
+
+
+def _multi_repo_workspace(tmp_grove: dict, count: int = 3) -> Workspace:
+    """Build a workspace with *count* repos for parallel tests."""
+    ws_path = tmp_grove["workspace_dir"] / "multi-ws"
+    ws_path.mkdir(exist_ok=True)
+    repos = []
+    for i in range(count):
+        name = f"repo-{i}"
+        src = tmp_grove["repos_dir"] / name
+        src.mkdir(exist_ok=True)
+        repos.append(
+            RepoWorktree(
+                repo_name=name,
+                source_repo=src,
+                worktree_path=ws_path / name,
+                branch="feat/parallel",
+            )
+        )
+    return Workspace(
+        name="multi-ws",
+        path=ws_path,
+        branch="feat/parallel",
+        repos=repos,
+        created_at="2025-01-01T00:00:00",
+    )
+
+
+class TestParallelExecution:
+    """Tests that verify parallel (multi-repo) behaviour."""
+
+    def test_multi_repo_fetch_all_called(self, tmp_grove):
+        """All repos are fetched in parallel during create."""
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        repos: dict[str, Path] = {}
+        for name in ("alpha", "beta", "gamma"):
+            p = tmp_grove["repos_dir"] / name
+            p.mkdir()
+            repos[name] = p
+
+        with (
+            patch("grove.workspace.git.worktree_has_branch", return_value=False),
+            patch("grove.workspace.git.branch_exists", return_value=True),
+            patch("grove.workspace.git.worktree_add"),
+            patch("grove.workspace.git.fetch") as mock_fetch,
+            patch("grove.workspace.git.read_grove_config", return_value={}),
+        ):
+            ws = workspace.create_workspace("par", repos, "feat/x", cfg)
+            assert ws is not None
+            assert mock_fetch.call_count == len(repos)
+
+    def test_multi_repo_status(self, tmp_grove):
+        """Status is collected for every repo in a multi-repo workspace."""
+        ws = _multi_repo_workspace(tmp_grove)
+        with (
+            patch("grove.workspace.git.current_branch", return_value="feat/parallel"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.repo_base_branch", return_value=None),
+            patch("grove.workspace.git.default_branch", return_value="origin/main"),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(0, 0)),
+        ):
+            results = workspace.workspace_status(ws)
+            assert len(results) == 3
+            repo_names = {r["repo"] for r in results}
+            assert repo_names == {"repo-0", "repo-1", "repo-2"}
+            for r in results:
+                assert r["status"] == "clean"
+
+    def test_error_in_one_repo_does_not_break_others(self, tmp_grove):
+        """A failure in one repo should not prevent results from other repos."""
+        ws = _multi_repo_workspace(tmp_grove)
+
+        fail_path = ws.repos[1].worktree_path  # repo-1 will fail
+
+        def branch_side_effect(path):
+            if path == fail_path:
+                raise GitError("corrupt repo")
+            return "feat/parallel"
+
+        with (
+            patch("grove.workspace.git.current_branch", side_effect=branch_side_effect),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.repo_base_branch", return_value=None),
+            patch("grove.workspace.git.default_branch", return_value="origin/main"),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(0, 0)),
+        ):
+            results = workspace.workspace_status(ws)
+            assert len(results) == 3
+
+            # The failed repo should have an error status
+            failed = [r for r in results if r["repo"] == "repo-1"]
+            assert len(failed) == 1
+            assert "error" in failed[0]["status"]
+
+            # The other repos should be fine
+            ok = [r for r in results if r["repo"] != "repo-1"]
+            assert all(r["status"] == "clean" for r in ok)
+
+    def test_multi_repo_sync(self, tmp_grove):
+        """Sync runs in parallel across multiple repos."""
+        ws = _multi_repo_workspace(tmp_grove)
+        with (
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.repo_base_branch", return_value="origin/main"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(0, 0)),
+        ):
+            results = workspace.sync_workspace(ws)
+            assert len(results) == 3
+            assert all(r["result"] == "up to date" for r in results)
+
+    def test_results_preserve_order(self, tmp_grove):
+        """Results should come back in the same order as workspace.repos."""
+        ws = _multi_repo_workspace(tmp_grove, count=5)
+        with (
+            patch("grove.workspace.git.current_branch", return_value="feat/parallel"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.repo_base_branch", return_value=None),
+            patch("grove.workspace.git.default_branch", return_value="origin/main"),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(0, 0)),
+        ):
+            results = workspace.workspace_status(ws)
+            assert [r["repo"] for r in results] == [f"repo-{i}" for i in range(5)]


### PR DESCRIPTION
## Summary
- Add `_parallel()` ThreadPoolExecutor helper to `workspace.py` for concurrent per-repo git operations
- Parallelize fetch, sync, status, and delete — significant speedup for workspaces with 3+ repos
- Extract `_sync_one_repo()` and `_status_one_repo()` for clean thread isolation
- Replace per-repo spinners with single aggregate spinner ("Fetching 5 repos…")
- Add 5 parallel-specific tests (multi-repo fetch, status, sync, error isolation, order preservation)

## Test plan
- [x] `just check` passes (129 tests, lint clean, format clean)
- [ ] Manual: `gw create` with multiple repos shows single spinner, then per-repo results
- [ ] Manual: `gw status` and `gw sync` feel faster with 3+ repos
- [ ] Manual: one repo failing (e.g. offline) doesn't break other repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)