### PR TITLE
Add Textual TUI for gw run

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -31,9 +31,18 @@ test *args:
 test-v *args:
     uv run pytest tests/ -v {{ args }}
 
-# Install gw as editable for development
+# Install gw as editable for development (local venv only)
 dev:
     uv pip install -e .
+
+# Install gw globally, linked to local source (changes reflect immediately)
+dev-global:
+    uv tool install --editable . --force --reinstall
+
+# Switch back to Homebrew-installed gw
+undev:
+    -uv tool uninstall grove
+    @echo "Homebrew gw is now active (if installed)"
 
 # Install gw as a uv tool (globally)
 install:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ gw status my-feature                                   # git status across repos
 gw status --all                                        # overview of all workspaces
 gw sync my-feature                                     # rebase all repos onto base branch
 gw go my-feature                                       # cd into workspace
-gw run my-feature                                      # run dev processes (Ctrl+C to stop)
+gw run my-feature                                      # run dev processes (TUI with per-repo logs)
 gw add-repo my-feature -r svc-c                        # add a repo to existing workspace
 gw remove-repo my-feature -r svc-a                     # remove a repo from workspace
 gw rename my-feature --to new-name                     # rename a workspace
@@ -88,9 +88,21 @@ The hook system follows the npm-style `pre`/`post` convention: one primitive (`r
 | Before/after rebase | `pre_sync`, `post_sync` | Type-check before rebase, reinstall after |
 | Dev session | `pre_run`, `run`, `post_run` | Pull containers, start dev server, tear down containers |
 
-### `gw run` (experimental)
+### `gw run`
 
-`gw run` starts `run` hooks across all repos as foreground processes and tears them down on Ctrl+C. It works, but the UX is minimal — all output is interleaved in a single terminal. Future versions may introduce a proper TUI (e.g. via [Textual](https://github.com/Textualize/textual)) with per-repo log panes, health indicators, and restart controls. Consider this command under active development.
+`gw run` launches a [Textual](https://github.com/Textualize/textual) TUI that manages `run` hooks across all repos. Each repo gets its own log pane with a sidebar showing status indicators (green = running, yellow = starting, red = exited with error).
+
+**Key bindings:**
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` / `↑` / `↓` | Navigate repos |
+| `g` / `G` | Jump to first / last |
+| `1`–`9` | Quick-select repo by number |
+| `r` | Restart selected repo |
+| `q` | Quit (terminates all processes) |
+
+Pre-run hooks fire before the TUI launches, post-run hooks fire after it exits.
 
 ## Works great with AI coding tools
 
@@ -112,7 +124,7 @@ Grove copies your `CLAUDE.md` into new workspaces, so your agent gets project co
 - Add or remove repos from existing workspaces without recreating them
 - Rename workspaces (directory, state, and git linkage updated automatically)
 - Lifecycle hooks: `setup`, `teardown`, `pre_sync`, `post_sync` per repo
-- `gw run` to start dev processes across repos, with `pre_run`/`post_run` hooks
+- `gw run` launches a Textual TUI with per-repo log panes, status indicators, vim keybindings, and restart controls
 - `gw status --all` for a cross-workspace overview at a glance
 - `gw doctor` to diagnose and auto-fix stale state entries
 - Offers saved presets during interactive workspace creation

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@ Add end-to-end tests that exercise the main flows against real git repos (not mo
 - `gw init` → `gw create` → `gw status` → `gw sync` → `gw delete`
 - `gw create` → `gw add-repo` → `gw remove-repo`
 - `gw create` → `gw rename` → `gw doctor`
-- `gw create` → `gw run` (with actual processes)
+- `gw create` → `gw run` (with actual processes, verify TUI launches)
 - Lifecycle hooks fire in correct order with real `.grove.toml` files
 
 ## Recursive repo discovery
@@ -27,3 +27,9 @@ Every command should be scriptable without interactive prompts (e.g. for CI, AI 
 - `gw remove-repo` — workspace picker, repo picker, confirmation prompt
 - `gw rename` — workspace picker
 - `gw go` — workspace picker
+
+## `gw run` TUI enhancements
+
+- PTY allocation for subprocess output — some programs buffer stdout when not connected to a TTY (workaround: `stdbuf -oL` or tool-specific flags in `.grove.toml`)
+- Log scrollback / search within a repo's log pane
+- Aggregate view showing interleaved output from all repos

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "typer>=0.12",
     "rich>=13.0",
     "simple-term-menu>=1.6.6",
+    "textual>=1.0",
 ]
 
 [project.scripts]
@@ -25,6 +26,7 @@ dev = [
     "ruff>=0.11",
     "ty>=0.0.1a6",
     "pytest>=8.0",
+    "pytest-asyncio>=0.24",
 ]
 
 [tool.ruff]

--- a/src/grove/cli.py
+++ b/src/grove/cli.py
@@ -682,15 +682,28 @@ def run(
         autocompletion=complete_workspace_name,
     ),
 ) -> None:
-    """Run dev processes across workspace repos (Ctrl+C to stop)."""
+    """Run dev processes across workspace repos (TUI with sidebar)."""
     ws = _resolve_workspace(name)
 
-    console.print(f"[bold]Running:[/] {ws.name}")
-    console.print()
-
-    count = workspace.run_workspace(ws)
-    if count == 0:
+    runnable = workspace.get_runnable(ws)
+    if not runnable:
         info("No repos have a [bold]run[/] hook in .grove.toml")
+        return
+
+    # Pre-run hooks
+    workspace.run_pre_hooks(runnable)
+
+    # Build TUI entries: (repo_name, command, cwd)
+    entries = [(wt.repo_name, " && ".join(cmds), str(wt.worktree_path)) for wt, cmds in runnable]
+
+    # Launch TUI
+    from grove.tui import RunApp
+
+    app = RunApp(entries)
+    app.run()
+
+    # Post-run hooks
+    workspace.run_post_hooks(runnable)
 
 
 _BACK_TO_REPOS = "← back to repos dir"

--- a/src/grove/tui.py
+++ b/src/grove/tui.py
@@ -318,15 +318,13 @@ class RunApp(App):
             self._switch_to(event.item.repo_index)
 
     def _switch_to(self, idx: int) -> None:
-        if idx < 0 or idx >= len(self.procs):
+        if idx < 0 or idx >= len(self.procs) or idx == self._selected:
             return
-        # Hide old log, show new
-        for i in range(len(self.procs)):
-            log = self.query_one(f"#log-{i}", RichLog)
-            if i == idx:
-                log.add_class("active")
-            else:
-                log.remove_class("active")
+        # Only touch the two logs that change
+        old_log = self.query_one(f"#log-{self._selected}", RichLog)
+        new_log = self.query_one(f"#log-{idx}", RichLog)
+        old_log.remove_class("active")
+        new_log.add_class("active")
         self._selected = idx
         self._update_log_panel_title()
 

--- a/src/grove/tui.py
+++ b/src/grove/tui.py
@@ -1,0 +1,291 @@
+"""Textual TUI for running workspace processes with a sidebar + log pane."""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+from dataclasses import dataclass, field
+from enum import Enum, auto
+
+from textual import work
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal
+from textual.widgets import Footer, Label, ListItem, ListView, RichLog
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+class ProcStatus(Enum):
+    """Lifecycle status of a managed process."""
+
+    STARTING = auto()
+    RUNNING = auto()
+    EXITED = auto()
+
+
+@dataclass
+class ProcessState:
+    """Tracks a single repo's subprocess and metadata."""
+
+    repo_name: str
+    command: str
+    cwd: str
+    status: ProcStatus = ProcStatus.STARTING
+    process: subprocess.Popen | None = field(default=None, repr=False)
+    exit_code: int | None = None
+    _cancel: threading.Event = field(default_factory=threading.Event, repr=False)
+
+    @property
+    def status_icon(self) -> str:
+        match self.status:
+            case ProcStatus.STARTING:
+                return "[yellow]●[/]"
+            case ProcStatus.RUNNING:
+                return "[green]●[/]"
+            case ProcStatus.EXITED:
+                if self.exit_code == 0:
+                    return "[dim]●[/]"
+                return "[red]●[/]"
+
+
+# ---------------------------------------------------------------------------
+# Widgets
+# ---------------------------------------------------------------------------
+
+
+class RepoItem(ListItem):
+    """A sidebar entry for one repo."""
+
+    def __init__(self, index: int, repo_name: str) -> None:
+        super().__init__()
+        self.repo_index = index
+        self.repo_name = repo_name
+
+    def compose(self) -> ComposeResult:
+        yield Label(f"[yellow]●[/] {self.repo_name}", id=f"label-{self.repo_index}")
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+_SIDEBAR_WIDTH = 30
+
+
+class RunApp(App):
+    """TUI that manages multiple subprocess outputs in a sidebar + log layout."""
+
+    SHOW_COMMAND_PALETTE = False
+    theme = "gruvbox"
+
+    CSS = f"""
+    #sidebar {{
+        width: {_SIDEBAR_WIDTH};
+        dock: left;
+        border-right: solid $accent;
+    }}
+    RichLog {{
+        display: none;
+    }}
+    RichLog.active {{
+        display: block;
+    }}
+    """
+
+    BINDINGS = [
+        Binding("q", "quit_app", "Quit", show=True),
+        Binding("r", "restart", "Restart", show=True),
+        # Vim navigation
+        Binding("j", "nav_down", "j/↓", show=True),
+        Binding("k", "nav_up", "k/↑", show=True),
+        Binding("g", "nav_first", "gg first", show=False),
+        Binding("G", "nav_last", "G last", show=False),  # noqa: N815
+        # Number keys
+        Binding("1", "select_1", "1", show=False),
+        Binding("2", "select_2", "2", show=False),
+        Binding("3", "select_3", "3", show=False),
+        Binding("4", "select_4", "4", show=False),
+        Binding("5", "select_5", "5", show=False),
+        Binding("6", "select_6", "6", show=False),
+        Binding("7", "select_7", "7", show=False),
+        Binding("8", "select_8", "8", show=False),
+        Binding("9", "select_9", "9", show=False),
+    ]
+
+    def __init__(self, entries: list[tuple[str, str, str]]) -> None:
+        """*entries*: list of ``(repo_name, command, cwd)``."""
+        super().__init__()
+        self.procs: list[ProcessState] = [
+            ProcessState(repo_name=name, command=cmd, cwd=cwd) for name, cmd, cwd in entries
+        ]
+        self._selected: int = 0
+
+    # ── Layout ────────────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        with Horizontal():
+            yield ListView(
+                *[RepoItem(i, p.repo_name) for i, p in enumerate(self.procs)],
+                id="sidebar",
+            )
+            for i, _ps in enumerate(self.procs):
+                classes = "active" if i == 0 else ""
+                yield RichLog(id=f"log-{i}", classes=classes, wrap=True, markup=True)
+        yield Footer()
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────
+
+    def on_mount(self) -> None:
+        sidebar = self.query_one("#sidebar", ListView)
+        sidebar.index = 0
+        for i in range(len(self.procs)):
+            self._start_process(i)
+
+    # ── Process management ────────────────────────────────────────────────
+
+    def _start_process(self, idx: int) -> None:
+        ps = self.procs[idx]
+        ps.status = ProcStatus.STARTING
+        ps.exit_code = None
+        ps._cancel = threading.Event()
+        self._update_label(idx)
+        self._run_subprocess(idx)
+
+    @work(thread=True)
+    def _run_subprocess(self, idx: int) -> None:
+        ps = self.procs[idx]
+        log = self.query_one(f"#log-{idx}", RichLog)
+
+        try:
+            proc = subprocess.Popen(
+                ps.command,
+                cwd=ps.cwd,
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+        except Exception as exc:
+            self.call_from_thread(log.write, f"[red]Failed to start: {exc}[/]")
+            ps.status = ProcStatus.EXITED
+            ps.exit_code = -1
+            self.call_from_thread(self._update_label, idx)
+            return
+
+        ps.process = proc
+        ps.status = ProcStatus.RUNNING
+        self.call_from_thread(self._update_label, idx)
+
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            if ps._cancel.is_set():
+                break
+            self.call_from_thread(log.write, line.rstrip("\n"))
+
+        proc.wait()
+        ps.exit_code = proc.returncode
+        ps.status = ProcStatus.EXITED
+        self.call_from_thread(self._update_label, idx)
+
+    def _terminate_process(self, idx: int) -> None:
+        ps = self.procs[idx]
+        ps._cancel.set()
+        if ps.process and ps.process.poll() is None:
+            ps.process.terminate()
+            try:
+                ps.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                ps.process.kill()
+                ps.process.wait()
+
+    def _update_label(self, idx: int) -> None:
+        ps = self.procs[idx]
+        label = self.query_one(f"#label-{idx}", Label)
+        label.update(f"{ps.status_icon} {ps.repo_name}")
+
+    # ── Selection ─────────────────────────────────────────────────────────
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        if isinstance(event.item, RepoItem):
+            self._switch_to(event.item.repo_index)
+
+    def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
+        if event.item and isinstance(event.item, RepoItem):
+            self._switch_to(event.item.repo_index)
+
+    def _switch_to(self, idx: int) -> None:
+        if idx < 0 or idx >= len(self.procs):
+            return
+        # Hide old log, show new
+        for i in range(len(self.procs)):
+            log = self.query_one(f"#log-{i}", RichLog)
+            if i == idx:
+                log.add_class("active")
+            else:
+                log.remove_class("active")
+        self._selected = idx
+
+    # ── Key actions ───────────────────────────────────────────────────────
+
+    def action_quit_app(self) -> None:
+        for i in range(len(self.procs)):
+            self._terminate_process(i)
+        self.exit()
+
+    def action_nav_down(self) -> None:
+        sidebar = self.query_one("#sidebar", ListView)
+        sidebar.index = min(self._selected + 1, len(self.procs) - 1)
+
+    def action_nav_up(self) -> None:
+        sidebar = self.query_one("#sidebar", ListView)
+        sidebar.index = max(self._selected - 1, 0)
+
+    def action_nav_first(self) -> None:
+        self.query_one("#sidebar", ListView).index = 0
+
+    def action_nav_last(self) -> None:
+        self.query_one("#sidebar", ListView).index = len(self.procs) - 1
+
+    def action_restart(self) -> None:
+        idx = self._selected
+        self._terminate_process(idx)
+        log = self.query_one(f"#log-{idx}", RichLog)
+        log.clear()
+        log.write("[dim]Restarting…[/]")
+        self._start_process(idx)
+
+    def _select_by_number(self, n: int) -> None:
+        idx = n - 1
+        if 0 <= idx < len(self.procs):
+            self.query_one("#sidebar", ListView).index = idx
+
+    def action_select_1(self) -> None:
+        self._select_by_number(1)
+
+    def action_select_2(self) -> None:
+        self._select_by_number(2)
+
+    def action_select_3(self) -> None:
+        self._select_by_number(3)
+
+    def action_select_4(self) -> None:
+        self._select_by_number(4)
+
+    def action_select_5(self) -> None:
+        self._select_by_number(5)
+
+    def action_select_6(self) -> None:
+        self._select_by_number(6)
+
+    def action_select_7(self) -> None:
+        self._select_by_number(7)
+
+    def action_select_8(self) -> None:
+        self._select_by_number(8)
+
+    def action_select_9(self) -> None:
+        self._select_by_number(9)

--- a/src/grove/tui.py
+++ b/src/grove/tui.py
@@ -10,8 +10,9 @@ from enum import Enum, auto
 from textual import work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal
-from textual.widgets import Footer, Label, ListItem, ListView, RichLog
+from textual.containers import Horizontal, Vertical
+from textual.css.query import NoMatches
+from textual.widgets import Footer, Label, ListItem, ListView, RichLog, Static
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -56,8 +57,37 @@ class ProcessState:
 # ---------------------------------------------------------------------------
 
 
+class AppHeader(Horizontal):
+    """Top bar showing app name and selected repo info."""
+
+    DEFAULT_CSS = """
+    AppHeader {
+        dock: top;
+        height: 1;
+        background: $accent;
+        color: $text;
+        padding: 0 1;
+    }
+    AppHeader #header-title {
+        width: 1fr;
+        color: $text;
+        text-style: bold;
+    }
+    AppHeader #header-info {
+        color: $text 70%;
+    }
+    """
+
+
 class RepoItem(ListItem):
     """A sidebar entry for one repo."""
+
+    DEFAULT_CSS = """
+    RepoItem {
+        padding: 0 1;
+        height: 1;
+    }
+    """
 
     def __init__(self, index: int, repo_name: str) -> None:
         super().__init__()
@@ -72,8 +102,6 @@ class RepoItem(ListItem):
 # App
 # ---------------------------------------------------------------------------
 
-_SIDEBAR_WIDTH = 30
-
 
 class RunApp(App):
     """TUI that manages multiple subprocess outputs in a sidebar + log layout."""
@@ -81,18 +109,42 @@ class RunApp(App):
     SHOW_COMMAND_PALETTE = False
     theme = "gruvbox"
 
-    CSS = f"""
-    #sidebar {{
-        width: {_SIDEBAR_WIDTH};
+    CSS = """
+    /* ── Sidebar ─────────────────────────────────── */
+    #sidebar-panel {
+        width: 32;
         dock: left;
-        border-right: solid $accent;
-    }}
-    RichLog {{
+        border-right: round $accent 40%;
+        border-title-color: $text-accent 50%;
+        border-title-style: bold;
+        padding: 0;
+    }
+    #sidebar-panel:focus-within {
+        border-right: round $accent;
+        border-title-color: $text-accent;
+    }
+    #sidebar {
+        width: 100%;
+    }
+
+    /* ── Log pane ────────────────────────────────── */
+    #log-panel {
+        border: round $accent 40%;
+        border-title-color: $text-accent 50%;
+        border-title-style: bold;
+    }
+    #log-panel:focus-within {
+        border: round $accent;
+        border-title-color: $text-accent;
+    }
+    RichLog {
         display: none;
-    }}
-    RichLog.active {{
+        background: $surface;
+        padding: 0 1;
+    }
+    RichLog.active {
         display: block;
-    }}
+    }
     """
 
     BINDINGS = [
@@ -126,14 +178,20 @@ class RunApp(App):
     # ── Layout ────────────────────────────────────────────────────────────
 
     def compose(self) -> ComposeResult:
+        yield AppHeader(
+            Static("[b]grove[/b] run", id="header-title"),
+            Label("", id="header-info"),
+        )
         with Horizontal():
-            yield ListView(
-                *[RepoItem(i, p.repo_name) for i, p in enumerate(self.procs)],
-                id="sidebar",
-            )
-            for i, _ps in enumerate(self.procs):
-                classes = "active" if i == 0 else ""
-                yield RichLog(id=f"log-{i}", classes=classes, wrap=True, markup=True)
+            with Vertical(id="sidebar-panel"):
+                yield ListView(
+                    *[RepoItem(i, p.repo_name) for i, p in enumerate(self.procs)],
+                    id="sidebar",
+                )
+            with Vertical(id="log-panel"):
+                for i, _ps in enumerate(self.procs):
+                    classes = "active" if i == 0 else ""
+                    yield RichLog(id=f"log-{i}", classes=classes, wrap=True, markup=True)
         yield Footer()
 
     # ── Lifecycle ─────────────────────────────────────────────────────────
@@ -141,6 +199,7 @@ class RunApp(App):
     def on_mount(self) -> None:
         sidebar = self.query_one("#sidebar", ListView)
         sidebar.index = 0
+        self._update_panel_titles()
         for i in range(len(self.procs)):
             self._start_process(i)
 
@@ -174,11 +233,13 @@ class RunApp(App):
             ps.status = ProcStatus.EXITED
             ps.exit_code = -1
             self.call_from_thread(self._update_label, idx)
+            self.call_from_thread(self._update_header_info)
             return
 
         ps.process = proc
         ps.status = ProcStatus.RUNNING
         self.call_from_thread(self._update_label, idx)
+        self.call_from_thread(self._update_header_info)
 
         assert proc.stdout is not None
         for line in proc.stdout:
@@ -190,6 +251,7 @@ class RunApp(App):
         ps.exit_code = proc.returncode
         ps.status = ProcStatus.EXITED
         self.call_from_thread(self._update_label, idx)
+        self.call_from_thread(self._update_header_info)
 
     def _terminate_process(self, idx: int) -> None:
         ps = self.procs[idx]
@@ -203,9 +265,47 @@ class RunApp(App):
                 ps.process.wait()
 
     def _update_label(self, idx: int) -> None:
-        ps = self.procs[idx]
-        label = self.query_one(f"#label-{idx}", Label)
-        label.update(f"{ps.status_icon} {ps.repo_name}")
+        try:
+            ps = self.procs[idx]
+            label = self.query_one(f"#label-{idx}", Label)
+            label.update(f"{ps.status_icon} {ps.repo_name}")
+        except NoMatches:
+            pass  # widget removed during shutdown
+
+    def _update_header_info(self) -> None:
+        try:
+            running = sum(1 for p in self.procs if p.status == ProcStatus.RUNNING)
+            exited = sum(1 for p in self.procs if p.status == ProcStatus.EXITED)
+            parts = []
+            if running:
+                parts.append(f"[green]{running} running[/]")
+            if exited:
+                failed = sum(
+                    1 for p in self.procs if p.status == ProcStatus.EXITED and p.exit_code != 0
+                )
+                if failed:
+                    parts.append(f"[red]{failed} failed[/]")
+                ok = exited - failed
+                if ok:
+                    parts.append(f"[dim]{ok} exited[/]")
+            info = self.query_one("#header-info", Label)
+            info.update("  ".join(parts))
+        except NoMatches:
+            pass  # widget removed during shutdown
+
+    def _update_panel_titles(self) -> None:
+        n = len(self.procs)
+        sidebar_panel = self.query_one("#sidebar-panel")
+        sidebar_panel.border_title = f"Repos ({n})"
+        self._update_log_panel_title()
+
+    def _update_log_panel_title(self) -> None:
+        try:
+            ps = self.procs[self._selected]
+            log_panel = self.query_one("#log-panel")
+            log_panel.border_title = f"{ps.repo_name} — {ps.command}"
+        except NoMatches:
+            pass  # widget removed during shutdown
 
     # ── Selection ─────────────────────────────────────────────────────────
 
@@ -228,6 +328,7 @@ class RunApp(App):
             else:
                 log.remove_class("active")
         self._selected = idx
+        self._update_log_panel_title()
 
     # ── Key actions ───────────────────────────────────────────────────────
 

--- a/src/grove/workspace.py
+++ b/src/grove/workspace.py
@@ -325,6 +325,31 @@ def sync_workspace(workspace: Workspace) -> list[dict[str, str]]:
     return results
 
 
+def get_runnable(ws: Workspace) -> list[tuple[RepoWorktree, list[str]]]:
+    """Return repos that have a ``run`` hook, with their command lists."""
+    return [
+        (wt, cmds) for wt in ws.repos if (cmds := git.repo_hook_commands(wt.source_repo, "run"))
+    ]
+
+
+def run_pre_hooks(runnable: list[tuple[RepoWorktree, list[str]]]) -> None:
+    """Execute ``pre_run`` hooks in parallel (best-effort)."""
+
+    def _pre_run(_name: str, repo_wt: RepoWorktree) -> None:
+        _run_hook(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path, "pre_run")
+
+    _parallel(_pre_run, [(wt.repo_name, wt) for wt, _ in runnable], "Pre-run")
+
+
+def run_post_hooks(runnable: list[tuple[RepoWorktree, list[str]]]) -> None:
+    """Execute ``post_run`` hooks in parallel (best-effort)."""
+
+    def _post_run(_name: str, repo_wt: RepoWorktree) -> None:
+        _run_hook(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path, "post_run")
+
+    _parallel(_post_run, [(wt.repo_name, wt) for wt, _ in runnable], "Post-run")
+
+
 def run_workspace(ws: Workspace) -> int:
     """Run ``run`` hooks across all repos as foreground processes.
 
@@ -332,18 +357,11 @@ def run_workspace(ws: Workspace) -> int:
     On exit (Ctrl+C or natural), runs ``post_run`` hooks for cleanup.
     Returns the number of repos that had a ``run`` hook.
     """
-    # Filter to repos that have a run hook, storing commands to avoid re-reading
-    runnable: list[tuple[RepoWorktree, list[str]]] = [
-        (wt, cmds) for wt in ws.repos if (cmds := git.repo_hook_commands(wt.source_repo, "run"))
-    ]
+    runnable = get_runnable(ws)
     if not runnable:
         return 0
 
-    # Pre-run hooks (parallel, best-effort)
-    def _pre_run(_name: str, repo_wt: RepoWorktree) -> None:
-        _run_hook(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path, "pre_run")
-
-    _parallel(_pre_run, [(wt.repo_name, wt) for wt, _ in runnable], "Pre-run")
+    run_pre_hooks(runnable)
 
     # Start all run processes
     processes: list[tuple[str, subprocess.Popen]] = []
@@ -371,11 +389,7 @@ def run_workspace(ws: Workspace) -> int:
             with contextlib.suppress(BaseException):
                 proc.wait(timeout=5)
 
-    # Post-run hooks (parallel, best-effort) — always runs
-    def _post_run(_name: str, repo_wt: RepoWorktree) -> None:
-        _run_hook(repo_wt.repo_name, repo_wt.source_repo, repo_wt.worktree_path, "post_run")
-
-    _parallel(_post_run, [(wt.repo_name, wt) for wt, _ in runnable], "Post-run")
+    run_post_hooks(runnable)
 
     return len(runnable)
 

--- a/src/grove/workspace.py
+++ b/src/grove/workspace.py
@@ -179,6 +179,7 @@ def _run_hook(repo_name: str, source_repo: Path, worktree_path: Path, hook: str)
                 cwd=worktree_path,
                 shell=True,
                 check=True,
+                stdin=subprocess.DEVNULL,
             )
         except subprocess.CalledProcessError as e:
             warning(f"[{repo_name}] {hook} command failed (exit {e.returncode}): {cmd}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -761,16 +761,22 @@ class TestRun:
         from grove import state
 
         state.add_workspace(sample_workspace)
-        with patch("grove.cli.workspace.run_workspace", return_value=2):
+        wt = sample_workspace.repos[0]
+        runnable = [(wt, ["npm start"])]
+        with (
+            patch("grove.cli.workspace.get_runnable", return_value=runnable),
+            patch("grove.cli.workspace.run_pre_hooks"),
+            patch("grove.cli.workspace.run_post_hooks"),
+            patch("grove.tui.RunApp.run"),
+        ):
             result = runner.invoke(app, ["run", "test-ws"])
         assert result.exit_code == 0
-        assert "Running" in result.output
 
     def test_no_hooks(self, tmp_grove, sample_workspace):
         from grove import state
 
         state.add_workspace(sample_workspace)
-        with patch("grove.cli.workspace.run_workspace", return_value=0):
+        with patch("grove.cli.workspace.get_runnable", return_value=[]):
             result = runner.invoke(app, ["run", "test-ws"])
         assert result.exit_code == 0
         assert "No repos" in result.output

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,107 @@
+"""Tests for grove.tui — ProcessState unit tests + Textual async pilot tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from grove.tui import ProcessState, ProcStatus, RunApp
+
+# ---------------------------------------------------------------------------
+# ProcessState unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestProcessState:
+    def test_defaults(self):
+        ps = ProcessState(repo_name="api", command="npm start", cwd="/tmp")
+        assert ps.status == ProcStatus.STARTING
+        assert ps.process is None
+        assert ps.exit_code is None
+
+    def test_status_icon_starting(self):
+        ps = ProcessState(repo_name="api", command="cmd", cwd="/tmp")
+        assert "yellow" in ps.status_icon
+
+    def test_status_icon_running(self):
+        ps = ProcessState(repo_name="api", command="cmd", cwd="/tmp", status=ProcStatus.RUNNING)
+        assert "green" in ps.status_icon
+
+    def test_status_icon_exited_success(self):
+        ps = ProcessState(
+            repo_name="api", command="cmd", cwd="/tmp", status=ProcStatus.EXITED, exit_code=0
+        )
+        assert "dim" in ps.status_icon
+
+    def test_status_icon_exited_failure(self):
+        ps = ProcessState(
+            repo_name="api", command="cmd", cwd="/tmp", status=ProcStatus.EXITED, exit_code=1
+        )
+        assert "red" in ps.status_icon
+
+
+class TestProcStatus:
+    def test_values(self):
+        assert ProcStatus.STARTING.name == "STARTING"
+        assert ProcStatus.RUNNING.name == "RUNNING"
+        assert ProcStatus.EXITED.name == "EXITED"
+
+
+# ---------------------------------------------------------------------------
+# Textual async pilot tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sidebar_renders_repos():
+    """Sidebar should show all repo names."""
+    entries = [
+        ("api", "echo api", "/tmp"),
+        ("web", "echo web", "/tmp"),
+    ]
+    app = RunApp(entries)
+    async with app.run_test(size=(120, 30)):
+        # Check sidebar items exist
+        sidebar = app.query_one("#sidebar")
+        items = sidebar.query("RepoItem")
+        assert len(items) == 2
+
+
+@pytest.mark.asyncio
+async def test_first_log_visible_on_mount():
+    """The first repo's log should be visible by default."""
+    entries = [
+        ("api", "echo hello", "/tmp"),
+        ("web", "echo world", "/tmp"),
+    ]
+    app = RunApp(entries)
+    async with app.run_test(size=(120, 30)):
+        log0 = app.query_one("#log-0")
+        log1 = app.query_one("#log-1")
+        assert log0.has_class("active")
+        assert not log1.has_class("active")
+
+
+@pytest.mark.asyncio
+async def test_number_key_switches_log():
+    """Pressing '2' should switch to the second repo's log."""
+    entries = [
+        ("api", "echo api", "/tmp"),
+        ("web", "echo web", "/tmp"),
+    ]
+    app = RunApp(entries)
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.press("2")
+        log0 = app.query_one("#log-0")
+        log1 = app.query_one("#log-1")
+        assert not log0.has_class("active")
+        assert log1.has_class("active")
+
+
+@pytest.mark.asyncio
+async def test_quit_key_exits():
+    """Pressing 'q' should exit the app."""
+    entries = [("api", "sleep 10", "/tmp")]
+    app = RunApp(entries)
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.press("q")
+        # App should have exited — if we reach here without hanging, it worked

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1299,3 +1299,56 @@ class TestRunWorkspace:
             mock_proc.terminate.return_value = None
             workspace.run_workspace(sample_workspace)
         mock_proc.terminate.assert_called_once()
+
+
+class TestGetRunnable:
+    def test_returns_repos_with_run_hook(self, tmp_grove, sample_workspace):
+        with patch(
+            "grove.workspace.git.repo_hook_commands",
+            side_effect=lambda _src, hook: ["npm start"] if hook == "run" else [],
+        ):
+            result = workspace.get_runnable(sample_workspace)
+        assert len(result) == 1
+        assert result[0][0].repo_name == "svc-auth"
+        assert result[0][1] == ["npm start"]
+
+    def test_empty_when_no_run_hook(self, tmp_grove, sample_workspace):
+        with patch("grove.workspace.git.repo_hook_commands", return_value=[]):
+            result = workspace.get_runnable(sample_workspace)
+        assert result == []
+
+    def test_multiple_commands(self, tmp_grove, sample_workspace):
+        with patch(
+            "grove.workspace.git.repo_hook_commands",
+            side_effect=lambda _src, hook: ["npm install", "npm start"] if hook == "run" else [],
+        ):
+            result = workspace.get_runnable(sample_workspace)
+        assert len(result) == 1
+        assert result[0][1] == ["npm install", "npm start"]
+
+
+class TestRunPreHooks:
+    def test_calls_pre_run_hook(self, tmp_grove, sample_workspace):
+        wt = sample_workspace.repos[0]
+        runnable = [(wt, ["npm start"])]
+        with patch("grove.workspace._run_hook") as mock_hook:
+            workspace.run_pre_hooks(runnable)
+        mock_hook.assert_called_once_with(wt.repo_name, wt.source_repo, wt.worktree_path, "pre_run")
+
+    def test_noop_when_empty(self):
+        # Should not raise
+        workspace.run_pre_hooks([])
+
+
+class TestRunPostHooks:
+    def test_calls_post_run_hook(self, tmp_grove, sample_workspace):
+        wt = sample_workspace.repos[0]
+        runnable = [(wt, ["npm start"])]
+        with patch("grove.workspace._run_hook") as mock_hook:
+            workspace.run_post_hooks(runnable)
+        mock_hook.assert_called_once_with(
+            wt.repo_name, wt.source_repo, wt.worktree_path, "post_run"
+        )
+
+    def test_noop_when_empty(self):
+        workspace.run_post_hooks([])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -148,6 +148,7 @@ class TestSetupHook:
                 cwd=ws.path / "svc-api",
                 shell=True,
                 check=True,
+                stdin=subprocess.DEVNULL,
             )
 
     def test_runs_multiple_setup_commands(self, tmp_grove):

--- a/uv.lock
+++ b/uv.lock
@@ -39,12 +39,14 @@ source = { editable = "." }
 dependencies = [
     { name = "rich" },
     { name = "simple-term-menu" },
+    { name = "textual" },
     { name = "typer" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -53,12 +55,14 @@ dev = [
 requires-dist = [
     { name = "rich", specifier = ">=13.0" },
     { name = "simple-term-menu", specifier = ">=1.6.6" },
+    { name = "textual", specifier = ">=1.0" },
     { name = "typer", specifier = ">=0.12" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = ">=0.11" },
     { name = "ty", specifier = ">=0.0.1a6" },
 ]
@@ -73,6 +77,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -82,6 +98,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
 ]
 
 [[package]]
@@ -100,6 +133,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/04/fea538adf7dbbd6d186f551d595961e564a3b6715bdf276b477460858672/platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291", size = 28394, upload-time = "2026-02-16T03:56:10.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/31/05e764397056194206169869b50cf2fee4dbbbc71b344705b9c0d878d4d8/platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd", size = 21168, upload-time = "2026-02-16T03:56:08.891Z" },
 ]
 
 [[package]]
@@ -134,6 +176,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -193,6 +248,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/08/c6bcb1e3c4c9528ec9049f4ac685afdafc72866664270f0deb416ccbba2a/textual-8.0.2.tar.gz", hash = "sha256:7b342f3ee9a5f2f1bd42d7b598cae00ff1275da68536769510db4b7fe8cabf5d", size = 6099270, upload-time = "2026-03-03T20:23:46.858Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/bc/0cd17f96f00b6e8bfbca64c574088c85f3c614912b3030f313752e30a099/textual-8.0.2-py3-none-any.whl", hash = "sha256:4ceadbe0e8a30eb80f9995000f4d031f711420a31b02da38f3482957b7c50ce4", size = 719174, upload-time = "2026-03-03T20:23:50.46Z" },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.18"
 source = { registry = "https://pypi.org/simple" }
@@ -229,4 +301,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]


### PR DESCRIPTION
## Summary
- Replace interleaved terminal output in `gw run` with a Textual TUI: sidebar listing repos with status indicators (green/yellow/red), main pane showing the selected repo's log output
- Vim keybindings (`hjkl`, `gG`), number keys (`1-9`), restart (`r`), quit (`q`), gruvbox theme
- Extract `get_runnable`, `run_pre_hooks`, `run_post_hooks` helpers from `run_workspace` for clean three-phase orchestration: pre-hooks → TUI → post-hooks
- Add `just dev-global` / `just undev` for editable global installs during development

## Test plan
- [x] `just check` — lint + format + 206 tests pass
- [ ] `uv run gw run` on a workspace with 2+ repos that have `run` hooks — confirm TUI launches, logs stream, sidebar shows status
- [ ] Press `j`/`k`/arrows — confirm repo switching
- [ ] Press `r` — confirm selected repo restarts, log clears
- [ ] Press `q` — confirm clean exit, post_run hooks fire
- [ ] Press number keys — confirm quick-select

🤖 Generated with [Claude Code](https://claude.com/claude-code)