### PR TITLE
Identify repos by git remote URL instead of folder name

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,14 @@ Implemented in multi-dir init PR:
 
 Deprecated in favor of `gw list -s`. Remove the `--all` flag from `gw status` after a few releases.
 
+## ~~Smarter repo discovery — identity by git remote~~ (done)
+
+Implemented: repos are now identified by `origin` remote URL instead of folder name.
+- Interactive pickers (`create`, `add-repo`, `explore`) do deep scans and show `org/repo` from remote
+- Same-named folders with different remotes are distinguished
+- Same remote across multiple paths is deduped (direct children preferred)
+- Non-interactive flags (`-r`) still use folder names for backward compat
+
 ## `gw run` TUI enhancements
 
 - PTY allocation for subprocess output — some programs buffer stdout when not connected to a TTY (workaround: `stdbuf -oL` or tool-specific flags in `.grove.toml`)

--- a/src/grove/cli.py
+++ b/src/grove/cli.py
@@ -106,6 +106,18 @@ def _sanitize_name(branch: str) -> str:
     return name
 
 
+def _validate_repo_names(repo_names: list[str], available: dict[str, Path]) -> dict[str, Path]:
+    """Validate repo names against available repos, exit on unknown names."""
+    selected: dict[str, Path] = {}
+    for rn in repo_names:
+        if rn not in available:
+            error(f"Repo [bold]{rn}[/] not found")
+            info(f"Available: {', '.join(available.keys())}")
+            raise typer.Exit(1)
+        selected[rn] = available[rn]
+    return selected
+
+
 def _pick_one(prompt_text: str, choices: list[str]) -> str:
     """Arrow-key single selection."""
     return choices[_pick_one_idx(prompt_text, choices)]
@@ -277,27 +289,44 @@ def explore() -> None:
         error("No repo dirs configured. Run: gw add-dir <path>")
         raise typer.Exit(1)
 
-    known = discover.find_all_repos(cfg.repo_dirs)
-    grouped = discover.explore_repos(cfg.repo_dirs)
+    discovered = discover.discover_repos(cfg.repo_dirs)
 
-    if not grouped:
+    if not discovered:
         info("No git repos found in configured directories")
         return
 
-    total = 0
+    # Group by parent dir for display
+    from collections import defaultdict
+
+    by_dir: dict[Path, list[discover.RepoInfo]] = defaultdict(list)
+    for r in discovered:
+        # Find which repo_dir this belongs to
+        parent = r.path.parent
+        for d in cfg.repo_dirs:
+            resolved_d = d.resolve()
+            try:
+                r.path.resolve().relative_to(resolved_d)
+                parent = d
+                break
+            except ValueError:
+                continue
+        by_dir[parent].append(r)
+
     nested_count = 0
-    for source_dir, repos in grouped.items():
+    for source_dir in sorted(by_dir):
         console.print(f"\n[bold]{source_dir}[/]")
-        for name, repo_path in sorted(repos.items()):
-            total += 1
-            if name not in known:
+        for r in sorted(by_dir[source_dir], key=lambda x: x.display_name):
+            is_nested = r.path.parent.resolve() != source_dir.resolve()
+            if is_nested:
                 nested_count += 1
-                console.print(f"  [green]★[/] {name}  [dim]{repo_path}[/]  [green](nested)[/]")
+                console.print(
+                    f"  [green]★[/] {r.display_name}  [dim]{r.path}[/]  [green](nested)[/]"
+                )
             else:
-                console.print(f"    {name}  [dim]{repo_path}[/]")
+                console.print(f"    {r.display_name}  [dim]{r.path}[/]")
 
     console.print()
-    info(f"{total} repos found" + (f" ({nested_count} nested)" if nested_count else ""))
+    info(f"{len(discovered)} repos found" + (f" ({nested_count} nested)" if nested_count else ""))
 
 
 @app.command()
@@ -327,7 +356,6 @@ def create(
 ) -> None:
     """Create a new workspace with worktrees from selected repos."""
     cfg = config.require_config()
-    available = discover.find_all_repos(cfg.repo_dirs)
 
     # --- Interactive fallback when branch is missing ---
     if branch is None:
@@ -341,9 +369,10 @@ def create(
             error("Branch name is required")
             raise typer.Exit(1)
 
-    # --- Resolve repos: -r > -p > --all / default all ---
+    # --- Resolve repos: -r > -p > --all / deep-scan picker ---
+    selected: dict[str, Path] | None = None
+
     if repos is not None:
-        # Explicit repo list
         repo_names = [r.strip() for r in repos.split(",")]
     elif preset is not None:
         if preset not in cfg.presets:
@@ -353,15 +382,21 @@ def create(
             raise typer.Exit(1)
         repo_names = cfg.presets[preset]
     elif all_repos:
+        available = discover.find_all_repos(cfg.repo_dirs)
         repo_names = list(available.keys())
     else:
-        # No flags at all — interactive picker
-        if not available:
+        # Interactive picker — deep scan with remote identity
+        discovered = discover.discover_repos(cfg.repo_dirs)
+        if not discovered:
             error("No repos found. Run: gw add-dir <path>")
             raise typer.Exit(1)
 
+        # Build picker: display_name -> RepoInfo
+        repo_by_display = {r.display_name: r for r in discovered}
+
         # Offer presets when available
         if cfg.presets:
+            available = discover.find_all_repos(cfg.repo_dirs)
             preset_names = list(cfg.presets.keys())
             preset_choices = [
                 f"{name}  ({', '.join(repos_list)})" for name, repos_list in cfg.presets.items()
@@ -371,34 +406,34 @@ def create(
                 [*preset_choices, "Pick manually…"],
             )
             if source_idx == len(preset_choices):
-                repo_names = _pick_many("Select repos", sorted(available.keys()))
+                picked = _pick_many("Select repos", sorted(repo_by_display.keys()))
+                selected = {repo_by_display[p].name: repo_by_display[p].path for p in picked}
             else:
                 repo_names = cfg.presets[preset_names[source_idx]]
+                selected = _validate_repo_names(repo_names, available)
         else:
-            repo_names = _pick_many("Select repos", sorted(available.keys()))
+            picked = _pick_many("Select repos", sorted(repo_by_display.keys()))
+            selected = {repo_by_display[p].name: repo_by_display[p].path for p in picked}
 
         # Offer to save as preset if none exist
         if (
             not cfg.presets
-            and len(repo_names) < len(available)
+            and selected
+            and len(selected) < len(repo_by_display)
             and typer.confirm("Save this selection as a preset?", default=False)
         ):
             from rich.prompt import Prompt
 
             preset_name = Prompt.ask("[bold]Preset name[/]", console=console)
             if preset_name:
-                cfg.presets[preset_name] = repo_names
+                cfg.presets[preset_name] = list(selected.keys())
                 config.save_config(cfg)
                 success(f"Preset [bold]{preset_name}[/] saved")
 
-    # Validate selected repos
-    selected: dict[str, Path] = {}
-    for rn in repo_names:
-        if rn not in available:
-            error(f"Repo [bold]{rn}[/] not found")
-            info(f"Available: {', '.join(available.keys())}")
-            raise typer.Exit(1)
-        selected[rn] = available[rn]
+    # Validate selected repos (non-interactive paths use folder names)
+    if selected is None:
+        available = discover.find_all_repos(cfg.repo_dirs)
+        selected = _validate_repo_names(repo_names, available)
 
     # --- Resolve name: explicit > auto-derive from branch ---
     if name is None:
@@ -575,7 +610,6 @@ def add_repo(
 ) -> None:
     """Add repos to an existing workspace."""
     cfg = config.require_config()
-    available = discover.find_all_repos(cfg.repo_dirs)
 
     # Resolve workspace
     if name is None:
@@ -591,22 +625,24 @@ def add_repo(
         raise typer.Exit(1)
 
     existing_names = {r.repo_name for r in ws.repos}
-    addable = {n: p for n, p in available.items() if n not in existing_names}
-
-    if not addable:
-        info("All repos are already in this workspace")
-        return
 
     if repos is not None:
+        available = discover.find_all_repos(cfg.repo_dirs)
         repo_names = [r.strip() for r in repos.split(",")]
         for rn in repo_names:
             if rn not in available:
                 error(f"Repo [bold]{rn}[/] not found")
                 raise typer.Exit(1)
+        selected = {rn: available[rn] for rn in repo_names}
     else:
-        repo_names = _pick_many("Select repos to add", sorted(addable.keys()))
-
-    selected = {rn: available[rn] for rn in repo_names}
+        # Interactive — deep scan with remote identity
+        discovered = discover.discover_repos(cfg.repo_dirs)
+        addable = {r.display_name: r for r in discovered if r.name not in existing_names}
+        if not addable:
+            info("All repos are already in this workspace")
+            return
+        picked = _pick_many("Select repos to add", sorted(addable.keys()))
+        selected = {addable[p].name: addable[p].path for p in picked}
     # Filter out already-present repos before calling workspace function
     actually_new = {rn: p for rn, p in selected.items() if rn not in existing_names}
     if not actually_new:

--- a/src/grove/discover.py
+++ b/src/grove/discover.py
@@ -2,7 +2,30 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
+
+from grove.git import parse_remote_name, remote_url
+
+
+@dataclass(frozen=True)
+class RepoInfo:
+    """A discovered repository with its identity and location."""
+
+    name: str  # folder name
+    path: Path  # absolute path to repo
+    remote: str | None  # origin remote URL
+    display_name: str  # org/repo from remote, or folder name as fallback
+
+
+def _repo_display_name(path: Path) -> str:
+    """Derive a display name from the remote URL, falling back to folder name."""
+    url = remote_url(path)
+    if url:
+        parsed = parse_remote_name(url)
+        if parsed:
+            return parsed
+    return path.name
 
 
 def find_repos(repos_dir: Path) -> dict[str, Path]:
@@ -33,6 +56,71 @@ def find_all_repos(repo_dirs: list[Path]) -> dict[str, Path]:
             if name not in repos:
                 repos[name] = path
     return repos
+
+
+def discover_repos(repo_dirs: list[Path], max_depth: int = 3) -> list[RepoInfo]:
+    """Deep-scan directories for git repos, deduped by remote URL.
+
+    Returns a list of :class:`RepoInfo` sorted by display name.
+    When multiple paths share the same remote URL, the one closest to a
+    configured ``repo_dirs`` root wins (i.e. direct children are preferred
+    over nested repos).
+    """
+    seen_remotes: dict[str, RepoInfo] = {}  # remote_url -> RepoInfo
+    seen_paths: set[Path] = set()
+
+    for d in repo_dirs:
+        _discover_recursive(d, d, seen_remotes, seen_paths, depth=0, max_depth=max_depth)
+
+    return sorted(seen_remotes.values(), key=lambda r: r.display_name)
+
+
+def _discover_recursive(
+    directory: Path,
+    root: Path,
+    seen_remotes: dict[str, RepoInfo],
+    seen_paths: set[Path],
+    depth: int,
+    max_depth: int,
+) -> None:
+    """Recursively scan *directory* for git repos up to *max_depth*."""
+    if depth > max_depth or not directory.is_dir():
+        return
+    try:
+        entries = sorted(directory.iterdir())
+    except PermissionError:
+        return
+    for entry in entries:
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        if (entry / ".git").is_dir():
+            resolved = entry.resolve()
+            if resolved in seen_paths:
+                continue
+            seen_paths.add(resolved)
+
+            url = remote_url(entry)
+            display = _repo_display_name(entry)
+            info = RepoInfo(
+                name=entry.name,
+                path=entry,
+                remote=url,
+                display_name=display,
+            )
+
+            if url and url in seen_remotes:
+                # Prefer direct children over nested repos
+                existing = seen_remotes[url]
+                if existing.path.parent != root and entry.parent == root:
+                    seen_remotes[url] = info
+                # Otherwise keep existing (first wins)
+            else:
+                key = url or str(resolved)
+                if key not in seen_remotes:
+                    seen_remotes[key] = info
+            # Don't descend into repos
+        else:
+            _discover_recursive(entry, root, seen_remotes, seen_paths, depth + 1, max_depth)
 
 
 def explore_repos(repo_dirs: list[Path], max_depth: int = 3) -> dict[Path, dict[str, Path]]:

--- a/src/grove/git.py
+++ b/src/grove/git.py
@@ -25,6 +25,34 @@ def _run(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProces
         raise GitError(e.stderr.strip() or e.stdout.strip()) from e
 
 
+def remote_url(path: Path, remote: str = "origin") -> str | None:
+    """Return the fetch URL for *remote*, or ``None`` if unavailable."""
+    try:
+        result = _run(["remote", "get-url", remote], cwd=path)
+        return result.stdout.strip() or None
+    except GitError:
+        return None
+
+
+def parse_remote_name(url: str) -> str | None:
+    """Extract ``owner/repo`` from a git remote URL.
+
+    Handles HTTPS (``https://github.com/owner/repo.git``)
+    and SSH (``git@github.com:owner/repo.git``) formats.
+    """
+    import re
+
+    # SSH: git@host:owner/repo.git
+    m = re.match(r"^[\w.-]+@[\w.-]+:(.*?)(?:\.git)?$", url)
+    if m:
+        return m.group(1)
+    # HTTPS: https://host/owner/repo.git
+    m = re.match(r"^https?://[^/]+/(.*?)(?:\.git)?$", url)
+    if m:
+        return m.group(1)
+    return None
+
+
 def is_git_repo(path: Path) -> bool:
     """Check if a directory is a git repository."""
     try:

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
-from grove.discover import explore_repos, find_all_repos, find_repos
+from grove.discover import discover_repos, explore_repos, find_all_repos, find_repos
 
 
 def _make_repo(path: Path) -> None:
@@ -77,3 +78,70 @@ class TestExploreRepos:
         assert dir2 in result
         assert "repo-a" in result[dir1]
         assert "repo-b" in result[dir2]
+
+
+class TestDiscoverRepos:
+    """Tests for discover_repos — deep scan with remote identity."""
+
+    def _make_repo_with_remote(self, path: Path, url: str) -> None:
+        _make_repo(path)
+        # We mock remote_url, so just need the .git dir to exist
+
+    def test_uses_remote_for_display_name(self, tmp_path: Path):
+        _make_repo(tmp_path / "my-repo")
+        with patch("grove.discover.remote_url", return_value="git@github.com:org/my-repo.git"):
+            result = discover_repos([tmp_path])
+        assert len(result) == 1
+        assert result[0].display_name == "org/my-repo"
+        assert result[0].name == "my-repo"
+
+    def test_falls_back_to_folder_name(self, tmp_path: Path):
+        _make_repo(tmp_path / "local-only")
+        with patch("grove.discover.remote_url", return_value=None):
+            result = discover_repos([tmp_path])
+        assert len(result) == 1
+        assert result[0].display_name == "local-only"
+
+    def test_dedup_by_remote_url(self, tmp_path: Path):
+        dir1 = tmp_path / "dir1"
+        dir2 = tmp_path / "dir2"
+        _make_repo(dir1 / "repo-a")
+        _make_repo(dir2 / "repo-a-fork")
+        url = "git@github.com:org/repo-a.git"
+        with patch("grove.discover.remote_url", return_value=url):
+            result = discover_repos([dir1, dir2])
+        # Same remote → deduped to one entry
+        assert len(result) == 1
+
+    def test_different_remotes_not_deduped(self, tmp_path: Path):
+        dir1 = tmp_path / "dir1"
+        dir2 = tmp_path / "dir2"
+        _make_repo(dir1 / "repo")
+        _make_repo(dir2 / "repo")
+
+        def mock_remote(path, remote="origin"):
+            if "dir1" in str(path):
+                return "git@github.com:org-a/repo.git"
+            return "git@github.com:org-b/repo.git"
+
+        with patch("grove.discover.remote_url", side_effect=mock_remote):
+            result = discover_repos([dir1, dir2])
+        assert len(result) == 2
+        names = {r.display_name for r in result}
+        assert names == {"org-a/repo", "org-b/repo"}
+
+    def test_prefers_direct_child_over_nested(self, tmp_path: Path):
+        _make_repo(tmp_path / "repo-a")
+        _make_repo(tmp_path / "nested" / "repo-a")
+        url = "git@github.com:org/repo-a.git"
+        with patch("grove.discover.remote_url", return_value=url):
+            result = discover_repos([tmp_path])
+        assert len(result) == 1
+        assert result[0].path == tmp_path / "repo-a"
+
+    def test_finds_nested_repos(self, tmp_path: Path):
+        _make_repo(tmp_path / "sub" / "deep-repo")
+        with patch("grove.discover.remote_url", return_value="git@github.com:org/deep.git"):
+            result = discover_repos([tmp_path])
+        assert len(result) == 1
+        assert result[0].display_name == "org/deep"

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -208,6 +208,41 @@ class TestPrStatus:
             assert git.pr_status(Path("/ws")) is None
 
 
+class TestRemoteUrl:
+    def test_returns_url(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="git@github.com:org/repo.git\n")
+        assert git.remote_url(Path("/repo")) == "git@github.com:org/repo.git"
+
+    def test_returns_none_on_error(self, mock_run):
+        mock_run.side_effect = GitError("no remote")
+        assert git.remote_url(Path("/repo")) is None
+
+    def test_custom_remote(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="https://github.com/org/repo.git\n")
+        git.remote_url(Path("/repo"), remote="upstream")
+        mock_run.assert_called_once_with(["remote", "get-url", "upstream"], cwd=Path("/repo"))
+
+
+class TestParseRemoteName:
+    def test_ssh_format(self):
+        assert git.parse_remote_name("git@github.com:org/repo.git") == "org/repo"
+
+    def test_ssh_no_git_suffix(self):
+        assert git.parse_remote_name("git@github.com:org/repo") == "org/repo"
+
+    def test_https_format(self):
+        assert git.parse_remote_name("https://github.com/org/repo.git") == "org/repo"
+
+    def test_https_no_git_suffix(self):
+        assert git.parse_remote_name("https://github.com/org/repo") == "org/repo"
+
+    def test_nested_path(self):
+        assert git.parse_remote_name("git@gitlab.com:group/sub/repo.git") == "group/sub/repo"
+
+    def test_invalid_url(self):
+        assert git.parse_remote_name("not-a-url") is None
+
+
 class TestRunIntegration:
     """Test the actual _run function with subprocess mocking."""
 


### PR DESCRIPTION
## Summary

- Repos are now identified by `origin` remote URL instead of folder name
- Interactive pickers (`create`, `add-repo`, `explore`) do deep scans and show `org/repo-name` derived from remote
- Same-named folders with different remotes are properly distinguished
- Same remote across multiple paths is deduped (direct children preferred over nested)
- Non-interactive flags (`-r`) still use folder names for backward compat
- New `RepoInfo` dataclass, `discover_repos()`, `git.remote_url()`, `git.parse_remote_name()`
- 15 new tests (265 total)

## Test plan

- [x] `parse_remote_name` handles SSH, HTTPS, nested paths, invalid URLs
- [x] `discover_repos` dedupes by remote, prefers direct children
- [x] Different remotes with same folder name are not deduped
- [x] Fallback to folder name when no remote
- [x] All 265 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)