### PR TITLE
Fix preset picker showing raw Rich markup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grove"
-version = "0.6.0"
+version = "0.6.1"
 description = "Git Worktree Workspace Orchestrator"
 readme = "README.md"
 authors = [

--- a/src/grove/cli.py
+++ b/src/grove/cli.py
@@ -103,6 +103,11 @@ def _sanitize_name(branch: str) -> str:
 
 def _pick_one(prompt_text: str, choices: list[str]) -> str:
     """Arrow-key single selection."""
+    return choices[_pick_one_idx(prompt_text, choices)]
+
+
+def _pick_one_idx(prompt_text: str, choices: list[str]) -> int:
+    """Arrow-key single selection, returns the chosen index."""
     from simple_term_menu import TerminalMenu
 
     menu = TerminalMenu(
@@ -115,7 +120,7 @@ def _pick_one(prompt_text: str, choices: list[str]) -> str:
     idx = menu.show()
     if idx is None:
         raise typer.Abort()
-    return choices[idx]
+    return idx
 
 
 def _pick_many(prompt_text: str, choices: list[str]) -> list[str]:
@@ -230,20 +235,19 @@ def create(
 
         # Offer presets when available
         if cfg.presets:
+            preset_names = list(cfg.presets.keys())
             preset_choices = [
-                f"{name}  [dim]({', '.join(repos_list)})[/]"
+                f"{name}  \033[2m({', '.join(repos_list)})\033[0m"
                 for name, repos_list in cfg.presets.items()
             ]
-            source = _pick_one(
+            source_idx = _pick_one_idx(
                 "Select repos from",
                 [*preset_choices, "Pick manually…"],
             )
-            if source == "Pick manually…":
+            if source_idx == len(preset_choices):
                 repo_names = _pick_many("Select repos", sorted(available.keys()))
             else:
-                # Extract preset name from the display string
-                chosen_preset = source.split("  [dim]")[0]
-                repo_names = cfg.presets[chosen_preset]
+                repo_names = cfg.presets[preset_names[source_idx]]
         else:
             repo_names = _pick_many("Select repos", sorted(available.keys()))
 

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "grove"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary
- Replace Rich `[dim]`/`[/]` markup with ANSI escape codes in preset picker — `simple-term-menu` doesn't understand Rich tags and renders them as literal text
- Use index-based selection (`_pick_one_idx`) instead of parsing preset names back from formatted display strings
- Bump version to 0.6.1

## Test plan
- [x] `just check` — 189 tests pass, lint clean
- [ ] Manual: `gw create` with presets configured — repo list should appear dimmed, not as `[dim](...)[/]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)