### PR TITLE
Add list -s flag, deprecate status --all

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ gw explore                                             # deep-scan for repos (2â
 # Day-to-day
 gw create my-feature -r svc-a,svc-b -b feat/login     # create workspace
 gw list                                                # list workspaces
+gw list -s                                             # list with git status summary
 gw status my-feature                                   # git status across repos
-gw status --all                                        # overview of all workspaces
 gw sync my-feature                                     # rebase all repos onto base branch
 gw go my-feature                                       # cd into workspace
 gw run my-feature                                      # run dev processes (TUI with per-repo logs)

--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,10 @@ Implemented in multi-dir init PR:
 - Discovery stays live — `create`/`add-repo` always scan fresh
 - Backward compat: old config with `repos_dir` (singular) treated as single-element list
 
+## Remove `status --all`
+
+Deprecated in favor of `gw list -s`. Remove the `--all` flag from `gw status` after a few releases.
+
 ## `gw run` TUI enhancements
 
 - PTY allocation for subprocess output — some programs buffer stdout when not connected to a TTY (workaround: `stdbuf -oL` or tool-specific flags in `.grove.toml`)

--- a/src/grove/cli.py
+++ b/src/grove/cli.py
@@ -428,8 +428,21 @@ def create(
 
 
 @app.command("list")
-def list_workspaces() -> None:
+def list_workspaces(
+    show_status: bool = typer.Option(False, "--status", "-s", help="Include git status summary"),
+) -> None:
     """List all workspaces."""
+    if show_status:
+        summaries = workspace.all_workspaces_summary()
+        if not summaries:
+            info("No workspaces. Create one with: gw create <name> -r repo1,repo2 -b branch")
+            return
+        table = make_table("Name", "Branch", "Repos", "Status", "Path")
+        for s in summaries:
+            table.add_row(s["name"], s["branch"], s["repos"], s["status"], s["path"])
+        console.print(table)
+        return
+
     workspaces = state.load_workspaces()
     if not workspaces:
         info("No workspaces. Create one with: gw create <name> -r repo1,repo2 -b branch")
@@ -716,6 +729,7 @@ def status(
 ) -> None:
     """Show git status across a workspace's repos."""
     if show_all:
+        warning("--all is deprecated, use: gw list -s")
         if name is not None:
             error("Cannot combine workspace name with --all")
             raise typer.Exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -316,6 +316,31 @@ class TestList:
         assert result.exit_code == 0
         assert "test-ws" in result.output
 
+    def test_status_flag(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with patch("grove.cli.workspace.all_workspaces_summary") as mock_summary:
+            mock_summary.return_value = [
+                {
+                    "name": "test-ws",
+                    "branch": "feat/test",
+                    "repos": "1",
+                    "status": "1 clean",
+                    "path": str(sample_workspace.path),
+                },
+            ]
+            result = runner.invoke(app, ["list", "-s"])
+        assert result.exit_code == 0
+        assert "test-ws" in result.output
+        assert "1 clean" in result.output
+
+    def test_status_flag_empty(self, tmp_grove):
+        with patch("grove.cli.workspace.all_workspaces_summary", return_value=[]):
+            result = runner.invoke(app, ["list", "--status"])
+        assert result.exit_code == 0
+        assert "No workspaces" in result.output
+
 
 class TestDelete:
     def test_success(self, tmp_grove, sample_workspace):
@@ -626,7 +651,9 @@ class TestPreset:
 
 
 class TestStatusAll:
-    def test_flag_works(self, tmp_grove, sample_workspace):
+    """status --all is deprecated in favor of list -s but still works."""
+
+    def test_flag_works_with_deprecation(self, tmp_grove, sample_workspace):
         from grove import state
 
         state.add_workspace(sample_workspace)
@@ -643,7 +670,7 @@ class TestStatusAll:
             result = runner.invoke(app, ["status", "--all"])
         assert result.exit_code == 0
         assert "test-ws" in result.output
-        assert "1 clean" in result.output
+        assert "deprecated" in result.output
 
     def test_mutual_exclusivity(self, tmp_grove, sample_workspace):
         from grove import state


### PR DESCRIPTION
## Summary

- `gw list -s` / `--status` adds a git status column (clean/modified/error) to workspace listing
- `gw list` (default) stays instant with no git calls
- `gw status --all` still works but prints a deprecation warning pointing to `gw list -s`
- TODO updated to track future removal of `status --all`

## Test plan

- [x] 250 tests passing (2 new)
- [ ] `gw list` — shows workspaces without status (fast, no git)
- [ ] `gw list -s` — shows workspaces with status summary
- [ ] `gw status --all` — still works, shows deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)