### PR TITLE
Harden state management, validation, and error handling

### DIFF
--- a/src/grove/cli.py
+++ b/src/grove/cli.py
@@ -98,8 +98,12 @@ def _sanitize_name(branch: str) -> str:
     """Derive a workspace name from a branch name.
 
     ``feat/login`` → ``feat-login``, strips leading/trailing dashes.
+    Raises ``typer.BadParameter`` if the result is empty.
     """
-    return re.sub(r"[/\s]+", "-", branch).strip("-")
+    name = re.sub(r"[/\s]+", "-", branch).strip("-")
+    if not name:
+        raise typer.BadParameter(f"Branch name {branch!r} produces an empty workspace name")
+    return name
 
 
 def _pick_one(prompt_text: str, choices: list[str]) -> str:

--- a/src/grove/config.py
+++ b/src/grove/config.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import contextlib
+import os
+import re
+import tempfile
 import tomllib
 from pathlib import Path
 
@@ -10,6 +14,17 @@ from grove.models import Config
 GROVE_DIR = Path.home() / ".grove"
 CONFIG_PATH = GROVE_DIR / "config.toml"
 DEFAULT_WORKSPACE_DIR = GROVE_DIR / "workspaces"
+
+# Preset names must be simple identifiers safe for TOML section headers.
+_VALID_PRESET_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def validate_preset_name(name: str) -> None:
+    """Raise ``ValueError`` if *name* is not a valid preset identifier."""
+    if not _VALID_PRESET_NAME.match(name):
+        raise ValueError(
+            f"Invalid preset name {name!r} — only letters, digits, hyphens, and underscores allowed"
+        )
 
 
 def ensure_grove_dir() -> None:
@@ -27,8 +42,11 @@ def load_config() -> Config | None:
 
 
 def save_config(config: Config) -> None:
-    """Save config to TOML."""
+    """Save config to TOML atomically."""
     ensure_grove_dir()
+    # Validate preset names before writing
+    for preset_name in config.presets:
+        validate_preset_name(preset_name)
     # Hand-write TOML to avoid extra dependency
     lines = [
         f'repos_dir = "{config.repos_dir}"',
@@ -40,7 +58,20 @@ def save_config(config: Config) -> None:
         lines.append(f"[presets.{preset_name}]")
         lines.append(f"repos = [{quoted}]")
     lines.append("")
-    CONFIG_PATH.write_text("\n".join(lines))
+    _atomic_write(CONFIG_PATH, "\n".join(lines))
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write *content* to *path* atomically via temp file + rename."""
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
 
 
 def require_config() -> Config:

--- a/src/grove/state.py
+++ b/src/grove/state.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
+import os
+import tempfile
 from pathlib import Path
 
 from grove.config import GROVE_DIR
@@ -15,13 +18,32 @@ def _load_raw() -> list[dict]:
     """Load raw state data."""
     if not STATE_PATH.exists():
         return []
-    return json.loads(STATE_PATH.read_text())
+    try:
+        return json.loads(STATE_PATH.read_text())
+    except json.JSONDecodeError as e:
+        raise SystemExit(
+            f"State file is corrupt ({STATE_PATH}): {e}\n"
+            "Delete the file to reset, or run: gw doctor --fix"
+        ) from e
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write *content* to *path* atomically via temp file + rename."""
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
 
 
 def _save_raw(data: list[dict]) -> None:
-    """Save raw state data."""
+    """Save raw state data atomically (write to temp, then replace)."""
     GROVE_DIR.mkdir(parents=True, exist_ok=True)
-    STATE_PATH.write_text(json.dumps(data, indent=2) + "\n")
+    _atomic_write(STATE_PATH, json.dumps(data, indent=2) + "\n")
 
 
 def load_workspaces() -> list[Workspace]:

--- a/src/grove/workspace.py
+++ b/src/grove/workspace.py
@@ -217,6 +217,7 @@ def _teardown_and_remove(
     """Run teardown hook then remove worktree. The shared removal primitive.
 
     *force_cleanup*: if True, fall back to ``shutil.rmtree`` when git fails.
+    When force cleanup succeeds, the error is swallowed (directory is gone).
     """
     if repo_wt.worktree_path.exists():
         with contextlib.suppress(Exception):
@@ -226,11 +227,18 @@ def _teardown_and_remove(
     except GitError:
         if force_cleanup and repo_wt.worktree_path.exists():
             shutil.rmtree(repo_wt.worktree_path, ignore_errors=True)
+            if not repo_wt.worktree_path.exists():
+                return  # directory cleaned up — don't propagate the error
         raise  # re-raise so _parallel records the error
 
 
 def delete_workspace(name: str) -> bool:
-    """Delete a workspace: remove worktrees, folder, and state entry."""
+    """Delete a workspace: remove worktrees, folder, and state entry.
+
+    Only removes the workspace from state when all worktree removals succeed
+    (or the workspace directory is gone). On partial failure the state entry is
+    kept so ``gw doctor`` can help clean up.
+    """
     workspace = state.get_workspace(name)
     if workspace is None:
         error(f"Workspace [bold]{name}[/] not found")
@@ -240,14 +248,23 @@ def delete_workspace(name: str) -> bool:
         _teardown_and_remove(_name, repo_wt, force_cleanup=True)
 
     items = [(wt.repo_name, wt) for wt in workspace.repos]
+    failures = 0
     for repo_name, _result, exc in _parallel(_remove_one, items, "Removing"):
         if exc is not None:
             warning(f"Could not remove worktree for {repo_name}: {exc}")
+            failures += 1
         else:
             success(f"Removed worktree: {repo_name}")
 
     if workspace.path.exists():
         shutil.rmtree(workspace.path, ignore_errors=True)
+
+    if failures and workspace.path.exists():
+        warning(
+            f"{failures} worktree(s) could not be removed. "
+            "Run [bold]gw doctor --fix[/] to clean up."
+        )
+        return False
 
     state.remove_workspace(name)
     return True
@@ -597,7 +614,11 @@ def remove_repo_from_workspace(
 
 
 def rename_workspace(old_name: str, new_name: str, config: Config) -> bool:
-    """Rename a workspace: directory, internal paths, state entry, and git linkage."""
+    """Rename a workspace: directory, internal paths, state entry, and git linkage.
+
+    Updates state first, then renames the directory.  If the directory rename
+    fails the state change is rolled back.
+    """
     ws = state.get_workspace(old_name)
     if ws is None:
         error(f"Workspace [bold]{old_name}[/] not found")
@@ -614,20 +635,30 @@ def rename_workspace(old_name: str, new_name: str, config: Config) -> bool:
         error(f"Directory already exists: {new_path}")
         return False
 
-    # Rename directory
-    try:
-        old_path.rename(new_path)
-    except OSError as e:
-        error(f"Failed to rename directory: {e}")
-        return False
+    # Save original values for rollback
+    orig_name = ws.name
+    orig_path = ws.path
+    orig_wt_paths = [(r, r.worktree_path) for r in ws.repos]
 
-    # Rebuild paths and update state in one write
+    # Update state first (easier to rollback than a directory rename)
     ws.name = new_name
     ws.path = new_path
     for repo_wt in ws.repos:
         repo_wt.worktree_path = new_path / repo_wt.repo_name
-
     state.update_workspace(ws, match_name=old_name)
+
+    # Rename directory
+    try:
+        old_path.rename(new_path)
+    except OSError as e:
+        # Rollback state to original values
+        ws.name = orig_name
+        ws.path = orig_path
+        for repo_wt, orig_wt_path in orig_wt_paths:
+            repo_wt.worktree_path = orig_wt_path
+        state.update_workspace(ws, match_name=new_name)
+        error(f"Failed to rename directory: {e}")
+        return False
 
     # Repair git worktree linkage (best-effort per repo)
     for repo_wt in ws.repos:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from grove.cli import _format_drift, _format_pr, _sanitize_name, app
@@ -43,6 +44,18 @@ class TestSanitizeName:
 
     def test_leading_slash(self):
         assert _sanitize_name("/feat") == "feat"
+
+    def test_all_slashes_raises(self):
+        with pytest.raises(typer.BadParameter, match="empty"):
+            _sanitize_name("/")
+
+    def test_all_spaces_raises(self):
+        with pytest.raises(typer.BadParameter, match="empty"):
+            _sanitize_name("  ")
+
+    def test_slash_space_raises(self):
+        with pytest.raises(typer.BadParameter, match="empty"):
+            _sanitize_name("/ /")
 
 
 class TestFormatDrift:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,6 +57,33 @@ class TestSaveLoad:
         assert config.load_config() is None
 
 
+class TestPresetNameValidation:
+    def test_valid_names(self):
+        for name in ("backend", "front-end", "my_preset", "v2", "A-Z_0-9"):
+            config.validate_preset_name(name)  # should not raise
+
+    def test_dots_rejected(self):
+        with pytest.raises(ValueError, match="Invalid preset name"):
+            config.validate_preset_name("backend.v2")
+
+    def test_spaces_rejected(self):
+        with pytest.raises(ValueError, match="Invalid preset name"):
+            config.validate_preset_name("my preset")
+
+    def test_brackets_rejected(self):
+        with pytest.raises(ValueError, match="Invalid preset name"):
+            config.validate_preset_name("bad]name")
+
+    def test_save_rejects_bad_preset_name(self, tmp_grove):
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+            presets={"backend.v2": ["svc-auth"]},
+        )
+        with pytest.raises(ValueError, match="Invalid preset name"):
+            config.save_config(cfg)
+
+
 class TestRequireConfig:
     def test_raises_when_not_initialized(self, tmp_grove):
         tmp_grove["config_path"].unlink()

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -80,6 +80,25 @@ class TestWorktreeList:
         assert result[1] == {"path": "/ws/feat", "branch": "feat/x"}
 
 
+class TestWorktreeListDetachedHead:
+    def test_detached_head_has_no_branch_key(self, mock_run):
+        mock_run.return_value = MagicMock(
+            stdout=(
+                "worktree /repo\nbranch refs/heads/main\n\n"
+                "worktree /ws/detached\nHEAD abc1234\ndetached\n"
+            )
+        )
+        result = git.worktree_list(Path("/repo"))
+        assert len(result) == 2
+        assert result[0] == {"path": "/repo", "branch": "main"}
+        assert result[1] == {"path": "/ws/detached"}
+        assert "branch" not in result[1]
+
+    def test_detached_head_not_matched_by_has_branch(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="worktree /ws/detached\nHEAD abc1234\ndetached\n")
+        assert git.worktree_has_branch(Path("/repo"), "main") is False
+
+
 class TestWorktreeHasBranch:
     def test_found(self, mock_run):
         mock_run.return_value = MagicMock(stdout="worktree /repo\nbranch refs/heads/main\n")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from grove import state
 from grove.models import Workspace
 
@@ -74,3 +76,15 @@ class TestStateOperations:
         raw = json.loads(tmp_grove["state_path"].read_text())
         assert len(raw) == 1
         assert raw[0]["name"] == "test-ws"
+
+    def test_corrupt_json_gives_helpful_error(self, tmp_grove):
+        tmp_grove["state_path"].write_text("{not valid json")
+        with pytest.raises(SystemExit, match="corrupt"):
+            state.load_workspaces()
+
+    def test_atomic_write_produces_valid_json(self, tmp_grove, sample_workspace):
+        state.add_workspace(sample_workspace)
+        # Verify the file is valid JSON (not truncated)
+        raw = json.loads(tmp_grove["state_path"].read_text())
+        assert isinstance(raw, list)
+        assert len(raw) == 1

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -205,6 +205,25 @@ class TestDeleteWorkspace:
         result = workspace.delete_workspace("nope")
         assert result is False
 
+    def test_partial_failure_keeps_state(self, tmp_grove, sample_workspace):
+        """When worktree removal fails and directory persists, state is kept."""
+        state.add_workspace(sample_workspace)
+        sample_workspace.path.mkdir(exist_ok=True)
+        # Make the worktree path exist so shutil.rmtree of workspace dir
+        # doesn't fully clean up (simulate stuck directory)
+        wt_dir = sample_workspace.repos[0].worktree_path
+        wt_dir.mkdir(parents=True, exist_ok=True)
+        # Make a file that prevents rmtree from cleaning up
+        # (We mock the removal to always fail)
+        with (
+            patch("grove.workspace.git.worktree_remove", side_effect=GitError("locked")),
+            patch("grove.workspace.shutil.rmtree"),  # prevent actual cleanup
+        ):
+            result = workspace.delete_workspace("test-ws")
+        # With failures and directory still present, state should be preserved
+        assert result is False
+        assert state.get_workspace("test-ws") is not None
+
 
 class TestSyncWorkspace:
     def test_up_to_date(self, tmp_grove, sample_workspace):
@@ -871,6 +890,23 @@ class TestRenameWorkspace:
         saved = state.get_workspace("renamed")
         for repo_wt in saved.repos:
             assert "renamed" in str(repo_wt.worktree_path)
+
+    def test_rollback_on_directory_rename_failure(self, tmp_grove, sample_workspace):
+        """If directory rename fails, state reverts to original values."""
+        state.add_workspace(sample_workspace)
+        cfg = Config(
+            repos_dir=tmp_grove["repos_dir"],
+            workspace_dir=tmp_grove["workspace_dir"],
+        )
+        with patch.object(Path, "rename", side_effect=OSError("permission denied")):
+            result = workspace.rename_workspace("test-ws", "new-name", cfg)
+        assert result is False
+        # State should still have the old workspace
+        ws = state.get_workspace("test-ws")
+        assert ws is not None
+        assert ws.path == sample_workspace.path
+        # New name should not exist in state
+        assert state.get_workspace("new-name") is None
 
     def test_created_at_preserved(self, tmp_grove, sample_workspace):
         state.add_workspace(sample_workspace)


### PR DESCRIPTION
## Summary
- Atomic file writes for `state.json` and `config.toml` — prevents corruption on crash/kill mid-write
- Corrupt JSON in state file now shows a helpful error instead of a raw traceback
- `_sanitize_name` rejects branches like `"/"` that produce empty workspace names
- Preset names validated for TOML safety (rejects dots, spaces, brackets)
- `rename_workspace` is now atomic: writes state first, renames directory second, rolls back on failure
- `_teardown_and_remove` no longer re-raises after successful force cleanup (no misleading warnings)
- `delete_workspace` keeps state entry on partial failure so `gw doctor` can assist with cleanup

## Test plan
- [x] All 225 tests pass
- [x] New tests for: corrupt state.json, empty sanitized name, preset name validation, detached HEAD worktree parsing, delete partial failure, rename rollback
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)