### PR TITLE
Kanban dashboard with task cards and launch flow

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,14 @@ A global non-blocking config/env var would add `if background:` branches across 
 
 This keeps the code simple: one flag, one branch, opt-in per invocation.
 
+## Dashboard task modal UX
+
+The create/edit modal works but the interaction is clunky:
+- Preset picker (OptionList) and repo list (SelectionList) are inline but navigating between them isn't smooth
+- `/` search only activates when repo list is focused — not discoverable
+- Consider a custom widget that combines preset selection + repo toggling in one cohesive interaction
+- Investigate Textual's `on_key` override for modal-local keybindings that don't conflict with the app's `priority=True` enter binding
+
 ## `gw run` TUI enhancements
 
 - PTY allocation for subprocess output — some programs buffer stdout when not connected to a TTY (workaround: `stdbuf -oL` or tool-specific flags in `.grove.toml`)

--- a/specs/dash-kanban.md
+++ b/specs/dash-kanban.md
@@ -1,0 +1,356 @@
+# Grove Dashboard v2 — Kanban Orchestration Board
+
+## Vision
+
+Transform `gw dash` from a read-only monitoring table into an interactive
+kanban board that can **create tasks, launch workspaces, start Claude agents,
+and monitor them** — all from one screen.
+
+The CLI (`gw create`, `gw ws`, `gw list`) remains terminal-agnostic.
+The dashboard is the opinionated "Zellij power-user" orchestration layer on top.
+
+---
+
+## Card Lifecycle
+
+```
+┌──────────┐     ┌──────────────┐     ┌─────────┐     ┌──────────┐     ┌──────┐
+│ PLANNED  │────▸│ PROVISIONING │────▸│ WORKING │────▸│  IDLE    │────▸│ DONE │
+└──────────┘     └──────────────┘     └─────────┘     └──────────┘     └──────┘
+     │                                     │               │
+     │                                     ▼               │
+     │                              ┌─────────────┐       │
+     │                              │   WAITING    │       │
+     │                              │ PERM/ANSWER  │       │
+     │                              └─────────────┘       │
+     │                                     │               │
+     │                                     ▼               │
+     │                              ┌─────────────┐       │
+     │                              │    ERROR     │───────┘
+     │                              └─────────────┘
+     │
+     ▼
+ ┌──────────┐
+ │ ARCHIVED │  (user dismisses without launching)
+ └──────────┘
+```
+
+**PLANNED** → User creates a card with a prompt/description.
+**PROVISIONING** → Dashboard calls `gw ws create` + launches Claude in a Zellij tab.
+**WORKING/WAITING/ERROR** → Hooks feed status back; card updates automatically.
+**IDLE** → Agent finished its turn, waiting for user input.
+**DONE** → User marks card as done (or auto-detect from SessionEnd hook).
+**ARCHIVED** → User dismisses a planned card without launching.
+
+---
+
+## Kanban Columns
+
+Default columns (status-based, auto-sorted):
+
+| Column | Statuses | Description |
+|--------|----------|-------------|
+| Planned | PLANNED | Tasks waiting to be launched |
+| Active | WORKING, PROVISIONING | Agents currently doing work |
+| Needs Attention | WAITING_PERMISSION, WAITING_ANSWER, ERROR | Requires user action |
+| Idle | IDLE | Finished their turn |
+| Done | DONE, ARCHIVED | Completed or dismissed |
+
+Cards flow between columns automatically based on hook events.
+Users can manually move cards to DONE or ARCHIVED.
+
+---
+
+## Card Design
+
+```
+╭─ feat/purchase-api ──────────── ⚡ WORKING ─╮
+│ Add bulk import endpoint for purchases       │
+│                                              │
+│ 🔧 Edit  ·  tools: 23  ·  3m                │
+│ ▁▂▃▅▇▅▃▂▁▃  main ← feat/purchase-api       │
+╰──────────────────────────────────────────────╯
+```
+
+Card shows:
+- **Title**: workspace/branch name
+- **Status badge**: colored by status
+- **Prompt snippet**: first line of the task description
+- **Last tool + counts**: what the agent is doing
+- **Sparkline + branch**: activity and git context
+
+Focused card expands to show more detail (or detail pane on the right).
+
+---
+
+## Launch Flow
+
+### User creates a card
+
+1. Press `c` (create) on the dashboard
+2. Input dialog: branch name, prompt/description, repo selection
+3. Card appears in PLANNED column
+
+### User launches a card
+
+1. Focus a PLANNED card, press `enter` (launch)
+2. Dashboard executes:
+   ```
+   gw ws create <branch> --repos <repos>
+   ```
+3. Dashboard generates a temp Zellij layout file:
+   ```kdl
+   layout {
+     tab name="<branch>" {
+       pane command="claude" args="--dangerously-skip-permissions" {
+         // or without --dangerously-skip-permissions based on config
+       }
+     }
+   }
+   ```
+4. Dashboard executes:
+   ```
+   zellij action new-tab --layout /tmp/grove-launch-<id>.kdl --cwd <workspace-path>
+   ```
+5. Claude starts, hooks fire, card moves to WORKING
+
+### Permissions config
+
+In `~/.grove/config.toml`:
+```toml
+[dash]
+# Permission mode for launched agents
+# Options: "default", "dangerously-skip-permissions"
+claude_permissions = "default"
+
+# Default model
+claude_model = ""
+
+# Extra CLI flags
+claude_extra_args = ""
+```
+
+---
+
+## Data Storage
+
+### Hybrid approach: Files + SQLite
+
+| Data | Storage | Why |
+|------|---------|-----|
+| Agent hook state | JSON files (`~/.grove/status/`) | Hot path, written every second by hooks, atomic writes |
+| Task cards | SQLite (`~/.grove/tasks.db`) | Persistent, queryable, survives agent restarts |
+| Config | TOML (`~/.grove/config.toml`) | Existing Grove config |
+
+### SQLite Schema
+
+```sql
+CREATE TABLE tasks (
+    id          TEXT PRIMARY KEY,  -- uuid
+    title       TEXT NOT NULL,     -- branch name or user title
+    description TEXT DEFAULT '',   -- prompt / task description
+    status      TEXT DEFAULT 'PLANNED',
+    branch      TEXT DEFAULT '',
+    repos       TEXT DEFAULT '[]', -- JSON array of repo names
+    workspace   TEXT DEFAULT '',   -- workspace name (after creation)
+    session_id  TEXT DEFAULT '',   -- linked Claude session (from hooks)
+    column_order INTEGER DEFAULT 0, -- position within column
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL,
+    launched_at TEXT,
+    completed_at TEXT,
+    config      TEXT DEFAULT '{}' -- JSON: permissions, model, extra args
+);
+
+CREATE INDEX idx_tasks_status ON tasks(status);
+CREATE INDEX idx_tasks_session ON tasks(session_id);
+```
+
+### Linking tasks to agents
+
+When a card is launched:
+1. `gw ws create` returns the workspace path
+2. Claude starts in that workspace
+3. The SessionStart hook fires with the workspace's `cwd`
+4. Dashboard matches the card's workspace path to the agent's `cwd`
+5. Card's `session_id` is set, linking task → agent
+
+---
+
+## Keyboard Bindings
+
+| Key | Action |
+|-----|--------|
+| `h` / `l` | Move focus between columns |
+| `j` / `k` | Move focus between cards in column |
+| `c` | Create new card |
+| `enter` | Launch planned card / Jump to agent tab |
+| `y` / `n` | Approve / Deny permission (on WAITING cards) |
+| `d` | Mark as done |
+| `x` | Archive / Delete card |
+| `e` | Edit card description |
+| `/` | Search / filter cards |
+| `r` | Refresh |
+| `q` | Quit |
+
+---
+
+## Textual Architecture
+
+```
+DashboardApp
+├── HeaderBar                    (existing, updated)
+├── HorizontalScroll             (kanban board)
+│   ├── KanbanColumn "Planned"
+│   │   └── VerticalScroll
+│   │       ├── TaskCard
+│   │       └── TaskCard
+│   ├── KanbanColumn "Active"
+│   │   └── VerticalScroll
+│   │       ├── TaskCard (linked to AgentState)
+│   │       └── TaskCard
+│   ├── KanbanColumn "Attention"
+│   │   └── VerticalScroll
+│   │       └── TaskCard
+│   ├── KanbanColumn "Idle"
+│   │   └── VerticalScroll
+│   │       └── TaskCard
+│   └── KanbanColumn "Done"
+│       └── VerticalScroll
+│           └── TaskCard
+├── AgentDetail                  (existing, shown for focused card)
+└── StatusLine                   (existing)
+```
+
+### Key widgets
+
+- **TaskCard** — extends `Static`, renders card content with Rich markup.
+  Has a `task_id` and optionally a linked `AgentState`.
+- **KanbanColumn** — `Vertical` container with a title and `VerticalScroll` body.
+  Independent scrolling per column.
+- **CardEditor** — modal dialog for creating/editing cards.
+
+### Data flow
+
+```
+SQLite (tasks) ──┐
+                 ├──▸ merge ──▸ TaskCards ──▸ KanbanColumns
+JSON files (agents) ─┘
+```
+
+On each poll tick:
+1. Read all tasks from SQLite
+2. Read all agent states from JSON files (existing `manager.scan()`)
+3. Match tasks to agents by `session_id` or workspace path
+4. Unlinked agents (started outside dash) appear as "ad-hoc" cards in Active
+5. Update card widgets in-place (mount new, remove completed)
+
+---
+
+## Zellij Integration
+
+### Capabilities (verified)
+
+| Operation | Zellij Support | Command |
+|-----------|---------------|---------|
+| Create tab with name + cwd | ✅ Full | `zellij action new-tab --name X --cwd Y` |
+| Run command in new tab | ⚠️ Via layout file | Temp `.kdl` with `pane command=...` |
+| Switch to tab by name | ✅ Full | `zellij action go-to-tab-name X` |
+| Send keys to pane | ✅ Full | `zellij action write-chars --pane-id N` |
+| Close focused tab | ✅ Full | `zellij action close-tab` |
+| Target session externally | ✅ Full | `zellij -s <session> action ...` |
+| Query focused tab | ⚠️ Indirect | `dump-layout` parsing |
+| Close tab by name | ❌ Not yet | Must focus first, then close |
+
+### Launch implementation
+
+```python
+def launch_card(task: Task, workspace_path: str) -> bool:
+    """Launch a Claude agent in a new Zellij tab."""
+    # Generate temp layout
+    layout = f'''layout {{
+  tab name="{task.branch}" {{
+    pane command="claude" args="{_claude_args(task)}"
+  }}
+}}'''
+    layout_path = Path(tempfile.mktemp(suffix=".kdl", prefix="grove-"))
+    layout_path.write_text(layout)
+
+    try:
+        result = subprocess.run(
+            ["zellij", "action", "new-tab",
+             "--layout", str(layout_path),
+             "--cwd", workspace_path],
+            capture_output=True, timeout=10,
+        )
+        return result.returncode == 0
+    finally:
+        layout_path.unlink(missing_ok=True)
+```
+
+---
+
+## Migration from v1
+
+The current table-based dash becomes a "compact view" toggle (`t` key).
+Default view is the kanban board. Users who prefer the table can switch.
+
+Existing features preserved:
+- Hook system (unchanged)
+- Agent state files (unchanged)
+- Search/filter
+- Approve/deny
+- Jump to tab
+
+New features:
+- Task cards with persistence
+- Launch from dashboard
+- Card lifecycle tracking
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Kanban layout (visual only)
+- Replace DataTable with KanbanColumn + TaskCard widgets
+- Auto-sort existing agents into columns by status
+- Keyboard navigation (h/j/k/l)
+- Keep detail panel
+
+### Phase 2 — Task persistence (SQLite)
+- Add `tasks.db` with schema
+- Create/edit/delete cards
+- Cards persist across dashboard restarts
+- Link cards to agents when launched externally
+
+### Phase 3 — Launch from dashboard
+- `gw ws create` integration (shell out)
+- Zellij tab creation with temp layout
+- Claude auto-start with configurable permissions
+- Full PLANNED → WORKING lifecycle
+
+### Phase 4 — Polish
+- Compact table view toggle
+- Card drag reordering (mouse)
+- Notifications (desktop or Zellij)
+- Multi-session support (multiple Zellij sessions)
+
+---
+
+## Open Questions
+
+1. **Should ad-hoc agents (started outside dash) auto-create task cards?**
+   Or stay as ephemeral entries that disappear on SessionEnd?
+
+2. **How to handle `gw ws create` failure?**
+   Show error on card? Move to ERROR status?
+
+3. **Should DONE cards auto-archive after N hours?**
+   Or require manual cleanup?
+
+4. **Claude prompt injection**: When launching Claude with a prompt from
+   the card, how to pass it? Pipe to stdin? `--prompt` flag?
+   Need to investigate Claude Code CLI flags.
+
+5. **Multiple agents per workspace**: A card could spawn multiple agents
+   (e.g., one per repo). How to represent this? Stacked cards?

--- a/src/grove/dash/app.py
+++ b/src/grove/dash/app.py
@@ -116,6 +116,7 @@ class DashboardApp(App):
         Binding("enter", "jump_to_agent", "Jump", priority=True),
         Binding("y", "approve", "Approve"),
         Binding("n", "deny", "Deny"),
+        Binding("s", "start_task", "Start"),
         Binding("c", "create_task", "Create"),
         Binding("e", "edit_task", "Edit"),
         Binding("d", "mark_done", "Done"),
@@ -155,6 +156,7 @@ class DashboardApp(App):
             "[dim]j/k[/] cards  "
             "[dim]enter[/] jump  "
             "[dim]y/n[/] approve/deny  "
+            "[dim]s[/] start  "
             "[dim]c[/] create  "
             "[dim]e[/] edit  "
             "[dim]d[/] done  "
@@ -271,6 +273,46 @@ class DashboardApp(App):
 
     # --- Task actions ---
 
+    def action_start_task(self) -> None:
+        """Launch a planned task — provision workspace + open Zellij tab."""
+        board = self.query_one(KanbanBoard)
+        card = board.focused_card
+        if card is None or card.task_data is None:
+            return
+        task = card.task_data
+        if task.status not in ("PLANNED", "IDLE"):
+            log.info("START: task %r not in launchable status (%s)", task.title, task.status)
+            return
+        self.push_screen(
+            ConfirmModal(f"Start task [bold]{task.title}[/]?"),
+            lambda confirmed: self._on_start_confirmed(confirmed, task),
+        )
+
+    def _on_start_confirmed(self, confirmed: bool, task: Task) -> None:
+        if not confirmed:
+            return
+        from grove.dash.launcher import launch_task
+
+        self.run_worker(
+            lambda: launch_task(task),
+            name=f"launch-{task.id}",
+            thread=True,
+        )
+        self._poll_state()
+
+    def on_worker_state_changed(self, event) -> None:
+        """Refresh board when a background worker completes."""
+        if not event.worker.name or not event.worker.is_finished:
+            return
+        if event.worker.name.startswith("launch-"):
+            result = event.worker.result
+            if result:
+                ok, msg = result
+                log.info("LAUNCH: %s — %s", "success" if ok else "failed", msg)
+            self._poll_state()
+        elif event.worker.name.startswith("delete-"):
+            self._poll_state()
+
     def action_create_task(self) -> None:
         """Open create modal."""
         self.push_screen(TaskModal(), self._on_task_created)
@@ -320,16 +362,44 @@ class DashboardApp(App):
         if card is None or card.task_data is None:
             return
         task = card.task_data
+        msg = f"Delete task [bold]{task.title}[/]?"
+        if task.workspace:
+            msg += f"\nWorkspace [bold]{task.workspace}[/] will also be removed."
         self.push_screen(
-            ConfirmModal(f"Delete task [bold]{task.title}[/]?"),
-            lambda confirmed: self._on_delete_confirmed(confirmed, task.id),
+            ConfirmModal(msg),
+            lambda confirmed: self._on_delete_confirmed(confirmed, task),
         )
 
-    def _on_delete_confirmed(self, confirmed: bool, task_id: str) -> None:
-        if confirmed:
-            self._store.delete(task_id)
-            log.info("TASK: deleted id=%s", task_id)
+    def _on_delete_confirmed(self, confirmed: bool, task: Task) -> None:
+        if not confirmed:
+            return
+        if task.workspace:
+            self.run_worker(
+                lambda: self._cleanup_workspace(task),
+                name=f"delete-{task.id}",
+                thread=True,
+            )
+        else:
+            self._store.delete(task.id)
+            log.info("TASK: deleted id=%s", task.id)
             self._poll_state()
+
+    @staticmethod
+    def _cleanup_workspace(task: Task) -> tuple[str, str]:
+        """Delete workspace + task in a background thread."""
+        from grove import workspace as ws_mod
+        from grove.dash.store import TaskStore
+
+        store = TaskStore()
+        ws_name = task.workspace
+        ok = ws_mod.delete_workspace(ws_name)
+        if ok:
+            log.info("TASK: cleaned up workspace %r", ws_name)
+        else:
+            log.warning("TASK: workspace cleanup failed for %r", ws_name)
+        store.delete(task.id)
+        log.info("TASK: deleted id=%s", task.id)
+        return task.id, ws_name
 
     # --- Search ---
 

--- a/src/grove/dash/app.py
+++ b/src/grove/dash/app.py
@@ -9,14 +9,19 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.theme import Theme
-from textual.widgets import DataTable, Input, Static
+from textual.widgets import Input, Static
 
 from grove.dash import manager
-from grove.dash.constants import CLEANUP_INTERVAL, STATE_POLL_INTERVAL
+from grove.dash.constants import CLEANUP_INTERVAL, STATE_POLL_INTERVAL, AgentStatus
 from grove.dash.models import AgentState
+from grove.dash.store import Task, TaskStore
 from grove.dash.widgets.agent_detail import AgentDetail
+from grove.dash.widgets.confirm_modal import ConfirmModal
 from grove.dash.widgets.header_bar import HeaderBar
-from grove.dash.widgets.session_list import SessionList, matches_filter
+from grove.dash.widgets.kanban_board import KanbanBoard
+from grove.dash.widgets.session_list import matches_filter
+from grove.dash.widgets.task_card import TaskCard
+from grove.dash.widgets.task_modal import TaskModal
 
 log = logging.getLogger("grove.dash")
 
@@ -43,7 +48,7 @@ GRUVBOX_DARK = Theme(
 class DashboardApp(App):
     """Grove agent dashboard."""
 
-    TITLE = "Grove Dashboard"
+    TITLE = "\u26a1\ufe0e gw dash"
 
     CSS = """
     Screen {
@@ -70,23 +75,9 @@ class DashboardApp(App):
         height: 1fr;
     }
 
-    #list-pane {
+    #board-pane {
         width: 2fr;
         height: 1fr;
-        border: round $panel;
-        border-title-color: $primary;
-        border-title-style: bold;
-        padding: 0;
-    }
-
-    #list-pane:focus-within {
-        border: round $primary;
-    }
-
-    SessionList {
-        height: 1fr;
-        min-height: 4;
-        background: $background;
     }
 
     #detail-pane {
@@ -120,9 +111,15 @@ class DashboardApp(App):
         Binding("q", "quit", "Quit"),
         Binding("j", "cursor_down", "Down", show=False),
         Binding("k", "cursor_up", "Up", show=False),
+        Binding("h", "cursor_left", "Left", show=False),
+        Binding("l", "cursor_right", "Right", show=False),
         Binding("enter", "jump_to_agent", "Jump", priority=True),
         Binding("y", "approve", "Approve"),
         Binding("n", "deny", "Deny"),
+        Binding("c", "create_task", "Create"),
+        Binding("e", "edit_task", "Edit"),
+        Binding("d", "mark_done", "Done"),
+        Binding("x", "delete_task", "Delete"),
         Binding("r", "refresh", "Refresh"),
         Binding("/", "start_search", "Search", show=False),
         Binding("escape", "stop_search", "Clear search", show=False),
@@ -132,7 +129,10 @@ class DashboardApp(App):
         super().__init__()
         self._agents: list[AgentState] = []
         self._filtered: list[AgentState] = []
+        self._tasks: list[Task] = []
+        self._filtered_tasks: list[Task] = []
         self._search_query: str = ""
+        self._store = TaskStore()
 
     def on_mount(self) -> None:
         self.register_theme(GRUVBOX_DARK)
@@ -144,36 +144,53 @@ class DashboardApp(App):
     def compose(self) -> ComposeResult:
         yield HeaderBar(id="header")
         with Horizontal(id="main-split"):
-            with Vertical(id="list-pane") as pane:
-                pane.border_title = "Agents"
-                yield SessionList(id="session-list")
+            with Vertical(id="board-pane"):
+                yield KanbanBoard(id="kanban-board")
             with Vertical(id="detail-pane") as pane:
                 pane.border_title = "Detail"
                 yield AgentDetail()
         yield Static(
             "[dim]q[/] quit  "
-            "[dim]↑↓[/] select  "
+            "[dim]h/l[/] columns  "
+            "[dim]j/k[/] cards  "
             "[dim]enter[/] jump  "
             "[dim]y/n[/] approve/deny  "
-            "[dim]r[/] refresh  "
+            "[dim]c[/] create  "
+            "[dim]e[/] edit  "
+            "[dim]d[/] done  "
+            "[dim]x[/] delete  "
             "[dim]/[/] search",
             id="status-line",
         )
 
+    # --- Polling ---
+
     def _poll_state(self) -> None:
         agents, summary = manager.scan()
         self._agents = agents
+        self._tasks = self._store.list_active()
         self._apply_filter()
 
         self.query_one(HeaderBar).update_summary(summary)
-        self.query_one(SessionList).update_agents(self._filtered)
+        board = self.query_one(KanbanBoard)
+        board.update_board(self._filtered, self._filtered_tasks)
         self._update_detail()
 
     def _apply_filter(self) -> None:
         if self._search_query:
+            q = self._search_query.lower()
             self._filtered = [a for a in self._agents if matches_filter(a, self._search_query)]
+            self._filtered_tasks = [
+                t
+                for t in self._tasks
+                if q in t.title.lower()
+                or q in t.branch.lower()
+                or q in t.description.lower()
+                or q in t.status.value.lower()
+            ]
         else:
             self._filtered = list(self._agents)
+            self._filtered_tasks = list(self._tasks)
 
     def _run_cleanup(self) -> None:
         manager.cleanup_stale()
@@ -181,43 +198,47 @@ class DashboardApp(App):
 
     def _update_detail(self) -> None:
         detail = self.query_one(AgentDetail)
-        session_list = self.query_one(SessionList)
-        idx = session_list.selected_index
-
-        if idx is not None and idx < len(self._filtered):
-            detail.show_agent(self._filtered[idx])
-        else:
-            detail.show_agent(None)
+        board = self.query_one(KanbanBoard)
+        agent = board.focused_agent
+        detail.show_agent(agent)
 
     def on_key(self, event) -> None:
         log.info("KEY: key=%r char=%r", event.key, event.character)
 
-    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
-        self._update_detail()
+    def on_descendant_focus(self, event) -> None:
+        if isinstance(event.widget, TaskCard):
+            self._update_detail()
+
+    # --- Navigation ---
 
     def action_cursor_down(self) -> None:
-        self.query_one(SessionList).action_cursor_down()
+        self.query_one(KanbanBoard).focus_next_card()
 
     def action_cursor_up(self) -> None:
-        self.query_one(SessionList).action_cursor_up()
+        self.query_one(KanbanBoard).focus_prev_card()
+
+    def action_cursor_left(self) -> None:
+        self.query_one(KanbanBoard).focus_prev_column()
+
+    def action_cursor_right(self) -> None:
+        self.query_one(KanbanBoard).focus_next_column()
+
+    # --- Agent actions ---
 
     def action_jump_to_agent(self) -> None:
         """Jump to the selected agent's Zellij tab."""
-        # If search input is focused, treat enter as submit, not jump
         results = self.query("#search-input")
         if results and results.first().has_focus:
-            self._dismiss_search(clear=False)
+            self._handle_search_submit()
             return
 
         from grove.dash import zellij
 
-        session_list = self.query_one(SessionList)
-        idx = session_list.selected_index
-        log.info("JUMP: idx=%s, filtered_count=%d", idx, len(self._filtered))
-        if idx is None or idx >= len(self._filtered):
+        board = self.query_one(KanbanBoard)
+        agent = board.focused_agent
+        if agent is None:
             return
 
-        agent = self._filtered[idx]
         log.info(
             "JUMP: project=%r cwd=%r display=%r",
             agent.project_name,
@@ -228,23 +249,17 @@ class DashboardApp(App):
         log.info("JUMP: result=%s", result)
 
     def action_approve(self) -> None:
-        """Approve permission request for selected agent."""
         self._send_response(approve=True)
 
     def action_deny(self) -> None:
-        """Deny permission request for selected agent."""
         self._send_response(approve=False)
 
     def _send_response(self, *, approve: bool) -> None:
         from grove.dash import zellij
 
-        session_list = self.query_one(SessionList)
-        idx = session_list.selected_index
-        if idx is None or idx >= len(self._filtered):
-            return
-
-        agent = self._filtered[idx]
-        if agent.status.value != "WAITING_PERMISSION":
+        board = self.query_one(KanbanBoard)
+        agent = board.focused_agent
+        if agent is None or agent.status.value != "WAITING_PERMISSION":
             return
 
         if zellij.jump_to_agent(agent.project_name, agent.cwd or ""):
@@ -254,8 +269,71 @@ class DashboardApp(App):
                 zellij.deny()
             zellij.jump_to_agent("grove")
 
+    # --- Task actions ---
+
+    def action_create_task(self) -> None:
+        """Open create modal."""
+        self.push_screen(TaskModal(), self._on_task_created)
+
+    def _on_task_created(self, task: Task | None) -> None:
+        if task is None:
+            return
+        self._store.add(task)
+        log.info("TASK: created %r id=%s", task.title, task.id)
+        self._poll_state()
+
+    def action_edit_task(self) -> None:
+        """Open edit modal for focused task card."""
+        board = self.query_one(KanbanBoard)
+        card = board.focused_card
+        if card is None or card.task_data is None:
+            return
+        self.push_screen(TaskModal(existing=card.task_data), self._on_task_edited)
+
+    def _on_task_edited(self, task: Task | None) -> None:
+        if task is None:
+            return
+        import json
+
+        self._store.update_field(
+            task.id,
+            title=task.title,
+            branch=task.branch,
+            description=task.description,
+            repos=json.dumps(task.repos),
+        )
+        log.info("TASK: updated %r id=%s", task.title, task.id)
+        self._poll_state()
+
+    def action_mark_done(self) -> None:
+        board = self.query_one(KanbanBoard)
+        card = board.focused_card
+        if card is None or card.task_data is None:
+            return
+        self._store.update_status(card.task_data.id, AgentStatus.DONE)
+        self._poll_state()
+
+    def action_delete_task(self) -> None:
+        """Delete focused task with confirmation."""
+        board = self.query_one(KanbanBoard)
+        card = board.focused_card
+        if card is None or card.task_data is None:
+            return
+        task = card.task_data
+        self.push_screen(
+            ConfirmModal(f"Delete task [bold]{task.title}[/]?"),
+            lambda confirmed: self._on_delete_confirmed(confirmed, task.id),
+        )
+
+    def _on_delete_confirmed(self, confirmed: bool, task_id: str) -> None:
+        if confirmed:
+            self._store.delete(task_id)
+            log.info("TASK: deleted id=%s", task_id)
+            self._poll_state()
+
+    # --- Search ---
+
     def action_start_search(self) -> None:
-        """Mount a search input and focus it."""
         log.info("SEARCH: action_start_search fired")
         results = self.query("#search-input")
         if results:
@@ -265,30 +343,31 @@ class DashboardApp(App):
         self.mount(search)
         search.focus()
 
+    def _handle_search_submit(self) -> None:
+        self._dismiss_search(clear=False)
+
     def _dismiss_search(self, *, clear: bool = False) -> None:
-        """Remove the search input widget."""
         results = self.query("#search-input")
         if results:
             results.first().remove()
         if clear:
             self._search_query = ""
             self._apply_filter()
-            self.query_one(SessionList).update_agents(self._filtered)
-        self.query_one(SessionList).focus()
+            board = self.query_one(KanbanBoard)
+            board.update_board(self._filtered, self._filtered_tasks)
 
     def action_stop_search(self) -> None:
-        """Hide search input, clear filter, refocus table."""
         self._dismiss_search(clear=True)
 
     def on_input_changed(self, event: Input.Changed) -> None:
-        """Filter agents as user types in search."""
-        self._search_query = event.value
-        self._apply_filter()
-        self.query_one(SessionList).update_agents(self._filtered)
+        if event.input.id == "search-input":
+            self._search_query = event.value
+            self._apply_filter()
+            self.query_one(KanbanBoard).update_board(self._filtered, self._filtered_tasks)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
-        """On Enter in search, dismiss input but keep filter active."""
-        self._dismiss_search(clear=False)
+        if event.input.id == "search-input":
+            self._handle_search_submit()
 
     def action_refresh(self) -> None:
         self._poll_state()

--- a/src/grove/dash/constants.py
+++ b/src/grove/dash/constants.py
@@ -6,11 +6,15 @@ from enum import StrEnum
 
 
 class AgentStatus(StrEnum):
+    PLANNED = "PLANNED"
+    PROVISIONING = "PROVISIONING"
     IDLE = "IDLE"
     WORKING = "WORKING"
     WAITING_PERMISSION = "WAITING_PERMISSION"
     WAITING_ANSWER = "WAITING_ANSWER"
     ERROR = "ERROR"
+    DONE = "DONE"
+    ARCHIVED = "ARCHIVED"
 
 
 # Statuses that require user attention
@@ -20,7 +24,34 @@ ATTENTION_STATUSES = {
     AgentStatus.ERROR,
 }
 
-# Status display
+# --- Gruvbox dark palette ---
+GREEN = "#b8bb26"
+AQUA = "#8ec07c"
+RED = "#fb4934"
+YELLOW = "#fabd2f"
+GREY = "#928374"
+FG = "#fbf1c7"
+ORANGE = "#fe8019"
+PURPLE = "#d3869b"
+BG = "#282828"
+BG_LIGHT = "#3c3836"
+
+# Status display: (color, short_label)
+BLUE = "#83a598"
+
+STATUS_DISPLAY: dict[AgentStatus, tuple[str, str]] = {
+    AgentStatus.PLANNED: (BLUE, "PLAN"),
+    AgentStatus.PROVISIONING: (AQUA, "PROV"),
+    AgentStatus.IDLE: (GREY, "IDLE"),
+    AgentStatus.WORKING: (GREEN, "WORK"),
+    AgentStatus.WAITING_PERMISSION: (RED, "PERM"),
+    AgentStatus.WAITING_ANSWER: (YELLOW, "WAIT"),
+    AgentStatus.ERROR: (ORANGE, "ERR"),
+    AgentStatus.DONE: (GREEN, "DONE"),
+    AgentStatus.ARCHIVED: (GREY, "ARCH"),
+}
+
+# Legacy alias kept for existing code
 STATUS_STYLES = {
     AgentStatus.IDLE: ("dim", "idle"),
     AgentStatus.WORKING: ("green", "working"),
@@ -39,3 +70,16 @@ STATE_DIR_NAME = "status"
 STATE_POLL_INTERVAL = 0.5
 CLEANUP_INTERVAL = 30.0
 STALE_TIMEOUT = 1800  # 30 minutes
+
+# Kanban column definitions: (column_id, title, statuses)
+KANBAN_COLUMNS: list[tuple[str, str, set[AgentStatus]]] = [
+    ("planned", "Planned", {AgentStatus.PLANNED}),
+    ("active", "Active", {AgentStatus.WORKING, AgentStatus.PROVISIONING}),
+    (
+        "attention",
+        "Attention",
+        {AgentStatus.WAITING_PERMISSION, AgentStatus.WAITING_ANSWER, AgentStatus.ERROR},
+    ),
+    ("idle", "Idle", {AgentStatus.IDLE}),
+    ("done", "Done", {AgentStatus.DONE, AgentStatus.ARCHIVED}),
+]

--- a/src/grove/dash/launcher.py
+++ b/src/grove/dash/launcher.py
@@ -1,0 +1,107 @@
+"""Launch flow — provision workspace, open Zellij tab, start Claude agent."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from grove.dash.store import Task
+
+log = logging.getLogger("grove.dash")
+
+
+def _sanitize_name(branch: str) -> str:
+    """Derive workspace name from branch (matches cli.py logic)."""
+    name = branch.replace("/", "-").replace("\\", "-")
+    # Strip leading dashes
+    return name.lstrip("-") or "workspace"
+
+
+def launch_task(task: Task) -> tuple[bool, str]:
+    """Provision a workspace and open a Zellij tab for a planned task.
+
+    Creates its own TaskStore since this runs in a background thread.
+    Returns (success, message).
+    """
+    from grove import config, discover, workspace
+    from grove.dash import zellij
+    from grove.dash.constants import AgentStatus
+    from grove.dash.store import TaskStore
+
+    store = TaskStore()
+
+    if not task.repos:
+        return False, "No repos selected"
+
+    if not task.branch:
+        return False, "No branch set"
+
+    # Load config and resolve repo paths
+    try:
+        cfg = config.load_config()
+    except Exception:
+        log.exception("Failed to load config")
+        return False, "Failed to load Grove config"
+
+    available = discover.find_all_repos(cfg.repo_dirs)
+    repo_paths: dict[str, Path] = {}
+    missing: list[str] = []
+    for repo_name in task.repos:
+        if repo_name in available:
+            repo_paths[repo_name] = available[repo_name]
+        else:
+            missing.append(repo_name)
+
+    if missing:
+        return False, f"Repos not found: {', '.join(missing)}"
+
+    if not repo_paths:
+        return False, "No valid repos to provision"
+
+    # Derive workspace name
+    ws_name = _sanitize_name(task.branch)
+
+    # Update task status to provisioning
+    store.update_status(task.id, AgentStatus.PROVISIONING)
+
+    # Create workspace — suppress Rich console output from bleeding into the TUI
+    import contextlib
+    import io
+
+    try:
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            ws = workspace.create_workspace(ws_name, repo_paths, task.branch, cfg)
+    except Exception:
+        log.exception("Failed to create workspace %s", ws_name)
+        store.update_status(task.id, AgentStatus.PLANNED)
+        return False, f"Failed to create workspace '{ws_name}'"
+
+    if ws is None:
+        store.update_status(task.id, AgentStatus.PLANNED)
+        return False, f"Workspace '{ws_name}' already exists or failed"
+
+    # Link workspace to task
+    store.update_field(task.id, workspace=ws_name)
+
+    # Open Zellij tab
+    ws_path = str(ws.path)
+    if zellij.is_available():
+        # Build claude command with prompt as positional arg (interactive mode)
+        claude_cmd = None
+        claude_args = None
+        if task.description:
+            claude_cmd = "claude"
+            claude_args = [task.description]
+
+        if zellij.new_tab(ws_name, ws_path, claude_cmd, claude_args):
+            log.info("LAUNCH: opened Zellij tab %r at %s", ws_name, ws_path)
+            # Jump back to dashboard tab
+            zellij.jump_to_agent("gw dash")
+        else:
+            log.warning("LAUNCH: failed to open Zellij tab")
+    else:
+        log.info("LAUNCH: not in Zellij, workspace created at %s", ws_path)
+
+    store.update_status(task.id, AgentStatus.WORKING)
+    log.info("LAUNCH: task %r launched as workspace %r", task.title, ws_name)
+    return True, f"Launched workspace '{ws_name}'"

--- a/src/grove/dash/store.py
+++ b/src/grove/dash/store.py
@@ -1,0 +1,241 @@
+"""SQLite task store for persistent kanban cards."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from grove.dash.constants import AgentStatus
+
+DB_PATH = Path.home() / ".grove" / "tasks.db"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS tasks (
+    id           TEXT PRIMARY KEY,
+    title        TEXT NOT NULL,
+    description  TEXT DEFAULT '',
+    status       TEXT DEFAULT 'PLANNED',
+    branch       TEXT DEFAULT '',
+    repos        TEXT DEFAULT '[]',
+    workspace    TEXT DEFAULT '',
+    session_id   TEXT DEFAULT '',
+    column_order INTEGER DEFAULT 0,
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL,
+    launched_at  TEXT,
+    completed_at TEXT,
+    config       TEXT DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+CREATE INDEX IF NOT EXISTS idx_tasks_session ON tasks(session_id);
+"""
+
+
+def _now() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass
+class Task:
+    """A persistent kanban task card."""
+
+    id: str
+    title: str
+    description: str = ""
+    status: AgentStatus = AgentStatus.PLANNED
+    branch: str = ""
+    repos: list[str] = field(default_factory=list)
+    workspace: str = ""
+    session_id: str = ""
+    column_order: int = 0
+    created_at: str = ""
+    updated_at: str = ""
+    launched_at: str = ""
+    completed_at: str = ""
+    config: dict = field(default_factory=dict)
+
+    @classmethod
+    def create(
+        cls,
+        title: str,
+        description: str = "",
+        branch: str = "",
+        repos: list[str] | None = None,
+        config: dict | None = None,
+    ) -> Task:
+        """Create a new task with generated ID and timestamps."""
+        now = _now()
+        return cls(
+            id=uuid.uuid4().hex[:12],
+            title=title,
+            description=description,
+            branch=branch,
+            repos=repos or [],
+            config=config or {},
+            created_at=now,
+            updated_at=now,
+        )
+
+
+class TaskStore:
+    """SQLite-backed task persistence."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self._db_path = db_path or DB_PATH
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn: sqlite3.Connection | None = None
+
+    def _get_conn(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._conn = sqlite3.connect(str(self._db_path))
+            self._conn.row_factory = sqlite3.Row
+            self._conn.executescript(_SCHEMA)
+        return self._conn
+
+    def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+    def _row_to_task(self, row: sqlite3.Row) -> Task:
+        status_raw = row["status"]
+        try:
+            status = AgentStatus(status_raw)
+        except ValueError:
+            status = AgentStatus.PLANNED
+        return Task(
+            id=row["id"],
+            title=row["title"],
+            description=row["description"] or "",
+            status=status,
+            branch=row["branch"] or "",
+            repos=json.loads(row["repos"] or "[]"),
+            workspace=row["workspace"] or "",
+            session_id=row["session_id"] or "",
+            column_order=row["column_order"] or 0,
+            created_at=row["created_at"] or "",
+            updated_at=row["updated_at"] or "",
+            launched_at=row["launched_at"] or "",
+            completed_at=row["completed_at"] or "",
+            config=json.loads(row["config"] or "{}"),
+        )
+
+    def add(self, task: Task) -> None:
+        """Insert a new task."""
+        conn = self._get_conn()
+        conn.execute(
+            """INSERT INTO tasks
+               (id, title, description, status, branch, repos, workspace,
+                session_id, column_order, created_at, updated_at,
+                launched_at, completed_at, config)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                task.id,
+                task.title,
+                task.description,
+                task.status.value,
+                task.branch,
+                json.dumps(task.repos),
+                task.workspace,
+                task.session_id,
+                task.column_order,
+                task.created_at,
+                task.updated_at,
+                task.launched_at,
+                task.completed_at,
+                json.dumps(task.config),
+            ),
+        )
+        conn.commit()
+
+    def get(self, task_id: str) -> Task | None:
+        """Get a task by ID."""
+        conn = self._get_conn()
+        row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        if row is None:
+            return None
+        return self._row_to_task(row)
+
+    def list_active(self) -> list[Task]:
+        """List all non-archived tasks, ordered by column_order."""
+        conn = self._get_conn()
+        rows = conn.execute(
+            "SELECT * FROM tasks WHERE status != 'ARCHIVED' ORDER BY column_order, created_at",
+        ).fetchall()
+        return [self._row_to_task(r) for r in rows]
+
+    def list_by_status(self, status: AgentStatus) -> list[Task]:
+        """List tasks with a specific status."""
+        conn = self._get_conn()
+        rows = conn.execute(
+            "SELECT * FROM tasks WHERE status = ? ORDER BY column_order, created_at",
+            (status.value,),
+        ).fetchall()
+        return [self._row_to_task(r) for r in rows]
+
+    def update_status(self, task_id: str, status: AgentStatus) -> None:
+        """Update a task's status."""
+        conn = self._get_conn()
+        now = _now()
+        extra = {}
+        if status == AgentStatus.DONE:
+            extra["completed_at"] = now
+        conn.execute(
+            "UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?",
+            (status.value, now, task_id),
+        )
+        if extra:
+            for col, val in extra.items():
+                conn.execute(
+                    f"UPDATE tasks SET {col} = ? WHERE id = ?",  # noqa: S608
+                    (val, task_id),
+                )
+        conn.commit()
+
+    def update_field(self, task_id: str, **fields: str) -> None:
+        """Update arbitrary fields on a task."""
+        conn = self._get_conn()
+        now = _now()
+        fields["updated_at"] = now
+        sets = ", ".join(f"{k} = ?" for k in fields)
+        vals = list(fields.values()) + [task_id]
+        conn.execute(f"UPDATE tasks SET {sets} WHERE id = ?", vals)  # noqa: S608
+        conn.commit()
+
+    def link_session(self, task_id: str, session_id: str) -> None:
+        """Link an agent session to a task."""
+        self.update_field(task_id, session_id=session_id)
+
+    def find_by_session(self, session_id: str) -> Task | None:
+        """Find a task linked to a specific agent session."""
+        conn = self._get_conn()
+        row = conn.execute("SELECT * FROM tasks WHERE session_id = ?", (session_id,)).fetchone()
+        if row is None:
+            return None
+        return self._row_to_task(row)
+
+    def find_by_workspace(self, workspace: str) -> Task | None:
+        """Find a task linked to a specific workspace name."""
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT * FROM tasks WHERE workspace = ? AND status NOT IN ('DONE', 'ARCHIVED')",
+            (workspace,),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_task(row)
+
+    def delete(self, task_id: str) -> None:
+        """Delete a task permanently."""
+        conn = self._get_conn()
+        conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
+        conn.commit()
+
+    def archive(self, task_id: str) -> None:
+        """Archive a task (soft delete)."""
+        self.update_status(task_id, AgentStatus.ARCHIVED)

--- a/src/grove/dash/widgets/confirm_modal.py
+++ b/src/grove/dash/widgets/confirm_modal.py
@@ -1,0 +1,53 @@
+"""Simple yes/no confirmation modal."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Label
+
+
+class ConfirmModal(ModalScreen[bool]):
+    """Modal that asks a yes/no question."""
+
+    DEFAULT_CSS = """
+    ConfirmModal {
+        align: center middle;
+    }
+
+    #confirm-container {
+        width: 50;
+        height: auto;
+        border: round $error;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #confirm-container Label {
+        width: 100%;
+        text-align: center;
+    }
+    """
+
+    BINDINGS = [
+        Binding("y", "confirm", "Yes"),
+        Binding("n", "cancel", "No"),
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, message: str) -> None:
+        super().__init__()
+        self._message = message
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="confirm-container"):
+            yield Label(f"\n{self._message}\n")
+            yield Label("[dim]y[/] yes  [dim]n[/] no  [dim]esc[/] cancel")
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)

--- a/src/grove/dash/widgets/header_bar.py
+++ b/src/grove/dash/widgets/header_bar.py
@@ -25,7 +25,7 @@ class HeaderBar(Static):
 
     def update_summary(self, summary: StatusSummary) -> None:
         self._summary = summary
-        parts = [f"[bold {_FG}]Grove Dashboard[/]  "]
+        parts = [f"[bold {_FG}]\u26a1\ufe0e gw dash[/]  "]
 
         if summary.total == 0:
             parts.append(f"[{_GREY}]No agents[/]")

--- a/src/grove/dash/widgets/kanban_board.py
+++ b/src/grove/dash/widgets/kanban_board.py
@@ -1,0 +1,187 @@
+"""KanbanBoard widget — horizontal layout of KanbanColumns."""
+
+from __future__ import annotations
+
+import logging
+
+from textual.containers import Horizontal
+
+from grove.dash.constants import KANBAN_COLUMNS
+from grove.dash.models import AgentState
+from grove.dash.store import Task
+from grove.dash.widgets.kanban_column import KanbanColumn
+from grove.dash.widgets.task_card import TaskCard
+
+log = logging.getLogger("grove.dash")
+
+
+class KanbanBoard(Horizontal):
+    """Horizontal layout of kanban columns, sorted by agent status."""
+
+    DEFAULT_CSS = """
+    KanbanBoard {
+        width: 1fr;
+        height: 1fr;
+    }
+    """
+
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self._columns: dict[str, KanbanColumn] = {}
+
+    def compose(self):
+        for col_id, title, _statuses in KANBAN_COLUMNS:
+            col = KanbanColumn(col_id, title)
+            self._columns[col_id] = col
+            yield col
+
+    def update_board(
+        self,
+        agents: list[AgentState],
+        tasks: list[Task] | None = None,
+    ) -> None:
+        """Distribute agents and tasks across columns by status."""
+        tasks = tasks or []
+
+        # Build linked set: session_ids that have a task
+        linked_sessions = {t.session_id for t in tasks if t.session_id}
+
+        # Bucket agents
+        agent_buckets: dict[str, list[AgentState]] = {col_id: [] for col_id, _, _ in KANBAN_COLUMNS}
+        for agent in agents:
+            # Skip agents that are linked to a task (task card takes priority)
+            if agent.session_id in linked_sessions:
+                continue
+            placed = False
+            for col_id, _title, statuses in KANBAN_COLUMNS:
+                if agent.status in statuses:
+                    agent_buckets[col_id].append(agent)
+                    placed = True
+                    break
+            if not placed:
+                agent_buckets["idle"].append(agent)
+
+        # Bucket tasks
+        task_buckets: dict[str, list[Task]] = {col_id: [] for col_id, _, _ in KANBAN_COLUMNS}
+        for task in tasks:
+            placed = False
+            # If task is linked to a running agent, use agent's status for column
+            effective_status = task.status
+            if task.session_id:
+                for agent in agents:
+                    if agent.session_id == task.session_id:
+                        effective_status = agent.status
+                        break
+
+            for col_id, _title, statuses in KANBAN_COLUMNS:
+                if effective_status in statuses:
+                    task_buckets[col_id].append(task)
+                    placed = True
+                    break
+            if not placed:
+                task_buckets["idle"].append(task)
+
+        # Update each column
+        for col_id, col in self._columns.items():
+            col.update_items(
+                agents=agent_buckets[col_id],
+                tasks=task_buckets[col_id],
+            )
+
+    # Backward compat
+    def update_agents(self, agents: list[AgentState]) -> None:
+        self.update_board(agents)
+
+    @property
+    def focused_card(self) -> TaskCard | None:
+        """Return the currently focused TaskCard."""
+        focused = self.screen.focused
+        if isinstance(focused, TaskCard):
+            return focused
+        return None
+
+    @property
+    def focused_agent(self) -> AgentState | None:
+        """Return the AgentState of the currently focused card."""
+        card = self.focused_card
+        if card:
+            return card.agent
+        return None
+
+    @property
+    def focused_task(self) -> Task | None:
+        """Return the Task of the currently focused card."""
+        card = self.focused_card
+        if card:
+            return card.task_data
+        return None
+
+    def focus_next_card(self) -> None:
+        self._move_focus(1)
+
+    def focus_prev_card(self) -> None:
+        self._move_focus(-1)
+
+    def focus_next_column(self) -> None:
+        self._move_column(1)
+
+    def focus_prev_column(self) -> None:
+        self._move_column(-1)
+
+    def _current_column_index(self) -> int | None:
+        focused = self.screen.focused
+        if not isinstance(focused, TaskCard):
+            return None
+        for i, (col_id, _, _) in enumerate(KANBAN_COLUMNS):
+            col = self._columns[col_id]
+            if focused in col.query(TaskCard):
+                return i
+        return None
+
+    def _move_focus(self, direction: int) -> None:
+        focused = self.screen.focused
+        if not isinstance(focused, TaskCard):
+            self._focus_first_available()
+            return
+
+        col_idx = self._current_column_index()
+        if col_idx is None:
+            return
+
+        col_id = KANBAN_COLUMNS[col_idx][0]
+        cards = list(self._columns[col_id].query(TaskCard))
+        if not cards:
+            return
+
+        try:
+            current = cards.index(focused)
+        except ValueError:
+            return
+
+        new_idx = max(0, min(len(cards) - 1, current + direction))
+        cards[new_idx].focus()
+
+    def _move_column(self, direction: int) -> None:
+        col_idx = self._current_column_index()
+        if col_idx is None:
+            col_idx = 0 if direction > 0 else len(KANBAN_COLUMNS) - 1
+        else:
+            col_idx += direction
+
+        col_count = len(KANBAN_COLUMNS)
+        col_idx = col_idx % col_count
+
+        for _ in range(col_count):
+            col_id = KANBAN_COLUMNS[col_idx][0]
+            cards = list(self._columns[col_id].query(TaskCard))
+            if cards:
+                cards[0].focus()
+                return
+            col_idx = (col_idx + direction) % col_count
+
+    def _focus_first_available(self) -> None:
+        for col_id, _, _ in KANBAN_COLUMNS:
+            cards = list(self._columns[col_id].query(TaskCard))
+            if cards:
+                cards[0].focus()
+                return

--- a/src/grove/dash/widgets/kanban_column.py
+++ b/src/grove/dash/widgets/kanban_column.py
@@ -1,0 +1,104 @@
+"""KanbanColumn widget — a scrollable column holding TaskCards."""
+
+from __future__ import annotations
+
+import logging
+
+from textual.containers import VerticalScroll
+
+from grove.dash.models import AgentState
+from grove.dash.store import Task
+from grove.dash.widgets.task_card import TaskCard
+
+log = logging.getLogger("grove.dash")
+
+
+class KanbanColumn(VerticalScroll):
+    """A single kanban column with a header and scrollable card list."""
+
+    DEFAULT_CSS = """
+    KanbanColumn {
+        width: 1fr;
+        height: 1fr;
+        border: round $panel;
+        border-title-color: $primary;
+        border-title-style: bold;
+        padding: 0;
+    }
+
+    KanbanColumn:focus-within {
+        border: round $primary;
+    }
+    """
+
+    def __init__(
+        self,
+        column_id: str,
+        title: str,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(id=f"col-{column_id}", **kwargs)
+        self.column_id = column_id
+        self.column_title = title
+        self._item_keys: list[str] = []
+        self.border_title = title
+
+    def update_items(
+        self,
+        agents: list[AgentState] | None = None,
+        tasks: list[Task] | None = None,
+    ) -> None:
+        """Sync cards to match given agents and tasks."""
+        agents = agents or []
+        tasks = tasks or []
+
+        # Build ordered list of (key, agent_or_none, task_or_none)
+        items: list[tuple[str, AgentState | None, Task | None]] = []
+        for t in tasks:
+            items.append((f"task-{t.id}", None, t))
+        for a in agents:
+            items.append((f"agent-{a.session_id}", a, None))
+
+        new_keys = [item[0] for item in items]
+        cards = list(self.query(TaskCard))
+
+        if new_keys == self._item_keys and len(cards) == len(items):
+            # Same items — update in place
+            for i, (_key, agent, task) in enumerate(items):
+                try:
+                    if agent:
+                        cards[i].update_agent(agent)
+                    elif task:
+                        cards[i].update_task(task)
+                except Exception:
+                    log.exception("Failed to update card %d in %s", i, self.column_id)
+        else:
+            # Structural change — remove all, then mount fresh (no IDs)
+            self._item_keys = new_keys
+            for card in cards:
+                try:
+                    card.remove()
+                except Exception:
+                    log.exception("Failed to remove card in %s", self.column_id)
+            for _key, agent, task in items:
+                self.mount(TaskCard(agent=agent, task_data=task))
+
+        # Update column title with count
+        count = len(items)
+        self.border_title = f"{self.column_title} ({count})" if count else self.column_title
+
+    # Keep backward compat
+    def update_agents(self, agents: list[AgentState]) -> None:
+        self.update_items(agents=agents)
+
+    @property
+    def card_count(self) -> int:
+        return len(self._item_keys)
+
+    @property
+    def focused_card(self) -> TaskCard | None:
+        """Return the currently focused card, if any."""
+        for card in self.query(TaskCard):
+            if card.has_focus:
+                return card
+        return None

--- a/src/grove/dash/widgets/task_card.py
+++ b/src/grove/dash/widgets/task_card.py
@@ -1,0 +1,230 @@
+"""TaskCard widget — a kanban card for an agent session or a planned task."""
+
+from __future__ import annotations
+
+from textual.widgets import Static
+
+from grove.dash.constants import (
+    AQUA,
+    FG,
+    GREEN,
+    GREY,
+    ORANGE,
+    PURPLE,
+    RED,
+    STATUS_DISPLAY,
+    AgentStatus,
+)
+from grove.dash.models import AgentState
+from grove.dash.store import Task
+
+
+def _idle_ago(seconds: float) -> str:
+    if seconds < 5:
+        return ""
+    if seconds < 60:
+        return f"{int(seconds)}s"
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m"
+    return f"{int(seconds // 3600)}h"
+
+
+class TaskCard(Static, can_focus=True):
+    """A kanban card for a single agent session or planned task."""
+
+    DEFAULT_CSS = """
+    TaskCard {
+        width: 100%;
+        height: auto;
+        min-height: 3;
+        padding: 0 1;
+        margin: 0;
+        border: round $panel;
+    }
+
+    TaskCard:focus {
+        border: round $primary;
+    }
+
+    TaskCard.status-working {
+        border-left: outer #b8bb26;
+    }
+    TaskCard.status-waiting-permission {
+        border-left: outer #fb4934;
+    }
+    TaskCard.status-waiting-answer {
+        border-left: outer #fabd2f;
+    }
+    TaskCard.status-error {
+        border-left: outer #fe8019;
+    }
+    TaskCard.status-idle {
+        border-left: outer #928374;
+    }
+    TaskCard.status-planned {
+        border-left: outer #83a598;
+    }
+    TaskCard.status-provisioning {
+        border-left: outer #8ec07c;
+    }
+    TaskCard.status-done {
+        border-left: outer #b8bb26;
+    }
+
+    TaskCard:focus.status-working {
+        border: round #b8bb26;
+        border-left: outer #b8bb26;
+    }
+    TaskCard:focus.status-waiting-permission {
+        border: round #fb4934;
+        border-left: outer #fb4934;
+    }
+    TaskCard:focus.status-waiting-answer {
+        border: round #fabd2f;
+        border-left: outer #fabd2f;
+    }
+    TaskCard:focus.status-error {
+        border: round #fe8019;
+        border-left: outer #fe8019;
+    }
+    TaskCard:focus.status-planned {
+        border: round #83a598;
+        border-left: outer #83a598;
+    }
+    """
+
+    def __init__(
+        self,
+        agent: AgentState | None = None,
+        task_data: Task | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.agent = agent
+        self.task_data = task_data
+        self._apply_status_class()
+
+    @property
+    def status(self) -> AgentStatus:
+        if self.agent:
+            return self.agent.status
+        if self.task_data:
+            return self.task_data.status
+        return AgentStatus.IDLE
+
+    @property
+    def card_id(self) -> str:
+        """Unique ID for this card (agent session_id or task id)."""
+        if self.agent:
+            return self.agent.session_id
+        if self.task_data:
+            return self.task_data.id
+        return ""
+
+    def _apply_status_class(self) -> None:
+        """Set CSS class based on status."""
+        for cls in list(self.classes):
+            if cls.startswith("status-"):
+                self.remove_class(cls)
+        css_status = self.status.value.lower().replace("_", "-")
+        self.add_class(f"status-{css_status}")
+
+    def update_agent(self, agent: AgentState) -> None:
+        """Update the card with new agent state."""
+        self.agent = agent
+        self._apply_status_class()
+        self.update(self._render_card())
+
+    def update_task(self, task_data: Task) -> None:
+        """Update the card with new task data."""
+        self.task_data = task_data
+        self._apply_status_class()
+        self.update(self._render_card())
+
+    def on_mount(self) -> None:
+        self.update(self._render_card())
+
+    def _render_card(self) -> str:
+        if self.agent:
+            return self._render_agent_card()
+        if self.task_data:
+            return self._render_task_card()
+        return f"[{GREY}]Empty card[/]"
+
+    def _render_agent_card(self) -> str:
+        a = self.agent
+        assert a is not None
+        color, label = STATUS_DISPLAY.get(a.status, (GREY, "?"))
+
+        # Line 1: Name + status badge
+        name = a.display_name or a.session_id[:12]
+        lines = [f"[bold {FG}]{name}[/]  [{color}]{label}[/]"]
+
+        # Line 2: Branch + tool info
+        parts: list[str] = []
+        if a.git_branch:
+            parts.append(f"[{AQUA}]{a.git_branch}[/]")
+        if a.last_tool:
+            ago = _idle_ago(a.idle_seconds)
+            ago_str = f" [{GREY}]{ago}[/]" if ago else ""
+            parts.append(f"{a.last_tool}{ago_str}")
+        if parts:
+            lines.append("  ".join(parts))
+
+        # Line 3: Counts + sparkline
+        meta: list[str] = []
+        if a.tool_count:
+            meta.append(f"[{GREY}]{a.tool_count} tools[/]")
+        if a.error_count:
+            meta.append(f"[{ORANGE}]{a.error_count} err[/]")
+        if a.subagent_count:
+            meta.append(f"[{AQUA}]+{a.subagent_count} sub[/]")
+        if a.uptime:
+            meta.append(f"[{GREY}]{a.uptime}[/]")
+        if a.sparkline:
+            meta.append(f"[{GREEN}]{a.sparkline}[/]")
+        if meta:
+            lines.append("  ".join(meta))
+
+        # Line 4: Prompt snippet
+        if a.initial_prompt:
+            prompt = a.initial_prompt.replace("\n", " ")[:60]
+            lines.append(f"[{GREY}]{prompt}[/]")
+
+        # Special states
+        if a.status == AgentStatus.WAITING_PERMISSION and a.tool_request_summary:
+            summary = a.tool_request_summary.splitlines()[0][:60]
+            lines.append(f"[{RED}]PERM: {a.last_tool}[/] [{GREY}]{summary}[/]")
+
+        if a.status == AgentStatus.ERROR and a.last_error:
+            err = a.last_error.replace("\n", " ")[:60]
+            lines.append(f"[{ORANGE}]{err}[/]")
+
+        if a.notification_message:
+            lines.append(f"[{PURPLE}]{a.notification_message[:60]}[/]")
+
+        return "\n".join(lines)
+
+    def _render_task_card(self) -> str:
+        t = self.task_data
+        assert t is not None
+        color, label = STATUS_DISPLAY.get(t.status, (GREY, "?"))
+
+        # Line 1: Title + status
+        lines = [f"[bold {FG}]{t.title}[/]  [{color}]{label}[/]"]
+
+        # Line 2: Branch
+        if t.branch:
+            lines.append(f"[{AQUA}]{t.branch}[/]")
+
+        # Line 3: Repos
+        if t.repos:
+            repos = ", ".join(t.repos[:3])
+            lines.append(f"[{GREY}]{repos}[/]")
+
+        # Line 4: Description snippet
+        if t.description:
+            desc = t.description.replace("\n", " ")[:80]
+            lines.append(f"[{GREY}]{desc}[/]")
+
+        return "\n".join(lines)

--- a/src/grove/dash/widgets/task_modal.py
+++ b/src/grove/dash/widgets/task_modal.py
@@ -1,0 +1,250 @@
+"""Task create/edit modal — input form for task cards."""
+
+from __future__ import annotations
+
+import logging
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Input, Label, SelectionList, Static, TextArea
+
+from grove.dash.store import Task
+
+log = logging.getLogger("grove.dash")
+
+
+def _load_repo_choices() -> tuple[list[str], dict[str, list[str]]]:
+    """Load available repos and presets from Grove config.
+
+    Returns (repo_names, presets_dict).
+    """
+    try:
+        from grove import config, discover
+
+        cfg = config.load_config()
+        available = discover.find_all_repos(cfg.repo_dirs)
+        repo_names = sorted(available.keys())
+        presets = dict(cfg.presets) if cfg.presets else {}
+        return repo_names, presets
+    except Exception:
+        log.exception("Failed to load repo config")
+        return [], {}
+
+
+class TaskModal(ModalScreen[Task | None]):
+    """Modal dialog for creating or editing a task card."""
+
+    DEFAULT_CSS = """
+    TaskModal {
+        align: center middle;
+    }
+
+    #task-modal-container {
+        width: 70;
+        height: auto;
+        max-height: 30;
+        border: round $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    .field-label {
+        width: 100%;
+        height: 1;
+        color: $text-muted;
+        margin: 1 0 0 0;
+    }
+
+    .field-label.first {
+        margin: 0;
+    }
+
+    #task-title {
+        width: 100%;
+        height: 1;
+        border: none;
+        background: $background;
+        padding: 0 1;
+    }
+
+    #task-branch {
+        width: 100%;
+        height: 1;
+        border: none;
+        background: $background;
+        padding: 0 1;
+    }
+
+    #task-description {
+        width: 100%;
+        height: 5;
+        border: none;
+        background: $background;
+    }
+
+    #preset-bar {
+        width: 100%;
+        height: 1;
+        margin: 0;
+    }
+
+    .preset-btn {
+        min-width: 8;
+        height: 1;
+        border: none;
+        background: $panel;
+        color: $text;
+        padding: 0 1;
+        margin: 0 1 0 0;
+    }
+
+    .preset-btn:hover {
+        background: $primary;
+    }
+
+    #repo-list {
+        width: 100%;
+        height: 8;
+        border: none;
+        background: $background;
+    }
+
+    #task-modal-hint {
+        width: 100%;
+        height: 1;
+        color: $text-muted;
+        margin: 1 0 0 0;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, existing: Task | None = None) -> None:
+        super().__init__()
+        self._existing = existing
+        self._repo_names, self._presets = _load_repo_choices()
+
+    def compose(self) -> ComposeResult:
+        e = self._existing
+        title = "Edit Task" if e else "Create Task"
+        selected_repos = set(e.repos) if e else set()
+
+        with Vertical(id="task-modal-container"):
+            yield Label(f"[bold]{title}[/]", classes="field-label first")
+
+            yield Label("Title", classes="field-label")
+            yield Input(
+                value=e.title if e else "",
+                placeholder="e.g. add-bulk-import",
+                id="task-title",
+            )
+
+            yield Label("Branch", classes="field-label")
+            yield Input(
+                value=e.branch if e else "",
+                placeholder="defaults to feat/<title>",
+                id="task-branch",
+            )
+
+            yield Label("Description / Prompt", classes="field-label")
+            yield TextArea(
+                e.description if e else "",
+                id="task-description",
+            )
+
+            if self._repo_names:
+                yield Label("Repos", classes="field-label")
+
+                # Preset buttons
+                if self._presets:
+                    with Horizontal(id="preset-bar"):
+                        for name in self._presets:
+                            yield Static(
+                                f"[dim]({name})[/]",
+                                classes="preset-btn",
+                                id=f"preset-{name}",
+                            )
+
+                # Repo selection list
+                selections = [(repo, repo, repo in selected_repos) for repo in self._repo_names]
+                yield SelectionList(*selections, id="repo-list")
+
+            yield Label(
+                "[dim]tab[/] next  "
+                "[dim]space[/] toggle repo  "
+                "[dim]ctrl+s[/] save  "
+                "[dim]esc[/] cancel",
+                id="task-modal-hint",
+            )
+
+    def on_mount(self) -> None:
+        self.query_one("#task-title", Input).focus()
+
+    def on_static_click(self, event: Static.Click) -> None:
+        """Handle preset button clicks."""
+        widget = event.widget
+        if not widget.id or not widget.id.startswith("preset-"):
+            return
+        preset_name = widget.id[len("preset-") :]
+        repos = self._presets.get(preset_name, [])
+        if not repos:
+            return
+
+        # Toggle the preset repos in the selection list
+        try:
+            repo_list = self.query_one("#repo-list", SelectionList)
+        except Exception:
+            return
+
+        repo_set = set(repos)
+        for repo_name in self._repo_names:
+            if repo_name in repo_set:
+                repo_list.select(repo_name)
+            else:
+                repo_list.deselect(repo_name)
+
+    def key_ctrl_s(self) -> None:
+        """Save the task."""
+        self._save()
+
+    def _save(self) -> None:
+        title = self.query_one("#task-title", Input).value.strip()
+        if not title:
+            self.dismiss(None)
+            return
+
+        branch = self.query_one("#task-branch", Input).value.strip()
+        if not branch:
+            branch = f"feat/{title}" if not title.startswith("feat/") else title
+        description = self.query_one("#task-description", TextArea).text.strip()
+
+        # Collect selected repos
+        repos: list[str] = []
+        try:
+            repo_list = self.query_one("#repo-list", SelectionList)
+            repos = list(repo_list.selected)
+        except Exception:
+            pass
+
+        if self._existing:
+            task = self._existing
+            task.title = title
+            task.branch = branch
+            task.description = description
+            task.repos = repos
+        else:
+            task = Task.create(
+                title=title,
+                branch=branch,
+                description=description,
+                repos=repos,
+            )
+
+        self.dismiss(task)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)

--- a/src/grove/dash/widgets/task_modal.py
+++ b/src/grove/dash/widgets/task_modal.py
@@ -6,9 +6,9 @@ import logging
 
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal, Vertical
+from textual.containers import Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Input, Label, SelectionList, Static, TextArea
+from textual.widgets import Input, Label, OptionList, SelectionList, TextArea
 
 from grove.dash.store import Task
 
@@ -34,7 +34,11 @@ def _load_repo_choices() -> tuple[list[str], dict[str, list[str]]]:
 
 
 class TaskModal(ModalScreen[Task | None]):
-    """Modal dialog for creating or editing a task card."""
+    """Modal dialog for creating or editing a task card.
+
+    Single-screen form with inline preset picker and repo selection.
+    Tab flows naturally through all fields.
+    """
 
     DEFAULT_CSS = """
     TaskModal {
@@ -44,7 +48,7 @@ class TaskModal(ModalScreen[Task | None]):
     #task-modal-container {
         width: 70;
         height: auto;
-        max-height: 30;
+        max-height: 38;
         border: round $primary;
         background: $surface;
         padding: 1 2;
@@ -79,29 +83,30 @@ class TaskModal(ModalScreen[Task | None]):
 
     #task-description {
         width: 100%;
-        height: 5;
+        height: 4;
         border: none;
         background: $background;
     }
 
-    #preset-bar {
+    #preset-list {
+        width: 100%;
+        height: auto;
+        max-height: 5;
+        border: none;
+        background: $background;
+    }
+
+    #repo-search {
         width: 100%;
         height: 1;
-        margin: 0;
-    }
-
-    .preset-btn {
-        min-width: 8;
-        height: 1;
         border: none;
-        background: $panel;
-        color: $text;
+        background: $background;
         padding: 0 1;
-        margin: 0 1 0 0;
+        display: none;
     }
 
-    .preset-btn:hover {
-        background: $primary;
+    #repo-search.visible {
+        display: block;
     }
 
     #repo-list {
@@ -120,13 +125,15 @@ class TaskModal(ModalScreen[Task | None]):
     """
 
     BINDINGS = [
-        Binding("escape", "cancel", "Cancel"),
+        Binding("escape", "cancel_or_search", "Cancel"),
+        Binding("slash", "start_search", "Search", show=False),
     ]
 
     def __init__(self, existing: Task | None = None) -> None:
         super().__init__()
         self._existing = existing
         self._repo_names, self._presets = _load_repo_choices()
+        self._searching = False
 
     def compose(self) -> ComposeResult:
         e = self._existing
@@ -154,28 +161,29 @@ class TaskModal(ModalScreen[Task | None]):
             yield TextArea(
                 e.description if e else "",
                 id="task-description",
+                tab_behavior="focus",
             )
 
             if self._repo_names:
-                yield Label("Repos", classes="field-label")
-
-                # Preset buttons
+                # Preset picker (tier 1)
                 if self._presets:
-                    with Horizontal(id="preset-bar"):
-                        for name in self._presets:
-                            yield Static(
-                                f"[dim]({name})[/]",
-                                classes="preset-btn",
-                                id=f"preset-{name}",
-                            )
+                    yield Label("Presets", classes="field-label")
+                    yield OptionList(
+                        *list(self._presets.keys()),
+                        id="preset-list",
+                    )
 
-                # Repo selection list
+                # Repo multi-select (tier 2) with search
+                yield Label("Repos [dim](/[/] search)", classes="field-label")
+                yield Input(placeholder="filter repos...", id="repo-search")
                 selections = [(repo, repo, repo in selected_repos) for repo in self._repo_names]
                 yield SelectionList(*selections, id="repo-list")
 
             yield Label(
                 "[dim]tab[/] next  "
-                "[dim]space[/] toggle repo  "
+                "[dim]enter[/] preset  "
+                "[dim]space[/] toggle  "
+                "[dim]/[/] filter  "
                 "[dim]ctrl+s[/] save  "
                 "[dim]esc[/] cancel",
                 id="task-modal-hint",
@@ -184,32 +192,88 @@ class TaskModal(ModalScreen[Task | None]):
     def on_mount(self) -> None:
         self.query_one("#task-title", Input).focus()
 
-    def on_static_click(self, event: Static.Click) -> None:
-        """Handle preset button clicks."""
-        widget = event.widget
-        if not widget.id or not widget.id.startswith("preset-"):
-            return
-        preset_name = widget.id[len("preset-") :]
+    # --- Preset selection ---
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        preset_name = str(event.option.prompt)
         repos = self._presets.get(preset_name, [])
         if not repos:
             return
 
-        # Toggle the preset repos in the selection list
+        log.info("MODAL: preset selected %r -> %r", preset_name, repos)
+
         try:
-            repo_list = self.query_one("#repo-list", SelectionList)
+            sel = self.query_one("#repo-list", SelectionList)
         except Exception:
+            log.exception("Failed to find repo list")
             return
 
         repo_set = set(repos)
         for repo_name in self._repo_names:
             if repo_name in repo_set:
-                repo_list.select(repo_name)
+                sel.select(repo_name)
             else:
-                repo_list.deselect(repo_name)
+                sel.deselect(repo_name)
+
+    # --- Repo search ---
+
+    def action_start_search(self) -> None:
+        # Only activate when repo-list is focused
+        focused = self.app.focused
+        try:
+            repo_list = self.query_one("#repo-list", SelectionList)
+        except Exception:
+            return
+        if focused is not repo_list:
+            return
+
+        search = self.query_one("#repo-search", Input)
+        search.add_class("visible")
+        search.value = ""
+        search.focus()
+        self._searching = True
+        log.info("MODAL: search started")
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id != "repo-search":
+            return
+        self._filter_repos(event.value)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id != "repo-search":
+            return
+        self._dismiss_search()
+
+    def _dismiss_search(self) -> None:
+        search = self.query_one("#repo-search", Input)
+        search.remove_class("visible")
+        self._searching = False
+        self.query_one("#repo-list", SelectionList).focus()
+        log.info("MODAL: search dismissed")
+
+    def _filter_repos(self, query: str) -> None:
+        sel = self.query_one("#repo-list", SelectionList)
+        q = query.lower().strip()
+
+        # Remember currently selected values before clearing
+        currently_selected = set(sel.selected)
+
+        sel.clear_options()
+        for repo in self._repo_names:
+            if not q or q in repo.lower():
+                sel.add_option((repo, repo, repo in currently_selected))
+
+    # --- Save / cancel ---
 
     def key_ctrl_s(self) -> None:
         """Save the task."""
         self._save()
+
+    def action_cancel_or_search(self) -> None:
+        if self._searching:
+            self._dismiss_search()
+        else:
+            self.dismiss(None)
 
     def _save(self) -> None:
         title = self.query_one("#task-title", Input).value.strip()
@@ -245,6 +309,3 @@ class TaskModal(ModalScreen[Task | None]):
             )
 
         self.dismiss(task)
-
-    def action_cancel(self) -> None:
-        self.dismiss(None)

--- a/src/grove/dash/zellij.py
+++ b/src/grove/dash/zellij.py
@@ -93,6 +93,57 @@ def deny() -> bool:
     return write_chars("n") and send_enter()
 
 
+def new_tab(
+    name: str,
+    cwd: str,
+    command: str | None = None,
+    command_args: list[str] | None = None,
+) -> bool:
+    """Open a new Zellij tab and send cd + command via write-chars.
+
+    Falls back to write-chars approach since Zellij --cwd and --layout
+    can behave unpredictably across versions.
+    """
+    import shlex
+    import time
+
+    try:
+        result = subprocess.run(
+            ["zellij", "action", "new-tab", "--name", name],
+            capture_output=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            log.info("ZELLIJ new-tab failed: %s", result.stderr)
+            return False
+
+        # Wait for shell to initialize
+        time.sleep(1.0)
+
+        # cd into workspace
+        write_chars(f"cd {shlex.quote(cwd)}")
+        send_enter()
+        time.sleep(0.3)
+
+        # Run command if provided
+        if command:
+            cmd = command
+            if command_args:
+                cmd += " " + " ".join(shlex.quote(a) for a in command_args)
+            write_chars(cmd)
+            send_enter()
+
+            # Auto-accept the workspace trust prompt ("Yes, I trust this folder")
+            # which is pre-selected as option 1. Just send Enter after claude loads.
+            time.sleep(3.0)
+            send_enter()
+
+        return True
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        log.exception("ZELLIJ new-tab error")
+        return False
+
+
 def _extract_workspace_name(cwd: str) -> str:
     """Extract Grove workspace name from a CWD path.
 

--- a/tests/test_dash_store.py
+++ b/tests/test_dash_store.py
@@ -1,0 +1,147 @@
+"""Tests for grove.dash.store — SQLite task persistence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from grove.dash.constants import AgentStatus
+from grove.dash.store import Task, TaskStore
+
+
+def _tmp_store(tmp_path: Path) -> TaskStore:
+    return TaskStore(db_path=tmp_path / "tasks.db")
+
+
+def test_create_and_get(tmp_path: Path) -> None:
+    store = _tmp_store(tmp_path)
+    task = Task.create(title="Add login page", branch="feat/login")
+    store.add(task)
+
+    loaded = store.get(task.id)
+    assert loaded is not None
+    assert loaded.title == "Add login page"
+    assert loaded.branch == "feat/login"
+    assert loaded.status == AgentStatus.PLANNED
+    assert loaded.created_at
+    store.close()
+
+
+def test_list_active(tmp_path: Path) -> None:
+    store = _tmp_store(tmp_path)
+    t1 = Task.create(title="Task 1")
+    t2 = Task.create(title="Task 2")
+    t3 = Task.create(title="Task 3")
+    store.add(t1)
+    store.add(t2)
+    store.add(t3)
+
+    # Archive one
+    store.archive(t2.id)
+
+    active = store.list_active()
+    assert len(active) == 2
+    assert {t.title for t in active} == {"Task 1", "Task 3"}
+    store.close()
+
+
+def test_update_status(tmp_path: Path) -> None:
+    store = _tmp_store(tmp_path)
+    task = Task.create(title="Bug fix")
+    store.add(task)
+
+    store.update_status(task.id, AgentStatus.WORKING)
+    loaded = store.get(task.id)
+    assert loaded is not None
+    assert loaded.status == AgentStatus.WORKING
+
+    store.update_status(task.id, AgentStatus.DONE)
+    loaded = store.get(task.id)
+    assert loaded is not None
+    assert loaded.status == AgentStatus.DONE
+    assert loaded.completed_at  # should be set
+    store.close()
+
+
+def test_link_session(tmp_path: Path) -> None:
+    store = _tmp_store(tmp_path)
+    task = Task.create(title="Feature")
+    store.add(task)
+
+    store.link_session(task.id, "session-abc")
+
+    by_session = store.find_by_session("session-abc")
+    assert by_session is not None
+    assert by_session.id == task.id
+    store.close()
+
+
+def test_find_by_workspace(tmp_path: Path) -> None:
+    store = _tmp_store(tmp_path)
+    task = Task.create(title="WS task")
+    store.add(task)
+    store.update_field(task.id, workspace="my-workspace")
+
+    found = store.find_by_workspace("my-workspace")
+    assert found is not None
+    assert found.id == task.id
+
+    # Archived tasks should not be found
+    store.archive(task.id)
+    found = store.find_by_workspace("my-workspace")
+    assert found is None
+    store.close()
+
+
+def test_list_by_status(tmp_path: Path) -> None:
+    store = _tmp_store(tmp_path)
+    t1 = Task.create(title="Planned")
+    t2 = Task.create(title="Working")
+    store.add(t1)
+    store.add(t2)
+    store.update_status(t2.id, AgentStatus.WORKING)
+
+    planned = store.list_by_status(AgentStatus.PLANNED)
+    assert len(planned) == 1
+    assert planned[0].title == "Planned"
+
+    working = store.list_by_status(AgentStatus.WORKING)
+    assert len(working) == 1
+    assert working[0].title == "Working"
+    store.close()
+
+
+def test_delete(tmp_path: Path) -> None:
+    store = _tmp_store(tmp_path)
+    task = Task.create(title="Temporary")
+    store.add(task)
+    assert store.get(task.id) is not None
+
+    store.delete(task.id)
+    assert store.get(task.id) is None
+    store.close()
+
+
+def test_repos_roundtrip(tmp_path: Path) -> None:
+    store = _tmp_store(tmp_path)
+    task = Task.create(title="Multi-repo", repos=["api", "web", "worker"])
+    store.add(task)
+
+    loaded = store.get(task.id)
+    assert loaded is not None
+    assert loaded.repos == ["api", "web", "worker"]
+    store.close()
+
+
+def test_config_roundtrip(tmp_path: Path) -> None:
+    store = _tmp_store(tmp_path)
+    task = Task.create(
+        title="Custom config",
+        config={"permissions": "dangerously-skip", "model": "opus"},
+    )
+    store.add(task)
+
+    loaded = store.get(task.id)
+    assert loaded is not None
+    assert loaded.config["permissions"] == "dangerously-skip"
+    assert loaded.config["model"] == "opus"
+    store.close()


### PR DESCRIPTION
## Summary
- Transform `gw dash` from a read-only agent table into an interactive kanban board with 5 columns (Planned/Active/Attention/Idle/Done)
- Add SQLite-backed task persistence with create/edit/delete/done lifecycle
- Add task launch flow: provision workspace + open Zellij tab + start Claude agent (experimental alpha)
- Delete now also cleans up linked workspaces
- Gruvbox dark theme, h/j/k/l navigation, `/` search filtering

## Known issues (alpha)
- **Enter key conflict**: app-level `priority=True` enter binding can interfere with modal widgets
- **Setup script flash**: workspace provisioning output briefly visible before suppression kicks in  
- **New tab focus**: launched tab steals focus momentarily before jumping back to dashboard
- **Task modal UX**: repo preset/selection interaction is functional but clunky (TODO item added)
- **Claude trust prompt**: auto-accepted via timed Enter keystroke — fragile timing dependency

## Test plan
- [x] `just check` passes (328 tests, lint clean)
- [ ] Create task via `c`, fill fields, ctrl+s to save — card appears in Planned
- [ ] Edit task via `e`, delete via `x` with confirmation
- [ ] Start task via `s` — workspace created, Zellij tab opens, Claude starts
- [ ] Delete started task — workspace cleaned up
- [ ] Search with `/` filters both agents and tasks
- [ ] h/l switches columns, j/k navigates cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)