### PR TITLE
Add lifecycle hooks, workspace commands, and gw run

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,14 @@ gw init ~/dev                                          # register repos director
 gw create my-feature -r svc-a,svc-b -b feat/login     # create workspace
 gw list                                                # list workspaces
 gw status my-feature                                   # git status across repos
+gw status --all                                        # overview of all workspaces
 gw sync my-feature                                     # rebase all repos onto base branch
 gw go my-feature                                       # cd into workspace
+gw run my-feature                                      # run dev processes (Ctrl+C to stop)
+gw add-repo my-feature -r svc-c                        # add a repo to existing workspace
+gw remove-repo my-feature -r svc-a                     # remove a repo from workspace
+gw rename my-feature --to new-name                     # rename a workspace
+gw doctor                                              # diagnose workspace health issues
 gw delete my-feature                                   # clean up
 ```
 
@@ -55,13 +61,36 @@ Drop a `.grove.toml` in any repo to override defaults:
 # merchant-portal/.grove.toml
 base_branch = "stage"              # branch from origin/stage instead of origin/main
 setup = "pnpm install"             # run after worktree creation
+teardown = "rm -rf node_modules"   # run before worktree removal
+pre_sync = "pnpm run build:check"  # run before rebase during sync
+post_sync = "pnpm install"         # run after successful rebase
+pre_run = "docker compose pull"    # run before gw run starts
+run = "pnpm dev"                   # started by gw run (foreground)
+post_run = "docker compose down"   # run on gw run exit / Ctrl+C
 ```
 
-`setup` accepts a string or a list of commands:
+All hook keys accept a string or a list of commands:
 
 ```toml
 setup = ["uv sync", "uv run pre-commit install"]
 ```
+
+Hook failures are warnings — they never block the operation they're attached to.
+
+### Design philosophy
+
+The hook system follows the npm-style `pre`/`post` convention: one primitive (`run`, `sync`) with optional `pre_` and `post_` counterparts that fire around it. Instead of building special-purpose features (secret injection, dependency installs, container management), Grove gives you generic hook points and gets out of the way. You compose what you need:
+
+| When | Hooks | Example use |
+|------|-------|-------------|
+| Worktree created | `setup` | `pnpm install`, inject secrets, seed DB |
+| Worktree removed | `teardown` | `rm -rf node_modules`, revoke temp creds |
+| Before/after rebase | `pre_sync`, `post_sync` | Type-check before rebase, reinstall after |
+| Dev session | `pre_run`, `run`, `post_run` | Pull containers, start dev server, tear down containers |
+
+### `gw run` (experimental)
+
+`gw run` starts `run` hooks across all repos as foreground processes and tears them down on Ctrl+C. It works, but the UX is minimal — all output is interleaved in a single terminal. Future versions may introduce a proper TUI (e.g. via [Textual](https://github.com/Textualize/textual)) with per-repo log panes, health indicators, and restart controls. Consider this command under active development.
 
 ## Works great with AI coding tools
 
@@ -80,6 +109,12 @@ Grove copies your `CLAUDE.md` into new workspaces, so your agent gets project co
 - Fetches latest from remotes before creating worktrees
 - Creates new branches from the default remote branch (`origin/main`)
 - Creates git worktrees from multiple repos into `~/.grove/workspaces/<name>/`
+- Add or remove repos from existing workspaces without recreating them
+- Rename workspaces (directory, state, and git linkage updated automatically)
+- Lifecycle hooks: `setup`, `teardown`, `pre_sync`, `post_sync` per repo
+- `gw run` to start dev processes across repos, with `pre_run`/`post_run` hooks
+- `gw status --all` for a cross-workspace overview at a glance
+- `gw doctor` to diagnose and auto-fix stale state entries
 - Offers saved presets during interactive workspace creation
 - Copies `CLAUDE.md` from your repos directory into new workspaces
 - Auto-creates branches if they don't exist

--- a/src/grove/cli.py
+++ b/src/grove/cli.py
@@ -461,7 +461,12 @@ def add_repo(
         repo_names = _pick_many("Select repos to add", sorted(addable.keys()))
 
     selected = {rn: available[rn] for rn in repo_names}
-    added = workspace.add_repo_to_workspace(ws, selected, cfg)
+    # Filter out already-present repos before calling workspace function
+    actually_new = {rn: p for rn, p in selected.items() if rn not in existing_names}
+    if not actually_new:
+        info("All selected repos are already in the workspace")
+        return
+    added = workspace.add_repo_to_workspace(ws, actually_new, cfg)
     if added is None:
         raise typer.Exit(1)
     success(f"Added {len(added)} repo(s) to [bold]{name}[/]")

--- a/src/grove/cli.py
+++ b/src/grove/cli.py
@@ -355,6 +355,167 @@ def delete(
         raise typer.Exit(1)
 
 
+@app.command()
+def doctor(
+    fix: bool = typer.Option(False, "--fix", help="Auto-fix stale state entries"),
+) -> None:
+    """Diagnose workspace health issues."""
+    cfg = config.require_config()
+    issues = workspace.diagnose_workspaces(cfg)
+
+    if not issues:
+        success("All workspaces healthy")
+        return
+
+    table = make_table("Workspace", "Repo", "Issue", "Suggested Action")
+    for issue in issues:
+        table.add_row(
+            issue.workspace_name,
+            issue.repo_name or "[dim]—[/]",
+            issue.issue,
+            issue.suggested_action,
+        )
+    console.print(table)
+
+    if fix:
+        fixed = workspace.fix_workspace_issues(issues)
+        if fixed:
+            success(f"Fixed {fixed} issue(s)")
+        else:
+            info("No auto-fixable issues found")
+    else:
+        info(f"Found {len(issues)} issue(s). Run [bold]gw doctor --fix[/] to auto-fix")
+
+
+@app.command()
+def rename(
+    name: str | None = typer.Argument(
+        None,
+        help="Current workspace name",
+        autocompletion=complete_workspace_name,
+    ),
+    to: str = typer.Option(..., "--to", help="New workspace name"),
+) -> None:
+    """Rename a workspace."""
+    cfg = config.require_config()
+
+    if name is None:
+        workspaces = state.load_workspaces()
+        if not workspaces:
+            error("No workspaces exist")
+            raise typer.Exit(1)
+        name = _pick_one("Select workspace to rename", [w.name for w in workspaces])
+
+    if workspace.rename_workspace(name, to, cfg):
+        success(f"Renamed [bold]{name}[/] → [bold]{to}[/]")
+    else:
+        raise typer.Exit(1)
+
+
+@app.command("add-repo")
+def add_repo(
+    name: str | None = typer.Argument(
+        None,
+        help="Workspace name",
+        autocompletion=complete_workspace_name,
+    ),
+    repos: str | None = typer.Option(
+        None,
+        "--repos",
+        "-r",
+        help="Comma-separated repo names to add",
+        autocompletion=complete_repo_name,
+    ),
+) -> None:
+    """Add repos to an existing workspace."""
+    cfg = config.require_config()
+    available = discover.find_repos(cfg.repos_dir)
+
+    # Resolve workspace
+    if name is None:
+        workspaces = state.load_workspaces()
+        if not workspaces:
+            error("No workspaces exist")
+            raise typer.Exit(1)
+        name = _pick_one("Select workspace", [w.name for w in workspaces])
+
+    ws = state.get_workspace(name)
+    if ws is None:
+        error(f"Workspace [bold]{name}[/] not found")
+        raise typer.Exit(1)
+
+    existing_names = {r.repo_name for r in ws.repos}
+    addable = {n: p for n, p in available.items() if n not in existing_names}
+
+    if not addable:
+        info("All repos are already in this workspace")
+        return
+
+    if repos is not None:
+        repo_names = [r.strip() for r in repos.split(",")]
+        for rn in repo_names:
+            if rn not in available:
+                error(f"Repo [bold]{rn}[/] not found in {cfg.repos_dir}")
+                raise typer.Exit(1)
+    else:
+        repo_names = _pick_many("Select repos to add", sorted(addable.keys()))
+
+    selected = {rn: available[rn] for rn in repo_names}
+    added = workspace.add_repo_to_workspace(ws, selected, cfg)
+    if added is None:
+        raise typer.Exit(1)
+    success(f"Added {len(added)} repo(s) to [bold]{name}[/]")
+
+
+@app.command("remove-repo")
+def remove_repo(
+    name: str | None = typer.Argument(
+        None,
+        help="Workspace name",
+        autocompletion=complete_workspace_name,
+    ),
+    repos: str | None = typer.Option(
+        None,
+        "--repos",
+        "-r",
+        help="Comma-separated repo names to remove",
+    ),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+) -> None:
+    """Remove repos from an existing workspace."""
+    # Resolve workspace
+    if name is None:
+        workspaces = state.load_workspaces()
+        if not workspaces:
+            error("No workspaces exist")
+            raise typer.Exit(1)
+        name = _pick_one("Select workspace", [w.name for w in workspaces])
+
+    ws = state.get_workspace(name)
+    if ws is None:
+        error(f"Workspace [bold]{name}[/] not found")
+        raise typer.Exit(1)
+
+    if not ws.repos:
+        error(f"Workspace [bold]{name}[/] has no repos")
+        raise typer.Exit(1)
+
+    if repos is not None:
+        repo_names = [r.strip() for r in repos.split(",")]
+    else:
+        repo_names = _pick_many("Select repos to remove", [r.repo_name for r in ws.repos])
+
+    if not force:
+        label = ", ".join(repo_names)
+        if not typer.confirm(f"Remove {label} from workspace {name}?"):
+            info("Cancelled")
+            return
+
+    ok = workspace.remove_repo_from_workspace(ws, repo_names, force=force)
+    if not ok:
+        raise typer.Exit(1)
+
+
 def _resolve_workspace(name: str | None) -> Workspace:
     """Resolve a workspace by name, cwd auto-detection, or interactive picker."""
     if name is None:
@@ -415,8 +576,23 @@ def status(
     ),
     verbose: bool = typer.Option(False, "--verbose", "-V", help="Show full git status output"),
     show_pr: bool = typer.Option(False, "--pr", "-P", help="Show GitHub PR status (requires gh)"),
+    show_all: bool = typer.Option(False, "--all", "-a", help="Show summary of all workspaces"),
 ) -> None:
     """Show git status across a workspace's repos."""
+    if show_all:
+        if name is not None:
+            error("Cannot combine workspace name with --all")
+            raise typer.Exit(1)
+        summaries = workspace.all_workspaces_summary()
+        if not summaries:
+            info("No workspaces. Create one with: gw create <name> -r repo1,repo2 -b branch")
+            return
+        table = make_table("Workspace", "Branch", "Repos", "Status")
+        for s in summaries:
+            table.add_row(s["name"], s["branch"], s["repos"], s["status"])
+        console.print(table)
+        return
+
     ws = _resolve_workspace(name)
 
     console.print(f"[bold]Workspace:[/] {ws.name}  [dim]({ws.path})[/]")
@@ -488,6 +664,25 @@ def sync(
             warning(f"{r['repo']}  {result_text}")
         else:
             error(f"{r['repo']}  {result_text}")
+
+
+@app.command()
+def run(
+    name: str | None = typer.Argument(
+        None,
+        help="Workspace name (auto-detects from cwd)",
+        autocompletion=complete_workspace_name,
+    ),
+) -> None:
+    """Run dev processes across workspace repos (Ctrl+C to stop)."""
+    ws = _resolve_workspace(name)
+
+    console.print(f"[bold]Running:[/] {ws.name}")
+    console.print()
+
+    count = workspace.run_workspace(ws)
+    if count == 0:
+        info("No repos have a [bold]run[/] hook in .grove.toml")
 
 
 _BACK_TO_REPOS = "← back to repos dir"

--- a/src/grove/discover.py
+++ b/src/grove/discover.py
@@ -4,18 +4,18 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from grove import git
-
 
 def find_repos(repos_dir: Path) -> dict[str, Path]:
     """Find all git repos in the given directory (one level deep).
 
     Returns a dict mapping repo name -> repo path.
+    Uses ``.git`` existence check instead of ``git rev-parse`` to avoid
+    spawning a subprocess per directory.
     """
     repos: dict[str, Path] = {}
     if not repos_dir.is_dir():
         return repos
     for entry in sorted(repos_dir.iterdir()):
-        if entry.is_dir() and not entry.name.startswith(".") and git.is_git_repo(entry):
+        if entry.is_dir() and not entry.name.startswith(".") and (entry / ".git").exists():
             repos[entry.name] = entry
     return repos

--- a/src/grove/discover.py
+++ b/src/grove/discover.py
@@ -16,6 +16,6 @@ def find_repos(repos_dir: Path) -> dict[str, Path]:
     if not repos_dir.is_dir():
         return repos
     for entry in sorted(repos_dir.iterdir()):
-        if entry.is_dir() and not entry.name.startswith(".") and (entry / ".git").exists():
+        if entry.is_dir() and not entry.name.startswith(".") and (entry / ".git").is_dir():
             repos[entry.name] = entry
     return repos

--- a/src/grove/git.py
+++ b/src/grove/git.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import subprocess
 from pathlib import Path
 
@@ -63,8 +64,13 @@ def default_branch(repo: Path) -> str:
         raise GitError("Could not determine default branch") from None
 
 
+@functools.cache
 def read_grove_config(path: Path) -> dict:
-    """Read ``.grove.toml`` from *path* and return the parsed dict (empty if absent)."""
+    """Read ``.grove.toml`` from *path* and return the parsed dict (empty if absent).
+
+    Cached for the lifetime of the process — safe because ``.grove.toml``
+    doesn't change during a single CLI invocation.
+    """
     import tomllib
 
     grove_toml = path / ".grove.toml"
@@ -78,6 +84,25 @@ def repo_base_branch(repo: Path) -> str | None:
     """Return ``origin/<base_branch>`` from ``.grove.toml``, or ``None``."""
     base = read_grove_config(repo).get("base_branch")
     return f"origin/{base}" if base else None
+
+
+def resolve_base_branch(repo: Path) -> str | None:
+    """Return the base branch for *repo*: ``.grove.toml`` > auto-detect > ``None``."""
+    base = repo_base_branch(repo)
+    if base is not None:
+        return base
+    try:
+        return default_branch(repo)
+    except GitError:
+        return None
+
+
+def repo_hook_commands(source_repo: Path, hook: str) -> list[str]:
+    """Return the command list for *hook* from ``.grove.toml`` (empty if absent)."""
+    value = read_grove_config(source_repo).get(hook)
+    if not value:
+        return []
+    return [value] if isinstance(value, str) else list(value)
 
 
 def create_branch(repo: Path, branch: str, start_point: str | None = None) -> None:
@@ -96,6 +121,11 @@ def worktree_add(repo: Path, worktree_path: Path, branch: str) -> None:
 def worktree_remove(repo: Path, worktree_path: Path) -> None:
     """Remove a git worktree."""
     _run(["worktree", "remove", str(worktree_path), "--force"], cwd=repo)
+
+
+def worktree_repair(repo: Path, worktree_path: Path) -> None:
+    """Repair worktree linkage after a directory move."""
+    _run(["worktree", "repair", str(worktree_path)], cwd=repo)
 
 
 def worktree_list(repo: Path) -> list[dict[str, str]]:

--- a/src/grove/state.py
+++ b/src/grove/state.py
@@ -55,10 +55,15 @@ def remove_workspace(name: str) -> None:
     save_workspaces(workspaces)
 
 
-def update_workspace(workspace: Workspace) -> None:
-    """Replace an existing workspace in state (matched by name)."""
+def update_workspace(workspace: Workspace, *, match_name: str | None = None) -> None:
+    """Replace an existing workspace in state.
+
+    Matches by *match_name* if given, otherwise by ``workspace.name``.
+    This allows atomic renames (match old name, write new name) in one operation.
+    """
+    key = match_name or workspace.name
     workspaces = load_workspaces()
-    workspaces = [workspace if w.name == workspace.name else w for w in workspaces]
+    workspaces = [workspace if w.name == key else w for w in workspaces]
     save_workspaces(workspaces)
 
 

--- a/src/grove/state.py
+++ b/src/grove/state.py
@@ -55,6 +55,13 @@ def remove_workspace(name: str) -> None:
     save_workspaces(workspaces)
 
 
+def update_workspace(workspace: Workspace) -> None:
+    """Replace an existing workspace in state (matched by name)."""
+    workspaces = load_workspaces()
+    workspaces = [workspace if w.name == workspace.name else w for w in workspaces]
+    save_workspaces(workspaces)
+
+
 def find_workspace_by_path(path: Path) -> Workspace | None:
     """Find a workspace that contains the given path."""
     resolved = path.resolve()

--- a/src/grove/workspace.py
+++ b/src/grove/workspace.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +48,89 @@ def _parallel(
     return results
 
 
+def _provision_worktrees(
+    repo_paths: dict[str, Path],
+    branch: str,
+    workspace_path: Path,
+    *,
+    remove_workspace_dir_on_rollback: bool = True,
+) -> list[RepoWorktree] | None:
+    """Validate, fetch, create branches/worktrees, run setup hooks.
+
+    Returns the created RepoWorktree list, or None on failure (with rollback).
+    This is the shared primitive used by both create and add-repo.
+    """
+    # Check for duplicate branch usage (git worktree limitation)
+    for repo_name, repo_path in repo_paths.items():
+        if git.worktree_has_branch(repo_path, branch):
+            error(
+                f"Branch [bold]{branch}[/] already has a worktree in "
+                f"[bold]{repo_name}[/] — git only allows one worktree per branch"
+            )
+            return None
+
+    # Fetch latest from all repos (parallel)
+    def _fetch_one(_name: str, path: Path) -> None:
+        git.fetch(path)
+
+    for repo_name, _result, exc in _parallel(_fetch_one, list(repo_paths.items()), "Fetching"):
+        if exc is not None:
+            warning(f"Could not fetch {repo_name}: {exc}")
+
+    # Create worktrees with rollback
+    created: list[RepoWorktree] = []
+    for repo_name, repo_path in repo_paths.items():
+        worktree_path = workspace_path / repo_name
+
+        # Auto-create branch from the default branch if it doesn't exist
+        if not git.branch_exists(repo_path, branch):
+            base = git.resolve_base_branch(repo_path)
+            info(
+                f"Creating branch [bold]{branch}[/] in {repo_name}"
+                + (f" from {base}" if base else "")
+            )
+            try:
+                git.create_branch(repo_path, branch, start_point=base)
+            except GitError as e:
+                error(f"Failed to create branch in {repo_name}: {e}")
+                _rollback(
+                    created,
+                    workspace_path,
+                    remove_workspace_dir=remove_workspace_dir_on_rollback,
+                )
+                return None
+
+        with console.status(f"Creating worktree for [bold]{repo_name}[/]..."):
+            try:
+                git.worktree_add(repo_path, worktree_path, branch)
+            except GitError as e:
+                error(f"Failed to create worktree for {repo_name}: {e}")
+                _rollback(
+                    created,
+                    workspace_path,
+                    remove_workspace_dir=remove_workspace_dir_on_rollback,
+                )
+                return None
+
+        repo_wt = RepoWorktree(
+            repo_name=repo_name,
+            source_repo=repo_path,
+            worktree_path=worktree_path,
+            branch=branch,
+        )
+        created.append(repo_wt)
+        success(f"{repo_name} -> {worktree_path}")
+
+    # Run per-repo setup hooks (parallel)
+    def _setup_one(_name: str, repo_wt: RepoWorktree) -> None:
+        _run_hook(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path, "setup")
+
+    setup_items = [(wt.repo_name, wt) for wt in created]
+    _parallel(_setup_one, setup_items, "Running setup for")
+
+    return created
+
+
 def create_workspace(
     name: str,
     repo_paths: dict[str, Path],
@@ -59,79 +143,15 @@ def create_workspace(
     """
     workspace_path = config.workspace_dir / name
 
-    # --- Validate upfront ---
     if state.get_workspace(name) is not None:
         error(f"Workspace [bold]{name}[/] already exists")
         return None
 
-    # Check for duplicate branch usage (git worktree limitation)
-    for repo_name, repo_path in repo_paths.items():
-        if git.worktree_has_branch(repo_path, branch):
-            error(
-                f"Branch [bold]{branch}[/] already has a worktree in "
-                f"[bold]{repo_name}[/] — git only allows one worktree per branch"
-            )
-            return None
-
-    # --- Fetch latest from all repos (parallel) ---
-    def _fetch_one(_name: str, path: Path) -> None:
-        git.fetch(path)
-
-    for repo_name, _result, exc in _parallel(_fetch_one, list(repo_paths.items()), "Fetching"):
-        if exc is not None:
-            warning(f"Could not fetch {repo_name}: {exc}")
-
-    # --- Create workspace directory ---
     workspace_path.mkdir(parents=True, exist_ok=True)
 
-    # --- Create worktrees with rollback ---
-    created: list[RepoWorktree] = []
-    for repo_name, repo_path in repo_paths.items():
-        worktree_path = workspace_path / repo_name
-
-        # Auto-create branch from the default branch if it doesn't exist
-        if not git.branch_exists(repo_path, branch):
-            # Per-repo .grove.toml > auto-detect
-            base = git.repo_base_branch(repo_path)
-            if base is None:
-                try:
-                    base = git.default_branch(repo_path)
-                except GitError:
-                    base = None
-            info(
-                f"Creating branch [bold]{branch}[/] in {repo_name}"
-                + (f" from {base}" if base else "")
-            )
-            try:
-                git.create_branch(repo_path, branch, start_point=base)
-            except GitError as e:
-                error(f"Failed to create branch in {repo_name}: {e}")
-                _rollback(created, workspace_path)
-                return None
-
-        with console.status(f"Creating worktree for [bold]{repo_name}[/]..."):
-            try:
-                git.worktree_add(repo_path, worktree_path, branch)
-            except GitError as e:
-                error(f"Failed to create worktree for {repo_name}: {e}")
-                _rollback(created, workspace_path)
-                return None
-
-        repo_wt = RepoWorktree(
-            repo_name=repo_name,
-            source_repo=repo_path,
-            worktree_path=worktree_path,
-            branch=branch,
-        )
-        created.append(repo_wt)
-        success(f"{repo_name} -> {worktree_path}")
-
-    # --- Run per-repo setup hooks (parallel) ---
-    def _setup_one(_name: str, repo_wt: RepoWorktree) -> None:
-        _run_setup(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path)
-
-    setup_items = [(wt.repo_name, wt) for wt in created]
-    _parallel(_setup_one, setup_items, "Running setup for")
+    created = _provision_worktrees(repo_paths, branch, workspace_path)
+    if created is None:
+        return None
 
     workspace = Workspace(
         name=name,
@@ -143,16 +163,14 @@ def create_workspace(
     return workspace
 
 
-def _run_setup(repo_name: str, source_repo: Path, worktree_path: Path) -> None:
-    """Run setup commands from ``.grove.toml`` (read from source repo, run in worktree)."""
-    cfg = git.read_grove_config(source_repo)
-    setup = cfg.get("setup")
-    if not setup:
+def _run_hook(repo_name: str, source_repo: Path, worktree_path: Path, hook: str) -> None:
+    """Run hook commands from ``.grove.toml`` (read from source repo, run in worktree)."""
+    commands = git.repo_hook_commands(source_repo, hook)
+    if not commands:
         return
 
-    commands = [setup] if isinstance(setup, str) else setup
     for cmd in commands:
-        info(f"[{repo_name}] running: {cmd}")
+        info(f"[{repo_name}] {hook}: {cmd}")
         try:
             subprocess.run(
                 cmd,
@@ -161,10 +179,15 @@ def _run_setup(repo_name: str, source_repo: Path, worktree_path: Path) -> None:
                 check=True,
             )
         except subprocess.CalledProcessError as e:
-            warning(f"[{repo_name}] setup command failed (exit {e.returncode}): {cmd}")
+            warning(f"[{repo_name}] {hook} command failed (exit {e.returncode}): {cmd}")
 
 
-def _rollback(created: list[RepoWorktree], workspace_path: Path) -> None:
+def _rollback(
+    created: list[RepoWorktree],
+    workspace_path: Path,
+    *,
+    remove_workspace_dir: bool = True,
+) -> None:
     """Remove already-created worktrees on failure."""
     if not created:
         return
@@ -172,8 +195,29 @@ def _rollback(created: list[RepoWorktree], workspace_path: Path) -> None:
     for repo_wt in created:
         with contextlib.suppress(GitError):
             git.worktree_remove(repo_wt.source_repo, repo_wt.worktree_path)
-    if workspace_path.exists():
+    if remove_workspace_dir and workspace_path.exists():
         shutil.rmtree(workspace_path, ignore_errors=True)
+
+
+def _teardown_and_remove(
+    _name: str,
+    repo_wt: RepoWorktree,
+    *,
+    force_cleanup: bool = False,
+) -> None:
+    """Run teardown hook then remove worktree. The shared removal primitive.
+
+    *force_cleanup*: if True, fall back to ``shutil.rmtree`` when git fails.
+    """
+    if repo_wt.worktree_path.exists():
+        with contextlib.suppress(Exception):
+            _run_hook(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path, "teardown")
+    try:
+        git.worktree_remove(repo_wt.source_repo, repo_wt.worktree_path)
+    except GitError:
+        if force_cleanup and repo_wt.worktree_path.exists():
+            shutil.rmtree(repo_wt.worktree_path, ignore_errors=True)
+        raise  # re-raise so _parallel records the error
 
 
 def delete_workspace(name: str) -> bool:
@@ -184,13 +228,7 @@ def delete_workspace(name: str) -> bool:
         return False
 
     def _remove_one(_name: str, repo_wt: RepoWorktree) -> None:
-        try:
-            git.worktree_remove(repo_wt.source_repo, repo_wt.worktree_path)
-        except GitError:
-            # Try manual cleanup if worktree path exists
-            if repo_wt.worktree_path.exists():
-                shutil.rmtree(repo_wt.worktree_path, ignore_errors=True)
-            raise  # re-raise so _parallel records the error
+        _teardown_and_remove(_name, repo_wt, force_cleanup=True)
 
     items = [(wt.repo_name, wt) for wt in workspace.repos]
     for repo_name, _result, exc in _parallel(_remove_one, items, "Removing"):
@@ -213,16 +251,13 @@ def _sync_one_repo(_name: str, repo_wt: RepoWorktree) -> dict[str, str]:
         git.fetch(repo_wt.worktree_path)
 
     # Determine base branch
-    base = git.repo_base_branch(repo_wt.source_repo)
+    base = git.resolve_base_branch(repo_wt.source_repo)
     if base is None:
-        try:
-            base = git.default_branch(repo_wt.source_repo)
-        except GitError:
-            return {
-                "repo": repo_wt.repo_name,
-                "base": "?",
-                "result": "error: could not determine base branch",
-            }
+        return {
+            "repo": repo_wt.repo_name,
+            "base": "?",
+            "result": "error: could not determine base branch",
+        }
 
     # Skip dirty worktrees — rebase on uncommitted changes is dangerous
     status_text = git.repo_status(repo_wt.worktree_path)
@@ -246,10 +281,17 @@ def _sync_one_repo(_name: str, repo_wt: RepoWorktree) -> dict[str, str]:
             "result": "up to date",
         }
 
+    # Pre-sync hook (best-effort)
+    with contextlib.suppress(Exception):
+        _run_hook(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path, "pre_sync")
+
     # Rebase
     try:
         git.rebase_onto(repo_wt.worktree_path, base)
         msg = f"rebased ({behind} new commits)" if behind > 0 else "rebased"
+        # Post-sync hook (best-effort, only on success)
+        with contextlib.suppress(Exception):
+            _run_hook(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path, "post_sync")
         return {
             "repo": repo_wt.repo_name,
             "base": base,
@@ -281,6 +323,60 @@ def sync_workspace(workspace: Workspace) -> list[dict[str, str]]:
     return results
 
 
+def run_workspace(ws: Workspace) -> int:
+    """Run ``run`` hooks across all repos as foreground processes.
+
+    Runs ``pre_run`` first, then starts ``run`` processes in parallel.
+    On exit (Ctrl+C or natural), runs ``post_run`` hooks for cleanup.
+    Returns the number of repos that had a ``run`` hook.
+    """
+    # Filter to repos that have a run hook
+    runnable = [wt for wt in ws.repos if git.repo_hook_commands(wt.source_repo, "run")]
+    if not runnable:
+        return 0
+
+    # Pre-run hooks (parallel, best-effort)
+    def _pre_run(_name: str, repo_wt: RepoWorktree) -> None:
+        _run_hook(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path, "pre_run")
+
+    _parallel(_pre_run, [(wt.repo_name, wt) for wt in runnable], "Pre-run")
+
+    # Start all run processes
+    processes: list[tuple[str, subprocess.Popen]] = []
+    for repo_wt in runnable:
+        commands = git.repo_hook_commands(repo_wt.source_repo, "run")
+        # Join multiple commands with && so they run as one shell
+        cmd = " && ".join(commands)
+        info(f"[{repo_wt.repo_name}] run: {cmd}")
+        proc = subprocess.Popen(
+            cmd,
+            cwd=repo_wt.worktree_path,
+            shell=True,
+        )
+        processes.append((repo_wt.repo_name, proc))
+
+    # Wait for all processes (Ctrl+C triggers KeyboardInterrupt)
+    try:
+        for _name, proc in processes:
+            proc.wait()
+    except KeyboardInterrupt:
+        info("Stopping…")
+        for _name, proc in processes:
+            with contextlib.suppress(BaseException):
+                proc.terminate()
+        for _name, proc in processes:
+            with contextlib.suppress(BaseException):
+                proc.wait(timeout=5)
+
+    # Post-run hooks (parallel, best-effort) — always runs
+    def _post_run(_name: str, repo_wt: RepoWorktree) -> None:
+        _run_hook(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path, "post_run")
+
+    _parallel(_post_run, [(wt.repo_name, wt) for wt in runnable], "Post-run")
+
+    return len(runnable)
+
+
 def _status_one_repo(_name: str, repo_wt: RepoWorktree) -> dict[str, str]:
     """Get status for a single repo."""
     try:
@@ -291,12 +387,11 @@ def _status_one_repo(_name: str, repo_wt: RepoWorktree) -> dict[str, str]:
         ahead_str = "-"
         behind_str = "-"
         try:
-            base = git.repo_base_branch(repo_wt.source_repo)
-            if base is None:
-                base = git.default_branch(repo_wt.source_repo)
-            ahead, behind = git.commits_ahead_behind(repo_wt.worktree_path, base)
-            ahead_str = str(ahead)
-            behind_str = str(behind)
+            base = git.resolve_base_branch(repo_wt.source_repo)
+            if base is not None:
+                ahead, behind = git.commits_ahead_behind(repo_wt.worktree_path, base)
+                ahead_str = str(ahead)
+                behind_str = str(behind)
         except Exception:
             pass
 
@@ -338,3 +433,303 @@ def workspace_status(workspace: Workspace) -> list[dict[str, str]]:
         else:
             results.append(result)
     return results
+
+
+# ---------------------------------------------------------------------------
+# Status --all
+# ---------------------------------------------------------------------------
+
+
+def all_workspaces_summary() -> list[dict[str, str]]:
+    """Return a summary row for every workspace.
+
+    Each dict contains ``{name, branch, repos, status, path}``.
+    """
+    workspaces = state.load_workspaces()
+    if not workspaces:
+        return []
+
+    def _summarise(_name: str, ws: Workspace) -> dict[str, str]:
+        statuses = workspace_status(ws)
+        clean = sum(1 for s in statuses if s["status"] == "clean")
+        modified = sum(
+            1
+            for s in statuses
+            if s["status"] not in ("clean", "") and not s["status"].startswith("error:")
+        )
+        errored = sum(1 for s in statuses if s["status"].startswith("error:"))
+
+        parts: list[str] = []
+        if clean:
+            parts.append(f"{clean} clean")
+        if modified:
+            parts.append(f"{modified} modified")
+        if errored:
+            parts.append(f"{errored} error")
+        summary = ", ".join(parts) if parts else "empty"
+
+        return {
+            "name": ws.name,
+            "branch": ws.branch,
+            "repos": str(len(ws.repos)),
+            "status": summary,
+            "path": str(ws.path),
+        }
+
+    items = [(ws.name, ws) for ws in workspaces]
+    results: list[dict[str, str]] = []
+    for _name, result, exc in _parallel(_summarise, items, "Checking"):
+        if exc is not None:
+            ws_match = next((ws for ws in workspaces if ws.name == _name), None)
+            results.append(
+                {
+                    "name": _name,
+                    "branch": ws_match.branch if ws_match else "?",
+                    "repos": str(len(ws_match.repos)) if ws_match else "?",
+                    "status": f"error: {exc}",
+                    "path": str(ws_match.path) if ws_match else "?",
+                }
+            )
+        else:
+            results.append(result)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Add / remove repos
+# ---------------------------------------------------------------------------
+
+
+def add_repo_to_workspace(
+    ws: Workspace,
+    repo_paths: dict[str, Path],
+    config: Config,
+) -> list[RepoWorktree] | None:
+    """Add new repos to an existing workspace.
+
+    Returns the newly created RepoWorktree entries, or None on failure.
+    """
+    existing_names = {r.repo_name for r in ws.repos}
+
+    # Filter out already-present repos
+    to_add = {n: p for n, p in repo_paths.items() if n not in existing_names}
+    if not to_add:
+        warning("All selected repos are already in the workspace")
+        return None
+
+    created = _provision_worktrees(
+        to_add, ws.branch, ws.path, remove_workspace_dir_on_rollback=False
+    )
+    if created is None:
+        return None
+
+    ws.repos.extend(created)
+    state.update_workspace(ws)
+    return created
+
+
+def remove_repo_from_workspace(
+    ws: Workspace,
+    repo_names: list[str],
+    *,
+    force: bool = False,
+) -> bool:
+    """Remove repos from an existing workspace.
+
+    Returns True if all removals succeeded, False if any failed.
+    """
+    existing = {r.repo_name: r for r in ws.repos}
+    to_remove: list[RepoWorktree] = []
+    for name in repo_names:
+        if name not in existing:
+            warning(f"{name} is not in workspace [bold]{ws.name}[/], skipping")
+            continue
+        to_remove.append(existing[name])
+
+    if not to_remove:
+        warning("No repos to remove")
+        return True
+
+    items = [(wt.repo_name, wt) for wt in to_remove]
+    removed_names: set[str] = set()
+    for name, _result, exc in _parallel(_teardown_and_remove, items, "Removing"):
+        if exc is not None:
+            warning(f"Could not remove worktree for {name}: {exc}")
+        else:
+            removed_names.add(name)
+            success(f"Removed repo: {name}")
+
+    # Update state for successful removals
+    if removed_names:
+        ws.repos = [r for r in ws.repos if r.repo_name not in removed_names]
+        state.update_workspace(ws)
+
+    return len(removed_names) == len(to_remove)
+
+
+# ---------------------------------------------------------------------------
+# Rename
+# ---------------------------------------------------------------------------
+
+
+def rename_workspace(old_name: str, new_name: str, config: Config) -> bool:
+    """Rename a workspace: directory, internal paths, state entry, and git linkage."""
+    ws = state.get_workspace(old_name)
+    if ws is None:
+        error(f"Workspace [bold]{old_name}[/] not found")
+        return False
+
+    if state.get_workspace(new_name) is not None:
+        error(f"Workspace [bold]{new_name}[/] already exists")
+        return False
+
+    old_path = ws.path
+    new_path = config.workspace_dir / new_name
+
+    if new_path.exists():
+        error(f"Directory already exists: {new_path}")
+        return False
+
+    # Rename directory
+    try:
+        old_path.rename(new_path)
+    except OSError as e:
+        error(f"Failed to rename directory: {e}")
+        return False
+
+    # Rebuild paths
+    ws.name = new_name
+    ws.path = new_path
+    for repo_wt in ws.repos:
+        repo_wt.worktree_path = new_path / repo_wt.repo_name
+
+    # Atomic state swap: remove old, add new
+    state.remove_workspace(old_name)
+    state.add_workspace(ws)
+
+    # Repair git worktree linkage (best-effort per repo)
+    for repo_wt in ws.repos:
+        with contextlib.suppress(Exception):
+            git.worktree_repair(repo_wt.source_repo, repo_wt.worktree_path)
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Doctor
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DoctorIssue:
+    """A single issue found by the doctor command."""
+
+    workspace_name: str
+    repo_name: str | None
+    issue: str
+    suggested_action: str
+
+
+def diagnose_workspaces(config: Config) -> list[DoctorIssue]:
+    """Check all workspaces for health issues."""
+    issues: list[DoctorIssue] = []
+    workspaces = state.load_workspaces()
+
+    for ws in workspaces:
+        # Check: workspace directory exists
+        if not ws.path.exists():
+            issues.append(
+                DoctorIssue(
+                    workspace_name=ws.name,
+                    repo_name=None,
+                    issue="workspace directory missing",
+                    suggested_action="remove stale state entry",
+                )
+            )
+            continue  # no point checking repos if dir is gone
+
+        for repo_wt in ws.repos:
+            # Check: source repo exists
+            if not repo_wt.source_repo.exists():
+                issues.append(
+                    DoctorIssue(
+                        workspace_name=ws.name,
+                        repo_name=repo_wt.repo_name,
+                        issue="source repo missing",
+                        suggested_action="remove stale repo entry",
+                    )
+                )
+                continue
+
+            # Check: worktree directory exists
+            if not repo_wt.worktree_path.exists():
+                issues.append(
+                    DoctorIssue(
+                        workspace_name=ws.name,
+                        repo_name=repo_wt.repo_name,
+                        issue="worktree directory missing",
+                        suggested_action="remove stale repo entry",
+                    )
+                )
+                continue
+
+            # Check: git worktree is registered
+            try:
+                wt_list = git.worktree_list(repo_wt.source_repo)
+                registered = any(
+                    Path(wt["path"]).resolve() == repo_wt.worktree_path.resolve() for wt in wt_list
+                )
+                if not registered:
+                    issues.append(
+                        DoctorIssue(
+                            workspace_name=ws.name,
+                            repo_name=repo_wt.repo_name,
+                            issue="worktree not registered in git",
+                            suggested_action="re-register with git worktree repair",
+                        )
+                    )
+            except GitError:
+                issues.append(
+                    DoctorIssue(
+                        workspace_name=ws.name,
+                        repo_name=repo_wt.repo_name,
+                        issue="git error checking worktree registration",
+                        suggested_action="check repo manually",
+                    )
+                )
+
+    return issues
+
+
+def fix_workspace_issues(issues: list[DoctorIssue]) -> int:
+    """Auto-fix stale state entries. Returns the number of fixes applied."""
+    fixed = 0
+
+    # Group workspace-level removals
+    ws_to_remove: set[str] = set()
+    # Group repo-level removals: workspace_name -> set of repo_names
+    repos_to_remove: dict[str, set[str]] = {}
+
+    for issue in issues:
+        if issue.repo_name is None and "remove stale state" in issue.suggested_action:
+            ws_to_remove.add(issue.workspace_name)
+        elif issue.repo_name is not None and "remove stale repo" in issue.suggested_action:
+            repos_to_remove.setdefault(issue.workspace_name, set()).add(issue.repo_name)
+
+    # Remove stale workspaces
+    for ws_name in ws_to_remove:
+        state.remove_workspace(ws_name)
+        fixed += 1
+
+    # Remove stale repos from workspaces
+    for ws_name, repo_names in repos_to_remove.items():
+        if ws_name in ws_to_remove:
+            continue  # already removed entirely
+        ws = state.get_workspace(ws_name)
+        if ws is None:
+            continue
+        ws.repos = [r for r in ws.repos if r.repo_name not in repo_names]
+        state.update_workspace(ws)
+        fixed += len(repo_names)
+
+    return fixed

--- a/src/grove/workspace.py
+++ b/src/grove/workspace.py
@@ -31,6 +31,8 @@ def _parallel(
         return []
 
     order = {name: idx for idx, (name, _) in enumerate(items)}
+    if len(order) != len(items):
+        raise ValueError(f"Duplicate names in parallel items: {[n for n, _ in items]}")
     results: list[tuple[str, Any, Exception | None]] = [("", None, None)] * len(items)
 
     with (
@@ -330,8 +332,10 @@ def run_workspace(ws: Workspace) -> int:
     On exit (Ctrl+C or natural), runs ``post_run`` hooks for cleanup.
     Returns the number of repos that had a ``run`` hook.
     """
-    # Filter to repos that have a run hook
-    runnable = [wt for wt in ws.repos if git.repo_hook_commands(wt.source_repo, "run")]
+    # Filter to repos that have a run hook, storing commands to avoid re-reading
+    runnable: list[tuple[RepoWorktree, list[str]]] = [
+        (wt, cmds) for wt in ws.repos if (cmds := git.repo_hook_commands(wt.source_repo, "run"))
+    ]
     if not runnable:
         return 0
 
@@ -339,12 +343,11 @@ def run_workspace(ws: Workspace) -> int:
     def _pre_run(_name: str, repo_wt: RepoWorktree) -> None:
         _run_hook(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path, "pre_run")
 
-    _parallel(_pre_run, [(wt.repo_name, wt) for wt in runnable], "Pre-run")
+    _parallel(_pre_run, [(wt.repo_name, wt) for wt, _ in runnable], "Pre-run")
 
     # Start all run processes
     processes: list[tuple[str, subprocess.Popen]] = []
-    for repo_wt in runnable:
-        commands = git.repo_hook_commands(repo_wt.source_repo, "run")
+    for repo_wt, commands in runnable:
         # Join multiple commands with && so they run as one shell
         cmd = " && ".join(commands)
         info(f"[{repo_wt.repo_name}] run: {cmd}")
@@ -372,7 +375,7 @@ def run_workspace(ws: Workspace) -> int:
     def _post_run(_name: str, repo_wt: RepoWorktree) -> None:
         _run_hook(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path, "post_run")
 
-    _parallel(_post_run, [(wt.repo_name, wt) for wt in runnable], "Post-run")
+    _parallel(_post_run, [(wt.repo_name, wt) for wt, _ in runnable], "Post-run")
 
     return len(runnable)
 
@@ -597,15 +600,13 @@ def rename_workspace(old_name: str, new_name: str, config: Config) -> bool:
         error(f"Failed to rename directory: {e}")
         return False
 
-    # Rebuild paths
+    # Rebuild paths and update state in one write
     ws.name = new_name
     ws.path = new_path
     for repo_wt in ws.repos:
         repo_wt.worktree_path = new_path / repo_wt.repo_name
 
-    # Atomic state swap: remove old, add new
-    state.remove_workspace(old_name)
-    state.add_workspace(ws)
+    state.update_workspace(ws, match_name=old_name)
 
     # Repair git worktree linkage (best-effort per repo)
     for repo_wt in ws.repos:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,16 @@ from unittest.mock import patch
 
 import pytest
 
+from grove import git
 from grove.models import Config, RepoWorktree, Workspace
+
+
+@pytest.fixture(autouse=True)
+def _clear_grove_config_cache():
+    """Clear the ``read_grove_config`` LRU cache between tests."""
+    git.read_grove_config.cache_clear()
+    yield
+    git.read_grove_config.cache_clear()
 
 
 @pytest.fixture()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from grove.cli import _format_drift, _format_pr, _sanitize_name, app
-from grove.models import Config, Workspace
+from grove.models import Config, RepoWorktree, Workspace
 
 runner = CliRunner()
 
@@ -541,6 +541,244 @@ class TestPreset:
             result = runner.invoke(app, ["preset", "remove", "nope"])
             assert result.exit_code == 1
             assert "not found" in result.output
+
+
+class TestStatusAll:
+    def test_flag_works(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with patch("grove.cli.workspace.all_workspaces_summary") as mock_summary:
+            mock_summary.return_value = [
+                {
+                    "name": "test-ws",
+                    "branch": "feat/test",
+                    "repos": "1",
+                    "status": "1 clean",
+                    "path": str(sample_workspace.path),
+                },
+            ]
+            result = runner.invoke(app, ["status", "--all"])
+        assert result.exit_code == 0
+        assert "test-ws" in result.output
+        assert "1 clean" in result.output
+
+    def test_mutual_exclusivity(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        result = runner.invoke(app, ["status", "test-ws", "--all"])
+        assert result.exit_code == 1
+        assert "Cannot combine" in result.output
+
+    def test_empty_state(self, tmp_grove):
+        with patch("grove.cli.workspace.all_workspaces_summary", return_value=[]):
+            result = runner.invoke(app, ["status", "--all"])
+        assert result.exit_code == 0
+        assert "No workspaces" in result.output
+
+
+class TestDoctor:
+    def test_healthy(self, tmp_grove):
+        with (
+            patch("grove.cli.config.require_config") as mock_cfg,
+            patch("grove.cli.workspace.diagnose_workspaces", return_value=[]),
+        ):
+            mock_cfg.return_value = Config(
+                repos_dir=tmp_grove["repos_dir"],
+                workspace_dir=tmp_grove["workspace_dir"],
+            )
+            result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "healthy" in result.output
+
+    def test_issues_table(self, tmp_grove):
+        from grove.workspace import DoctorIssue
+
+        issues = [
+            DoctorIssue(
+                workspace_name="stale",
+                repo_name=None,
+                issue="workspace directory missing",
+                suggested_action="remove stale state entry",
+            )
+        ]
+        with (
+            patch("grove.cli.config.require_config") as mock_cfg,
+            patch("grove.cli.workspace.diagnose_workspaces", return_value=issues),
+        ):
+            mock_cfg.return_value = Config(
+                repos_dir=tmp_grove["repos_dir"],
+                workspace_dir=tmp_grove["workspace_dir"],
+            )
+            result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "stale" in result.output
+        assert "missing" in result.output
+
+    def test_fix_flag(self, tmp_grove):
+        from grove.workspace import DoctorIssue
+
+        issues = [
+            DoctorIssue(
+                workspace_name="stale",
+                repo_name=None,
+                issue="workspace directory missing",
+                suggested_action="remove stale state entry",
+            )
+        ]
+        with (
+            patch("grove.cli.config.require_config") as mock_cfg,
+            patch("grove.cli.workspace.diagnose_workspaces", return_value=issues),
+            patch("grove.cli.workspace.fix_workspace_issues", return_value=1) as mock_fix,
+        ):
+            mock_cfg.return_value = Config(
+                repos_dir=tmp_grove["repos_dir"],
+                workspace_dir=tmp_grove["workspace_dir"],
+            )
+            result = runner.invoke(app, ["doctor", "--fix"])
+        assert result.exit_code == 0
+        assert "Fixed 1" in result.output
+        mock_fix.assert_called_once()
+
+
+class TestRename:
+    def test_success(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with (
+            patch("grove.cli.config.require_config") as mock_cfg,
+            patch("grove.cli.workspace.rename_workspace", return_value=True),
+        ):
+            mock_cfg.return_value = Config(
+                repos_dir=tmp_grove["repos_dir"],
+                workspace_dir=tmp_grove["workspace_dir"],
+            )
+            result = runner.invoke(app, ["rename", "test-ws", "--to", "new-name"])
+        assert result.exit_code == 0
+        assert "new-name" in result.output
+
+    def test_failure(self, tmp_grove):
+        with (
+            patch("grove.cli.config.require_config") as mock_cfg,
+            patch("grove.cli.workspace.rename_workspace", return_value=False),
+        ):
+            mock_cfg.return_value = Config(
+                repos_dir=tmp_grove["repos_dir"],
+                workspace_dir=tmp_grove["workspace_dir"],
+            )
+            result = runner.invoke(app, ["rename", "nope", "--to", "new"])
+        assert result.exit_code == 1
+
+
+class TestAddRepo:
+    def test_with_flags(self, tmp_grove, sample_workspace, fake_repos):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        mock_added = [
+            RepoWorktree(
+                repo_name="svc-api",
+                source_repo=tmp_grove["repos_dir"] / "svc-api",
+                worktree_path=sample_workspace.path / "svc-api",
+                branch="feat/test",
+            )
+        ]
+        with (
+            patch("grove.cli.config.require_config") as mock_cfg,
+            patch("grove.cli.discover.find_repos", return_value=fake_repos),
+            patch("grove.cli.workspace.add_repo_to_workspace", return_value=mock_added),
+        ):
+            mock_cfg.return_value = Config(
+                repos_dir=tmp_grove["repos_dir"],
+                workspace_dir=tmp_grove["workspace_dir"],
+            )
+            result = runner.invoke(app, ["add-repo", "test-ws", "-r", "svc-api"])
+        assert result.exit_code == 0
+        assert "Added 1" in result.output
+
+    def test_not_found(self, tmp_grove, fake_repos):
+        with (
+            patch("grove.cli.config.require_config") as mock_cfg,
+            patch("grove.cli.discover.find_repos", return_value=fake_repos),
+        ):
+            mock_cfg.return_value = Config(
+                repos_dir=tmp_grove["repos_dir"],
+                workspace_dir=tmp_grove["workspace_dir"],
+            )
+            result = runner.invoke(app, ["add-repo", "nope", "-r", "svc-api"])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_invalid_repo(self, tmp_grove, sample_workspace, fake_repos):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with (
+            patch("grove.cli.config.require_config") as mock_cfg,
+            patch("grove.cli.discover.find_repos", return_value=fake_repos),
+        ):
+            mock_cfg.return_value = Config(
+                repos_dir=tmp_grove["repos_dir"],
+                workspace_dir=tmp_grove["workspace_dir"],
+            )
+            result = runner.invoke(app, ["add-repo", "test-ws", "-r", "nonexistent"])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+
+class TestRemoveRepo:
+    def test_with_flags(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with (
+            patch("grove.cli.workspace.remove_repo_from_workspace", return_value=True),
+        ):
+            result = runner.invoke(app, ["remove-repo", "test-ws", "-r", "svc-auth", "--force"])
+        assert result.exit_code == 0
+
+    def test_not_found(self, tmp_grove):
+        result = runner.invoke(app, ["remove-repo", "nope", "-r", "svc-auth", "--force"])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_confirmation_required(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with (
+            patch("grove.cli.workspace.remove_repo_from_workspace", return_value=True),
+        ):
+            result = runner.invoke(app, ["remove-repo", "test-ws", "-r", "svc-auth"], input="n\n")
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
+
+class TestRun:
+    def test_success(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with patch("grove.cli.workspace.run_workspace", return_value=2):
+            result = runner.invoke(app, ["run", "test-ws"])
+        assert result.exit_code == 0
+        assert "Running" in result.output
+
+    def test_no_hooks(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with patch("grove.cli.workspace.run_workspace", return_value=0):
+            result = runner.invoke(app, ["run", "test-ws"])
+        assert result.exit_code == 0
+        assert "No repos" in result.output
+
+    def test_not_found(self, tmp_grove):
+        result = runner.invoke(app, ["run", "nope"])
+        assert result.exit_code == 1
+        assert "not found" in result.output
 
 
 class TestShellInit:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -475,3 +476,826 @@ class TestParallelExecution:
         ):
             results = workspace.workspace_status(ws)
             assert [r["repo"] for r in results] == [f"repo-{i}" for i in range(5)]
+
+
+class TestLifecycleHooks:
+    def test_teardown_runs_before_delete(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        call_order: list[str] = []
+
+        def mock_hook(repo_name, source_repo, worktree_path, hook):
+            if hook == "teardown":
+                call_order.append("teardown")
+
+        def mock_remove(repo, path):
+            call_order.append("remove")
+
+        wt_path = sample_workspace.repos[0].worktree_path
+        wt_path.mkdir(parents=True, exist_ok=True)
+
+        with (
+            patch("grove.workspace._run_hook", side_effect=mock_hook),
+            patch("grove.workspace.git.worktree_remove", side_effect=mock_remove),
+        ):
+            workspace.delete_workspace("test-ws")
+        assert call_order == ["teardown", "remove"]
+
+    def test_teardown_failure_does_not_block_delete(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        wt_path = sample_workspace.repos[0].worktree_path
+        wt_path.mkdir(parents=True, exist_ok=True)
+
+        with (
+            patch(
+                "grove.workspace._run_hook",
+                side_effect=subprocess.CalledProcessError(1, "teardown"),
+            ),
+            patch("grove.workspace.git.worktree_remove"),
+        ):
+            result = workspace.delete_workspace("test-ws")
+        assert result is True
+        assert state.get_workspace("test-ws") is None
+
+    def test_pre_sync_runs_before_rebase(self, tmp_grove, sample_workspace):
+        call_order: list[str] = []
+
+        def mock_hook(repo_name, source_repo, worktree_path, hook):
+            call_order.append(hook)
+
+        def mock_rebase(path, base):
+            call_order.append("rebase")
+
+        with (
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.repo_base_branch", return_value="origin/main"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(1, 3)),
+            patch("grove.workspace._run_hook", side_effect=mock_hook),
+            patch("grove.workspace.git.rebase_onto", side_effect=mock_rebase),
+        ):
+            results = workspace.sync_workspace(sample_workspace)
+        assert results[0]["result"] == "rebased (3 new commits)"
+        assert call_order == ["pre_sync", "rebase", "post_sync"]
+
+    def test_post_sync_not_on_conflict(self, tmp_grove, sample_workspace):
+        hooks_called: list[str] = []
+
+        def mock_hook(repo_name, source_repo, worktree_path, hook):
+            hooks_called.append(hook)
+
+        with (
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.repo_base_branch", return_value="origin/main"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(0, 2)),
+            patch("grove.workspace._run_hook", side_effect=mock_hook),
+            patch("grove.workspace.git.rebase_onto", side_effect=GitError("conflict")),
+            patch("grove.workspace.git.rebase_abort"),
+        ):
+            results = workspace.sync_workspace(sample_workspace)
+        assert results[0]["result"] == "conflict"
+        assert "pre_sync" in hooks_called
+        assert "post_sync" not in hooks_called
+
+    def test_pre_sync_not_when_up_to_date(self, tmp_grove, sample_workspace):
+        hooks_called: list[str] = []
+
+        def mock_hook(repo_name, source_repo, worktree_path, hook):
+            hooks_called.append(hook)
+
+        with (
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.repo_base_branch", return_value="origin/main"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(1, 0)),
+            patch("grove.workspace._run_hook", side_effect=mock_hook),
+        ):
+            results = workspace.sync_workspace(sample_workspace)
+        assert results[0]["result"] == "up to date"
+        assert hooks_called == []
+
+    def test_post_sync_after_successful_rebase(self, tmp_grove, sample_workspace):
+        hooks_called: list[str] = []
+
+        def mock_hook(repo_name, source_repo, worktree_path, hook):
+            hooks_called.append(hook)
+
+        with (
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.repo_base_branch", return_value="origin/main"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(0, 5)),
+            patch("grove.workspace._run_hook", side_effect=mock_hook),
+            patch("grove.workspace.git.rebase_onto"),
+        ):
+            results = workspace.sync_workspace(sample_workspace)
+        assert results[0]["result"] == "rebased (5 new commits)"
+        assert "post_sync" in hooks_called
+
+
+class TestAddRepoToWorkspace:
+    def test_success(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        new_repo = tmp_grove["repos_dir"] / "svc-api"
+        new_repo.mkdir()
+
+        with (
+            patch("grove.workspace.git.worktree_has_branch", return_value=False),
+            patch("grove.workspace.git.branch_exists", return_value=True),
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.worktree_add"),
+            patch("grove.workspace.git.read_grove_config", return_value={}),
+        ):
+            result = workspace.add_repo_to_workspace(sample_workspace, {"svc-api": new_repo}, cfg)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].repo_name == "svc-api"
+        # State updated
+        saved = state.get_workspace("test-ws")
+        assert len(saved.repos) == 2
+
+    def test_already_in_workspace_skip(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        existing = tmp_grove["repos_dir"] / "svc-auth"
+        existing.mkdir(exist_ok=True)
+
+        result = workspace.add_repo_to_workspace(sample_workspace, {"svc-auth": existing}, cfg)
+        assert result is None
+
+    def test_branch_conflict(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        new_repo = tmp_grove["repos_dir"] / "svc-api"
+        new_repo.mkdir()
+
+        with patch("grove.workspace.git.worktree_has_branch", return_value=True):
+            result = workspace.add_repo_to_workspace(sample_workspace, {"svc-api": new_repo}, cfg)
+        assert result is None
+
+    def test_branch_creation(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        new_repo = tmp_grove["repos_dir"] / "svc-api"
+        new_repo.mkdir()
+
+        with (
+            patch("grove.workspace.git.worktree_has_branch", return_value=False),
+            patch("grove.workspace.git.branch_exists", return_value=False),
+            patch("grove.workspace.git.default_branch", return_value="origin/main"),
+            patch("grove.workspace.git.create_branch") as mock_create,
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.worktree_add"),
+            patch("grove.workspace.git.read_grove_config", return_value={}),
+        ):
+            result = workspace.add_repo_to_workspace(sample_workspace, {"svc-api": new_repo}, cfg)
+        assert result is not None
+        mock_create.assert_called_once()
+
+    def test_setup_hook_runs(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        new_repo = tmp_grove["repos_dir"] / "svc-api"
+        new_repo.mkdir()
+
+        with (
+            patch("grove.workspace.git.worktree_has_branch", return_value=False),
+            patch("grove.workspace.git.branch_exists", return_value=True),
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.worktree_add"),
+            patch("grove.workspace.subprocess.run") as mock_sub,
+            patch(
+                "grove.workspace.git.read_grove_config",
+                return_value={"setup": "npm install"},
+            ),
+            patch(
+                "grove.workspace.git.repo_hook_commands",
+                return_value=["npm install"],
+            ),
+        ):
+            result = workspace.add_repo_to_workspace(sample_workspace, {"svc-api": new_repo}, cfg)
+        assert result is not None
+        assert mock_sub.called
+
+    def test_rollback_does_not_delete_workspace_dir(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        new_repo = tmp_grove["repos_dir"] / "svc-api"
+        new_repo.mkdir()
+
+        with (
+            patch("grove.workspace.git.worktree_has_branch", return_value=False),
+            patch("grove.workspace.git.branch_exists", return_value=True),
+            patch("grove.workspace.git.fetch"),
+            patch("grove.workspace.git.worktree_add", side_effect=GitError("disk full")),
+            patch("grove.workspace.git.worktree_remove"),
+        ):
+            result = workspace.add_repo_to_workspace(sample_workspace, {"svc-api": new_repo}, cfg)
+        assert result is None
+        # Workspace dir should still exist
+        assert sample_workspace.path.exists()
+
+
+class TestRemoveRepoFromWorkspace:
+    def test_success(self, tmp_grove):
+        ws_path = tmp_grove["workspace_dir"] / "test-ws"
+        ws_path.mkdir()
+        ws = Workspace(
+            name="test-ws",
+            path=ws_path,
+            branch="feat/test",
+            repos=[
+                RepoWorktree(
+                    repo_name="svc-auth",
+                    source_repo=tmp_grove["repos_dir"] / "svc-auth",
+                    worktree_path=ws_path / "svc-auth",
+                    branch="feat/test",
+                ),
+                RepoWorktree(
+                    repo_name="svc-api",
+                    source_repo=tmp_grove["repos_dir"] / "svc-api",
+                    worktree_path=ws_path / "svc-api",
+                    branch="feat/test",
+                ),
+            ],
+        )
+        state.add_workspace(ws)
+
+        with (
+            patch("grove.workspace._run_hook"),
+            patch("grove.workspace.git.worktree_remove"),
+        ):
+            ok = workspace.remove_repo_from_workspace(ws, ["svc-auth"])
+        assert ok is True
+        saved = state.get_workspace("test-ws")
+        assert len(saved.repos) == 1
+        assert saved.repos[0].repo_name == "svc-api"
+
+    def test_not_in_workspace_skip(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        ok = workspace.remove_repo_from_workspace(sample_workspace, ["nonexistent"])
+        assert ok is True  # nothing to remove = success
+
+    def test_teardown_hook_runs(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        wt_path = sample_workspace.repos[0].worktree_path
+        wt_path.mkdir(parents=True, exist_ok=True)
+        hooks: list[str] = []
+
+        def mock_hook(repo_name, source_repo, worktree_path, hook):
+            hooks.append(hook)
+
+        with (
+            patch("grove.workspace._run_hook", side_effect=mock_hook),
+            patch("grove.workspace.git.worktree_remove"),
+        ):
+            workspace.remove_repo_from_workspace(sample_workspace, ["svc-auth"])
+        assert "teardown" in hooks
+
+    def test_partial_failure(self, tmp_grove):
+        ws_path = tmp_grove["workspace_dir"] / "test-ws"
+        ws_path.mkdir()
+        ws = Workspace(
+            name="test-ws",
+            path=ws_path,
+            branch="feat/test",
+            repos=[
+                RepoWorktree(
+                    repo_name="good",
+                    source_repo=tmp_grove["repos_dir"] / "good",
+                    worktree_path=ws_path / "good",
+                    branch="feat/test",
+                ),
+                RepoWorktree(
+                    repo_name="bad",
+                    source_repo=tmp_grove["repos_dir"] / "bad",
+                    worktree_path=ws_path / "bad",
+                    branch="feat/test",
+                ),
+            ],
+        )
+        state.add_workspace(ws)
+
+        def failing_remove(repo, path):
+            if "bad" in str(path):
+                raise GitError("cannot remove")
+
+        with (
+            patch("grove.workspace._run_hook"),
+            patch("grove.workspace.git.worktree_remove", side_effect=failing_remove),
+        ):
+            ok = workspace.remove_repo_from_workspace(ws, ["good", "bad"])
+        assert ok is False
+        # Good repo should be removed from state
+        saved = state.get_workspace("test-ws")
+        assert len(saved.repos) == 1
+        assert saved.repos[0].repo_name == "bad"
+
+
+class TestRenameWorkspace:
+    def test_success(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        with patch("grove.workspace.git.worktree_repair"):
+            result = workspace.rename_workspace("test-ws", "new-name", cfg)
+        assert result is True
+        assert state.get_workspace("test-ws") is None
+        saved = state.get_workspace("new-name")
+        assert saved is not None
+        assert saved.path == cfg.workspace_dir / "new-name"
+
+    def test_not_found(self, tmp_grove):
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        assert workspace.rename_workspace("nope", "new", cfg) is False
+
+    def test_name_taken(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        other = Workspace(
+            name="other",
+            path=tmp_grove["workspace_dir"] / "other",
+            branch="feat/x",
+            repos=[],
+        )
+        (tmp_grove["workspace_dir"] / "other").mkdir()
+        state.add_workspace(other)
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        assert workspace.rename_workspace("test-ws", "other", cfg) is False
+
+    def test_dir_exists(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        # Create target dir manually (not as workspace)
+        (cfg.workspace_dir / "conflict").mkdir()
+        assert workspace.rename_workspace("test-ws", "conflict", cfg) is False
+
+    def test_paths_updated(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        with patch("grove.workspace.git.worktree_repair"):
+            workspace.rename_workspace("test-ws", "renamed", cfg)
+        saved = state.get_workspace("renamed")
+        for repo_wt in saved.repos:
+            assert "renamed" in str(repo_wt.worktree_path)
+
+    def test_created_at_preserved(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        original_created = sample_workspace.created_at
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        with patch("grove.workspace.git.worktree_repair"):
+            workspace.rename_workspace("test-ws", "renamed", cfg)
+        saved = state.get_workspace("renamed")
+        assert saved.created_at == original_created
+
+    def test_worktree_repair_called(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        with patch("grove.workspace.git.worktree_repair") as mock_repair:
+            workspace.rename_workspace("test-ws", "renamed", cfg)
+        assert mock_repair.called
+
+    def test_repair_failure_does_not_abort(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        with patch("grove.workspace.git.worktree_repair", side_effect=GitError("broken")):
+            result = workspace.rename_workspace("test-ws", "renamed", cfg)
+        assert result is True
+        assert state.get_workspace("renamed") is not None
+
+
+class TestAllWorkspacesSummary:
+    def test_empty(self, tmp_grove):
+        result = workspace.all_workspaces_summary()
+        assert result == []
+
+    def test_all_clean(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        with (
+            patch("grove.workspace.git.current_branch", return_value="feat/test"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.repo_base_branch", return_value=None),
+            patch("grove.workspace.git.default_branch", return_value="origin/main"),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(0, 0)),
+        ):
+            results = workspace.all_workspaces_summary()
+        assert len(results) == 1
+        assert results[0]["name"] == "test-ws"
+        assert "1 clean" in results[0]["status"]
+
+    def test_mixed_status(self, tmp_grove):
+        ws_path = tmp_grove["workspace_dir"] / "mixed"
+        ws_path.mkdir()
+        ws = Workspace(
+            name="mixed",
+            path=ws_path,
+            branch="feat/x",
+            repos=[
+                RepoWorktree(
+                    repo_name="clean-repo",
+                    source_repo=tmp_grove["repos_dir"] / "clean-repo",
+                    worktree_path=ws_path / "clean-repo",
+                    branch="feat/x",
+                ),
+                RepoWorktree(
+                    repo_name="dirty-repo",
+                    source_repo=tmp_grove["repos_dir"] / "dirty-repo",
+                    worktree_path=ws_path / "dirty-repo",
+                    branch="feat/x",
+                ),
+            ],
+        )
+        state.add_workspace(ws)
+
+        def status_side_effect(path):
+            if "dirty" in str(path):
+                return " M file.py"
+            return ""
+
+        with (
+            patch("grove.workspace.git.current_branch", return_value="feat/x"),
+            patch("grove.workspace.git.repo_status", side_effect=status_side_effect),
+            patch("grove.workspace.git.repo_base_branch", return_value=None),
+            patch("grove.workspace.git.default_branch", return_value="origin/main"),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(0, 0)),
+        ):
+            results = workspace.all_workspaces_summary()
+        assert len(results) == 1
+        assert "1 clean" in results[0]["status"]
+        assert "1 modified" in results[0]["status"]
+
+    def test_multi_workspace(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        ws2_path = tmp_grove["workspace_dir"] / "ws2"
+        ws2_path.mkdir()
+        ws2 = Workspace(
+            name="ws2",
+            path=ws2_path,
+            branch="feat/other",
+            repos=[],
+        )
+        state.add_workspace(ws2)
+
+        with (
+            patch("grove.workspace.git.current_branch", return_value="feat/test"),
+            patch("grove.workspace.git.repo_status", return_value=""),
+            patch("grove.workspace.git.repo_base_branch", return_value=None),
+            patch("grove.workspace.git.default_branch", return_value="origin/main"),
+            patch("grove.workspace.git.commits_ahead_behind", return_value=(0, 0)),
+        ):
+            results = workspace.all_workspaces_summary()
+        assert len(results) == 2
+        names = {r["name"] for r in results}
+        assert names == {"test-ws", "ws2"}
+
+    def test_error_isolation(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        with (
+            patch(
+                "grove.workspace.git.current_branch",
+                side_effect=GitError("broken"),
+            ),
+        ):
+            results = workspace.all_workspaces_summary()
+        assert len(results) == 1
+        # Should still get a result even with error
+        assert results[0]["name"] == "test-ws"
+
+
+class TestDiagnoseWorkspaces:
+    def test_no_issues(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        # Create worktree path
+        wt_path = sample_workspace.repos[0].worktree_path
+        wt_path.mkdir(parents=True, exist_ok=True)
+        # Create source repo
+        src = sample_workspace.repos[0].source_repo
+        src.mkdir(parents=True, exist_ok=True)
+
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        with patch(
+            "grove.workspace.git.worktree_list",
+            return_value=[
+                {"path": str(wt_path.resolve()), "branch": "feat/test"},
+            ],
+        ):
+            issues = workspace.diagnose_workspaces(cfg)
+        assert issues == []
+
+    def test_workspace_dir_missing(self, tmp_grove):
+        ws_path = tmp_grove["workspace_dir"] / "gone"
+        # Don't create the dir
+        ws = Workspace(name="gone", path=ws_path, branch="feat/x", repos=[])
+        state.add_workspace(ws)
+
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        issues = workspace.diagnose_workspaces(cfg)
+        assert len(issues) == 1
+        assert issues[0].issue == "workspace directory missing"
+
+    def test_source_repo_missing(self, tmp_grove):
+        ws_path = tmp_grove["workspace_dir"] / "test-ws"
+        ws_path.mkdir()
+        wt_path = ws_path / "svc-auth"
+        wt_path.mkdir()
+        ws = Workspace(
+            name="test-ws",
+            path=ws_path,
+            branch="feat/test",
+            repos=[
+                RepoWorktree(
+                    repo_name="svc-auth",
+                    source_repo=tmp_grove["repos_dir"] / "nonexistent",
+                    worktree_path=wt_path,
+                    branch="feat/test",
+                ),
+            ],
+        )
+        state.add_workspace(ws)
+
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        issues = workspace.diagnose_workspaces(cfg)
+        assert len(issues) == 1
+        assert issues[0].issue == "source repo missing"
+
+    def test_worktree_dir_missing(self, tmp_grove):
+        ws_path = tmp_grove["workspace_dir"] / "test-ws"
+        ws_path.mkdir()
+        src = tmp_grove["repos_dir"] / "svc-auth"
+        src.mkdir()
+        ws = Workspace(
+            name="test-ws",
+            path=ws_path,
+            branch="feat/test",
+            repos=[
+                RepoWorktree(
+                    repo_name="svc-auth",
+                    source_repo=src,
+                    worktree_path=ws_path / "svc-auth",  # not created
+                    branch="feat/test",
+                ),
+            ],
+        )
+        state.add_workspace(ws)
+
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        issues = workspace.diagnose_workspaces(cfg)
+        assert len(issues) == 1
+        assert issues[0].issue == "worktree directory missing"
+
+    def test_git_unregistered(self, tmp_grove):
+        ws_path = tmp_grove["workspace_dir"] / "test-ws"
+        ws_path.mkdir()
+        wt_path = ws_path / "svc-auth"
+        wt_path.mkdir()
+        src = tmp_grove["repos_dir"] / "svc-auth"
+        src.mkdir()
+        ws = Workspace(
+            name="test-ws",
+            path=ws_path,
+            branch="feat/test",
+            repos=[
+                RepoWorktree(
+                    repo_name="svc-auth",
+                    source_repo=src,
+                    worktree_path=wt_path,
+                    branch="feat/test",
+                ),
+            ],
+        )
+        state.add_workspace(ws)
+
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        # Return empty worktree list — not registered
+        with patch("grove.workspace.git.worktree_list", return_value=[]):
+            issues = workspace.diagnose_workspaces(cfg)
+        assert len(issues) == 1
+        assert issues[0].issue == "worktree not registered in git"
+
+    def test_git_error(self, tmp_grove):
+        ws_path = tmp_grove["workspace_dir"] / "test-ws"
+        ws_path.mkdir()
+        wt_path = ws_path / "svc-auth"
+        wt_path.mkdir()
+        src = tmp_grove["repos_dir"] / "svc-auth"
+        src.mkdir()
+        ws = Workspace(
+            name="test-ws",
+            path=ws_path,
+            branch="feat/test",
+            repos=[
+                RepoWorktree(
+                    repo_name="svc-auth",
+                    source_repo=src,
+                    worktree_path=wt_path,
+                    branch="feat/test",
+                ),
+            ],
+        )
+        state.add_workspace(ws)
+
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        with patch("grove.workspace.git.worktree_list", side_effect=GitError("broken")):
+            issues = workspace.diagnose_workspaces(cfg)
+        assert len(issues) == 1
+        assert "git error" in issues[0].issue
+
+
+class TestFixWorkspaceIssues:
+    def test_removes_stale_workspace(self, tmp_grove):
+        ws = Workspace(
+            name="gone",
+            path=tmp_grove["workspace_dir"] / "gone",
+            branch="feat/x",
+            repos=[],
+        )
+        state.add_workspace(ws)
+
+        issues = [
+            workspace.DoctorIssue(
+                workspace_name="gone",
+                repo_name=None,
+                issue="workspace directory missing",
+                suggested_action="remove stale state entry",
+            )
+        ]
+        fixed = workspace.fix_workspace_issues(issues)
+        assert fixed == 1
+        assert state.get_workspace("gone") is None
+
+    def test_removes_stale_repo(self, tmp_grove):
+        ws_path = tmp_grove["workspace_dir"] / "test-ws"
+        ws_path.mkdir()
+        ws = Workspace(
+            name="test-ws",
+            path=ws_path,
+            branch="feat/test",
+            repos=[
+                RepoWorktree(
+                    repo_name="good",
+                    source_repo=tmp_grove["repos_dir"] / "good",
+                    worktree_path=ws_path / "good",
+                    branch="feat/test",
+                ),
+                RepoWorktree(
+                    repo_name="stale",
+                    source_repo=tmp_grove["repos_dir"] / "stale",
+                    worktree_path=ws_path / "stale",
+                    branch="feat/test",
+                ),
+            ],
+        )
+        state.add_workspace(ws)
+
+        issues = [
+            workspace.DoctorIssue(
+                workspace_name="test-ws",
+                repo_name="stale",
+                issue="source repo missing",
+                suggested_action="remove stale repo entry",
+            )
+        ]
+        fixed = workspace.fix_workspace_issues(issues)
+        assert fixed == 1
+        saved = state.get_workspace("test-ws")
+        assert len(saved.repos) == 1
+        assert saved.repos[0].repo_name == "good"
+
+    def test_skips_git_issues(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+
+        issues = [
+            workspace.DoctorIssue(
+                workspace_name="test-ws",
+                repo_name="svc-auth",
+                issue="worktree not registered in git",
+                suggested_action="re-register with git worktree repair",
+            )
+        ]
+        fixed = workspace.fix_workspace_issues(issues)
+        assert fixed == 0
+
+
+class TestRunWorkspace:
+    def test_no_run_hook_returns_zero(self, tmp_grove, sample_workspace):
+        with patch("grove.workspace.git.repo_hook_commands", return_value=[]):
+            count = workspace.run_workspace(sample_workspace)
+        assert count == 0
+
+    def test_runs_processes(self, tmp_grove, sample_workspace):
+        with (
+            patch("grove.workspace.git.repo_hook_commands") as mock_cmds,
+            patch("grove.workspace.subprocess.Popen") as mock_popen,
+            patch("grove.workspace._run_hook"),
+        ):
+            mock_cmds.return_value = ["echo hello"]
+            mock_proc = mock_popen.return_value
+            mock_proc.wait.return_value = 0
+            count = workspace.run_workspace(sample_workspace)
+        assert count == 1
+        mock_popen.assert_called_once()
+
+    def test_pre_run_before_processes(self, tmp_grove, sample_workspace):
+        call_order: list[str] = []
+
+        def mock_hook(repo_name, source_repo, worktree_path, hook):
+            call_order.append(hook)
+
+        with (
+            patch("grove.workspace.git.repo_hook_commands", return_value=["echo hi"]),
+            patch("grove.workspace._run_hook", side_effect=mock_hook),
+            patch("grove.workspace.subprocess.Popen") as mock_popen,
+        ):
+            mock_proc = mock_popen.return_value
+            mock_proc.wait.return_value = 0
+            workspace.run_workspace(sample_workspace)
+        assert call_order[0] == "pre_run"
+        assert call_order[-1] == "post_run"
+
+    def test_post_run_on_keyboard_interrupt(self, tmp_grove, sample_workspace):
+        hooks_called: list[str] = []
+
+        def mock_hook(repo_name, source_repo, worktree_path, hook):
+            hooks_called.append(hook)
+
+        with (
+            patch("grove.workspace.git.repo_hook_commands", return_value=["sleep 100"]),
+            patch("grove.workspace._run_hook", side_effect=mock_hook),
+            patch("grove.workspace.subprocess.Popen") as mock_popen,
+        ):
+            mock_proc = mock_popen.return_value
+            mock_proc.wait.side_effect = KeyboardInterrupt
+            mock_proc.terminate.return_value = None
+            workspace.run_workspace(sample_workspace)
+        assert "post_run" in hooks_called
+
+    def test_processes_terminated_on_interrupt(self, tmp_grove, sample_workspace):
+        with (
+            patch("grove.workspace.git.repo_hook_commands", return_value=["sleep 100"]),
+            patch("grove.workspace._run_hook"),
+            patch("grove.workspace.subprocess.Popen") as mock_popen,
+        ):
+            mock_proc = mock_popen.return_value
+            mock_proc.wait.side_effect = [KeyboardInterrupt, None]
+            mock_proc.terminate.return_value = None
+            workspace.run_workspace(sample_workspace)
+        mock_proc.terminate.assert_called_once()


### PR DESCRIPTION
## Summary

- **Lifecycle hooks**: `teardown`, `pre_sync`, `post_sync`, `pre_run`, `run`, `post_run` — follows npm-style `pre`/`post` convention. Generic hook points instead of special-purpose features.
- **New commands**: `add-repo`, `remove-repo`, `rename`, `doctor`, `status --all`, `run`
- **Shared primitives**: Extracted `resolve_base_branch`, `_provision_worktrees`, `_teardown_and_remove` to eliminate code duplication across create/add-repo/delete/remove-repo
- **Performance**: Cache `.grove.toml` reads with `@functools.cache` (eliminates 3-4x redundant reads per repo per command); replace subprocess-based repo discovery with `.git` stat check
- **Tests**: 189 (up from 129) — 60 new tests covering all new features

`gw run` is marked experimental in the README — output is interleaved in a single terminal for now, with Textual TUI as the planned future direction.

## Test plan

- [x] `just check` passes (lint + format + 189 tests)
- [ ] Manual smoke test: create workspace, add-repo, remove-repo, rename, doctor, status --all, run, delete
- [ ] Verify hook execution order: setup → teardown, pre_sync → rebase → post_sync, pre_run → run → post_run

🤖 Generated with [Claude Code](https://claude.com/claude-code)