### PR TITLE
Add --back and --clean-up flags to gw go

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,27 +9,41 @@ Add end-to-end tests that exercise the main flows against real git repos (not mo
 - `gw create` → `gw run` (with actual processes, verify TUI launches)
 - Lifecycle hooks fire in correct order with real `.grove.toml` files
 
-## ~~Rethink init + repo discovery~~ (done)
-
-Implemented in multi-dir init PR:
-- Config stores `repo_dirs: list[Path]` instead of singular `repos_dir`
-- `gw init` sets up `~/.grove`, optionally accepts dirs upfront
-- `gw add-dir <path>` / `gw remove-dir <path>` to manage source directories
-- `gw explore` scans all configured dirs recursively (up to 3 levels deep), prints discovered repos grouped by source dir, highlights new finds
-- Discovery stays live — `create`/`add-repo` always scan fresh
-- Backward compat: old config with `repos_dir` (singular) treated as single-element list
-
 ## Remove `status --all`
 
 Deprecated in favor of `gw list -s`. Remove the `--all` flag from `gw status` after a few releases.
 
-## ~~Smarter repo discovery — identity by git remote~~ (done)
+## Background cleanup for `gw go --clean-up`
 
-Implemented: repos are now identified by `origin` remote URL instead of folder name.
-- Interactive pickers (`create`, `add-repo`, `explore`) do deep scans and show `org/repo` from remote
-- Same-named folders with different remotes are distinguished
-- Same remote across multiple paths is deduped (direct children preferred)
-- Non-interactive flags (`-r`) still use folder names for backward compat
+Currently `gw go -c` runs workspace deletion synchronously — the shell waits for the full cleanup before `cd`ing. This is fine for now since `delete_workspace` is fast (parallel worktree removal), but if it becomes a UX bottleneck, consider spawning cleanup as a detached subprocess:
+
+```python
+print(dest)
+subprocess.Popen(
+    [sys.executable, "-m", "grove", "delete", "--force", name],
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+    start_new_session=True,
+)
+```
+
+This lets the shell `cd` instantly while cleanup runs in the background. If the cleanup fails, `gw doctor` would catch the stale state.
+
+### Other background task candidates
+
+- **`gw sync` fetch/rebase** — network I/O across multiple remotes is the slowest user-facing operation
+- **`gw create` setup hooks** — `.grove.toml` `setup` commands (`npm install`, `uv sync`) can be slow; user could `cd` into the workspace immediately while setup runs in the background
+- **`gw explore` deep scan** — recursive repo discovery could be slow on large filesystems; cache refresh could happen in background
+
+### Design: keep it simple, avoid a global "background mode"
+
+A global non-blocking config/env var would add `if background:` branches across every feature — too much surface area. Instead, start with a per-invocation flag:
+
+- `gw create --background-setup` — cd into workspace immediately, run `.grove.toml` setup hooks in background
+- Default stays synchronous (safe — user expects `npm install` to finish before they run `npm start`)
+- If the flag sees enough use, promote to `.grove.toml` config: `setup_background = true`
+
+This keeps the code simple: one flag, one branch, opt-in per invocation.
 
 ## `gw run` TUI enhancements
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,21 +13,9 @@ Add end-to-end tests that exercise the main flows against real git repos (not mo
 
 Deprecated in favor of `gw list -s`. Remove the `--all` flag from `gw status` after a few releases.
 
-## Background cleanup for `gw go --clean-up`
+## Background tasks
 
-Currently `gw go -c` runs workspace deletion synchronously — the shell waits for the full cleanup before `cd`ing. This is fine for now since `delete_workspace` is fast (parallel worktree removal), but if it becomes a UX bottleneck, consider spawning cleanup as a detached subprocess:
-
-```python
-print(dest)
-subprocess.Popen(
-    [sys.executable, "-m", "grove", "delete", "--force", name],
-    stdout=subprocess.DEVNULL,
-    stderr=subprocess.DEVNULL,
-    start_new_session=True,
-)
-```
-
-This lets the shell `cd` instantly while cleanup runs in the background. If the cleanup fails, `gw doctor` would catch the stale state.
+`gw go --delete` already uses a detached subprocess for cleanup — the shell `cd`s immediately while deletion runs in the background. If cleanup fails, `gw doctor` catches stale state.
 
 ### Other background task candidates
 

--- a/src/grove/cli.py
+++ b/src/grove/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -892,9 +893,9 @@ _BACK_TO_REPOS = "← back to repos dir"
 def _resolve_back_path(ws: Workspace) -> Path:
     """Resolve the 'back' destination for a workspace.
 
-    1. Single repo → source_repo
-    2. Multi-repo, all in same parent dir → that parent dir
-    3. Multi-repo, different parent dirs → picker
+    1. Single repo → parent directory of source_repo
+    2. Multi-repo, all in same parent dir → that shared parent dir
+    3. Multi-repo, different parent dirs → interactive picker
     """
     source_dirs: list[Path] = []
     seen: set[str] = set()
@@ -905,11 +906,30 @@ def _resolve_back_path(ws: Workspace) -> Path:
             seen.add(key)
             source_dirs.append(parent)
 
+    if not source_dirs:
+        error("Workspace has no repos — cannot determine a source directory")
+        raise typer.Exit(1)
+
     if len(source_dirs) == 1:
         return source_dirs[0]
 
     picked = _pick_one("Select repo directory", [str(d) for d in source_dirs])
     return Path(picked)
+
+
+def _do_cleanup(ws_name: str) -> None:
+    """Spawn a detached subprocess to delete a workspace.
+
+    The subprocess runs independently so the shell function can cd
+    immediately without waiting for worktree removal to finish.
+    If cleanup fails, ``gw doctor`` will catch the stale state.
+    """
+    subprocess.Popen(
+        [sys.executable, "-m", "grove", "delete", "--force", ws_name],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
 
 
 @app.command()
@@ -920,11 +940,15 @@ def go(
         autocompletion=complete_workspace_name,
     ),
     back: bool = typer.Option(False, "--back", "-b", help="Go back to the source repo directory"),
-    clean_up: bool = typer.Option(
-        False, "--clean-up", "-c", help="Delete current workspace after navigating away"
+    delete: bool = typer.Option(
+        False, "--delete", "-d", help="Delete current workspace after navigating away"
     ),
 ) -> None:
     """Print workspace path (use with shell function for cd)."""
+    if back and name is not None:
+        error("--back cannot be combined with a workspace name")
+        raise typer.Exit(1)
+
     current_ws = state.find_workspace_by_path(Path.cwd())
 
     # --back: go to source repo dir of current workspace
@@ -933,8 +957,8 @@ def go(
             error("Not inside a workspace")
             raise typer.Exit(1)
         dest = _resolve_back_path(current_ws)
-        if clean_up:
-            workspace.delete_workspace(current_ws.name)
+        if delete:
+            _do_cleanup(current_ws.name)
         print(dest)
         return
 
@@ -975,9 +999,14 @@ def go(
         error(f"Workspace [bold]{name}[/] not found")
         raise typer.Exit(1)
 
-    # --clean-up: delete current workspace before navigating to target
-    if clean_up and current_ws and current_ws.name != ws.name:
-        workspace.delete_workspace(current_ws.name)
+    # --delete: delete current workspace before navigating to target
+    if delete:
+        if current_ws is None:
+            warning("--delete has no effect: not inside a workspace")
+        elif current_ws.name == ws.name:
+            warning(f"--delete skipped: already in workspace [bold]{ws.name}[/]")
+        else:
+            _do_cleanup(current_ws.name)
 
     # Print raw path for shell function to consume
     print(ws.path)

--- a/src/grove/cli.py
+++ b/src/grove/cli.py
@@ -889,6 +889,29 @@ def run(
 _BACK_TO_REPOS = "← back to repos dir"
 
 
+def _resolve_back_path(ws: Workspace) -> Path:
+    """Resolve the 'back' destination for a workspace.
+
+    1. Single repo → source_repo
+    2. Multi-repo, all in same parent dir → that parent dir
+    3. Multi-repo, different parent dirs → picker
+    """
+    source_dirs: list[Path] = []
+    seen: set[str] = set()
+    for repo_wt in ws.repos:
+        parent = repo_wt.source_repo.parent.resolve()
+        key = str(parent)
+        if key not in seen:
+            seen.add(key)
+            source_dirs.append(parent)
+
+    if len(source_dirs) == 1:
+        return source_dirs[0]
+
+    picked = _pick_one("Select repo directory", [str(d) for d in source_dirs])
+    return Path(picked)
+
+
 @app.command()
 def go(
     name: str | None = typer.Argument(
@@ -896,8 +919,25 @@ def go(
         help="Workspace name",
         autocompletion=complete_workspace_name,
     ),
+    back: bool = typer.Option(False, "--back", "-b", help="Go back to the source repo directory"),
+    clean_up: bool = typer.Option(
+        False, "--clean-up", "-c", help="Delete current workspace after navigating away"
+    ),
 ) -> None:
     """Print workspace path (use with shell function for cd)."""
+    current_ws = state.find_workspace_by_path(Path.cwd())
+
+    # --back: go to source repo dir of current workspace
+    if back:
+        if current_ws is None:
+            error("Not inside a workspace")
+            raise typer.Exit(1)
+        dest = _resolve_back_path(current_ws)
+        if clean_up:
+            workspace.delete_workspace(current_ws.name)
+        print(dest)
+        return
+
     # Interactive fallback
     if name is None:
         workspaces = state.load_workspaces()
@@ -905,7 +945,6 @@ def go(
             error("No workspaces. Create one first: gw create ...")
             raise typer.Exit(1)
 
-        current_ws = state.find_workspace_by_path(Path.cwd())
         choices = [
             f"{ws.name}  (current)" if current_ws and ws.name == current_ws.name else ws.name
             for ws in workspaces
@@ -935,6 +974,10 @@ def go(
     if ws is None:
         error(f"Workspace [bold]{name}[/] not found")
         raise typer.Exit(1)
+
+    # --clean-up: delete current workspace before navigating to target
+    if clean_up and current_ws and current_ws.name != ws.name:
+        workspace.delete_workspace(current_ws.name)
 
     # Print raw path for shell function to consume
     print(ws.path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -577,6 +577,137 @@ class TestGo:
         assert result.exit_code == 1
         assert "not found" in result.output
 
+    def test_back_single_repo(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with patch("grove.cli.state.find_workspace_by_path", return_value=sample_workspace):
+            result = runner.invoke(app, ["go", "--back"])
+        assert result.exit_code == 0
+        assert str(tmp_grove["repos_dir"]) in result.output
+
+    def test_back_not_in_workspace(self, tmp_grove):
+        result = runner.invoke(app, ["go", "--back"])
+        assert result.exit_code == 1
+        assert "Not inside a workspace" in result.output
+
+    def test_back_with_name_errors(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with patch("grove.cli.state.find_workspace_by_path", return_value=sample_workspace):
+            result = runner.invoke(app, ["go", "test-ws", "--back"])
+        assert result.exit_code == 1
+        assert "cannot be combined" in result.output
+
+    def test_back_multi_repo_same_dir(self, tmp_grove):
+        from grove import state
+
+        ws_path = tmp_grove["workspace_dir"] / "multi-ws"
+        ws_path.mkdir()
+        repos_dir = tmp_grove["repos_dir"]
+        ws = Workspace(
+            name="multi-ws",
+            path=ws_path,
+            branch="feat/x",
+            repos=[
+                RepoWorktree(
+                    repo_name="svc-auth",
+                    source_repo=repos_dir / "svc-auth",
+                    worktree_path=ws_path / "svc-auth",
+                    branch="feat/x",
+                ),
+                RepoWorktree(
+                    repo_name="svc-api",
+                    source_repo=repos_dir / "svc-api",
+                    worktree_path=ws_path / "svc-api",
+                    branch="feat/x",
+                ),
+            ],
+        )
+        state.add_workspace(ws)
+        with patch("grove.cli.state.find_workspace_by_path", return_value=ws):
+            result = runner.invoke(app, ["go", "--back"])
+        assert result.exit_code == 0
+        assert str(repos_dir) in result.output
+
+    def test_back_empty_repos(self, tmp_grove):
+        from grove import state
+
+        ws_path = tmp_grove["workspace_dir"] / "empty-ws"
+        ws_path.mkdir()
+        ws = Workspace(name="empty-ws", path=ws_path, branch="feat/x", repos=[])
+        state.add_workspace(ws)
+        with patch("grove.cli.state.find_workspace_by_path", return_value=ws):
+            result = runner.invoke(app, ["go", "--back"])
+        assert result.exit_code == 1
+        assert "no repos" in result.output
+
+    def test_delete_current_workspace(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        ws_path2 = tmp_grove["workspace_dir"] / "other-ws"
+        ws_path2.mkdir()
+        other_ws = Workspace(
+            name="other-ws",
+            path=ws_path2,
+            branch="feat/other",
+            repos=[
+                RepoWorktree(
+                    repo_name="svc-api",
+                    source_repo=tmp_grove["repos_dir"] / "svc-api",
+                    worktree_path=ws_path2 / "svc-api",
+                    branch="feat/other",
+                ),
+            ],
+        )
+        state.add_workspace(sample_workspace)
+        state.add_workspace(other_ws)
+        with (
+            patch("grove.cli.state.find_workspace_by_path", return_value=sample_workspace),
+            patch("grove.cli.subprocess.Popen") as mock_popen,
+        ):
+            result = runner.invoke(app, ["go", "other-ws", "--delete"])
+        assert result.exit_code == 0
+        assert str(ws_path2) in result.output
+        mock_popen.assert_called_once()
+        assert "test-ws" in mock_popen.call_args[0][0]
+
+    def test_delete_same_workspace_warns(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with (
+            patch("grove.cli.state.find_workspace_by_path", return_value=sample_workspace),
+            patch("grove.cli.subprocess.Popen") as mock_popen,
+        ):
+            result = runner.invoke(app, ["go", "test-ws", "--delete"])
+        assert result.exit_code == 0
+        mock_popen.assert_not_called()
+        assert "skipped" in result.output
+
+    def test_back_and_delete(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        with (
+            patch("grove.cli.state.find_workspace_by_path", return_value=sample_workspace),
+            patch("grove.cli.subprocess.Popen") as mock_popen,
+        ):
+            result = runner.invoke(app, ["go", "--back", "--delete"])
+        assert result.exit_code == 0
+        assert str(tmp_grove["repos_dir"]) in result.output
+        mock_popen.assert_called_once()
+        assert "test-ws" in mock_popen.call_args[0][0]
+
+    def test_delete_not_in_workspace_warns(self, tmp_grove, sample_workspace):
+        from grove import state
+
+        state.add_workspace(sample_workspace)
+        result = runner.invoke(app, ["go", "test-ws", "--delete"])
+        assert result.exit_code == 0
+        assert "no effect" in result.output
+
 
 class TestPreset:
     def _make_config(self, tmp_grove):


### PR DESCRIPTION
## Summary
- Add `--back` (`-b`) flag to `gw go` — navigates to the source repo directory of the current workspace, with picker when repos span multiple dirs
- Add `--clean-up` (`-c`) flag to `gw go` — deletes the current workspace after navigating away
- Flags compose: `gw go -b -c` goes back and cleans up in one step, `gw go foo -c` switches workspace and cleans up the old one
- Clean up completed TODO items and document background task ideas

## Test plan
- [ ] `gw go -b` from inside a single-repo workspace → lands in source repo parent dir
- [ ] `gw go -b` from inside a multi-repo workspace (same dir) → lands in shared parent dir
- [ ] `gw go -b` from inside a multi-repo workspace (different dirs) → shows picker
- [ ] `gw go -b` from outside a workspace → shows error
- [ ] `gw go -c` → interactive pick, then deletes current workspace
- [ ] `gw go -b -c` → goes back and deletes current workspace
- [ ] `gw go foo -c` → navigates to foo, deletes current workspace
- [ ] `gw go foo -c` when already in foo → does not self-delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)