### PR TITLE
Fix hook commands breaking on Homebrew/uv upgrades

### DIFF
--- a/src/grove/cli.py
+++ b/src/grove/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -949,8 +950,6 @@ def _do_cleanup(ws_name: str) -> None:
     immediately without waiting for worktree removal to finish.
     If cleanup fails, ``gw doctor`` will catch the stale state.
     """
-    import shutil
-
     gw_path = shutil.which("gw")
     if gw_path:
         cmd = [gw_path, "delete", "--force", ws_name]

--- a/src/grove/cli.py
+++ b/src/grove/cli.py
@@ -949,8 +949,15 @@ def _do_cleanup(ws_name: str) -> None:
     immediately without waiting for worktree removal to finish.
     If cleanup fails, ``gw doctor`` will catch the stale state.
     """
+    import shutil
+
+    gw_path = shutil.which("gw")
+    if gw_path:
+        cmd = [gw_path, "delete", "--force", ws_name]
+    else:
+        cmd = [sys.executable, "-m", "grove", "delete", "--force", ws_name]
     subprocess.Popen(
-        [sys.executable, "-m", "grove", "delete", "--force", ws_name],
+        cmd,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         start_new_session=True,
@@ -1052,6 +1059,22 @@ def dash_main(ctx: typer.Context) -> None:
         from grove.dash.app import run_dashboard
 
         run_dashboard()
+
+
+@app.command("_hook", hidden=True)
+def _hook_entrypoint(
+    event: str = typer.Option(..., "--event", help="Hook event type"),
+) -> None:
+    """Internal hook handler invoked by Claude Code. Not for direct use."""
+    import json as _json
+
+    from grove.dash.hook import handle_event
+
+    try:
+        input_data = _json.load(sys.stdin)
+    except (ValueError, _json.JSONDecodeError):
+        return
+    handle_event(event, input_data)
 
 
 @dash_app.command("install")

--- a/src/grove/dash/installer.py
+++ b/src/grove/dash/installer.py
@@ -27,8 +27,11 @@ HOOK_EVENTS = [
     "TaskCompleted",
 ]
 
-# Marker to identify our hooks
+# Markers to identify our hooks.
+# _GROVE_MARKER matches the legacy format (python -m grove.dash) used before v0.13.
+# Can be removed once all users have re-run `gw dash install`.
 _GROVE_MARKER = "grove.dash"
+_GROVE_HOOK_CMD = "gw _hook"
 
 
 def _hook_command(event: str) -> str:
@@ -53,14 +56,14 @@ def _resolve_gw() -> str:
     gw_path = shutil.which("gw")
     if gw_path:
         return gw_path
-    # Fallback for dev installs
-    return f"{sys.executable} -m grove.cli"
+    # Fallback for dev installs — multi-token string, interpreted by shell
+    return f"{sys.executable} -m grove.dash"
 
 
 def _is_grove_hook(hook: dict) -> bool:
     """Check if a hook entry belongs to Grove (old or new format)."""
     cmd = hook.get("command", "")
-    return _GROVE_MARKER in cmd or "gw _hook" in cmd
+    return _GROVE_MARKER in cmd or _GROVE_HOOK_CMD in cmd
 
 
 def install_hooks(dry_run: bool = False) -> dict[str, list[str]]:

--- a/src/grove/dash/installer.py
+++ b/src/grove/dash/installer.py
@@ -27,11 +27,8 @@ HOOK_EVENTS = [
     "TaskCompleted",
 ]
 
-# Markers to identify our hooks.
-# _GROVE_MARKER matches the legacy format (python -m grove.dash) used before v0.13.
-# Can be removed once all users have re-run `gw dash install`.
-_GROVE_MARKER = "grove.dash"
-_GROVE_HOOK_CMD = "gw _hook"
+# Marker to identify our hooks
+_GROVE_MARKER = "gw _hook"
 
 
 def _hook_command(event: str) -> str:
@@ -61,9 +58,9 @@ def _resolve_gw() -> str:
 
 
 def _is_grove_hook(hook: dict) -> bool:
-    """Check if a hook entry belongs to Grove (old or new format)."""
+    """Check if a hook entry belongs to Grove."""
     cmd = hook.get("command", "")
-    return _GROVE_MARKER in cmd or _GROVE_HOOK_CMD in cmd
+    return _GROVE_MARKER in cmd
 
 
 def install_hooks(dry_run: bool = False) -> dict[str, list[str]]:

--- a/src/grove/dash/installer.py
+++ b/src/grove/dash/installer.py
@@ -32,15 +32,35 @@ _GROVE_MARKER = "grove.dash"
 
 
 def _hook_command(event: str) -> str:
-    """Build the hook command string for a given event."""
-    python = sys.executable
-    return f"GROVE_EVENT={event} {python} -m grove.dash --event {event}"
+    """Build the hook command string for a given event.
+
+    Uses the ``gw`` console-script entry point (stable across upgrades)
+    rather than the versioned Python interpreter path, which breaks when
+    Homebrew or uv upgrades Grove to a new version.
+    """
+    gw = _resolve_gw()
+    return f"GROVE_EVENT={event} {gw} _hook --event {event}"
+
+
+def _resolve_gw() -> str:
+    """Find the stable ``gw`` binary path.
+
+    Prefers ``shutil.which`` so we get the canonical PATH entry (e.g.
+    /opt/homebrew/bin/gw) rather than a version-specific Cellar path.
+    Falls back to ``sys.executable -m grove.dash`` for editable/dev installs
+    where ``gw`` might not be on PATH.
+    """
+    gw_path = shutil.which("gw")
+    if gw_path:
+        return gw_path
+    # Fallback for dev installs
+    return f"{sys.executable} -m grove.cli"
 
 
 def _is_grove_hook(hook: dict) -> bool:
-    """Check if a hook entry belongs to Grove."""
+    """Check if a hook entry belongs to Grove (old or new format)."""
     cmd = hook.get("command", "")
-    return _GROVE_MARKER in cmd
+    return _GROVE_MARKER in cmd or "gw _hook" in cmd
 
 
 def install_hooks(dry_run: bool = False) -> dict[str, list[str]]:

--- a/src/grove/dash/installer.py
+++ b/src/grove/dash/installer.py
@@ -29,6 +29,9 @@ HOOK_EVENTS = [
 
 # Marker to identify our hooks
 _GROVE_MARKER = "gw _hook"
+# Legacy marker from pre-v0.13 (used sys.executable + python -m grove.dash).
+# Needed so uninstall can clean up old hooks. Safe to remove in v0.14+.
+_LEGACY_MARKER = "grove.dash"
 
 
 def _hook_command(event: str) -> str:
@@ -60,7 +63,7 @@ def _resolve_gw() -> str:
 def _is_grove_hook(hook: dict) -> bool:
     """Check if a hook entry belongs to Grove."""
     cmd = hook.get("command", "")
-    return _GROVE_MARKER in cmd
+    return _GROVE_MARKER in cmd or _LEGACY_MARKER in cmd
 
 
 def install_hooks(dry_run: bool = False) -> dict[str, list[str]]:

--- a/tests/test_dash_installer.py
+++ b/tests/test_dash_installer.py
@@ -58,7 +58,7 @@ class TestInstallHooks:
         assert len(pre_rules) == 2
         all_cmds = [h["command"] for rule in pre_rules for h in rule.get("hooks", [])]
         assert "my-custom-hook" in all_cmds
-        assert any("grove.dash" in c or "gw _hook" in c for c in all_cmds)
+        assert any("gw _hook" in c for c in all_cmds)
 
         # Other settings preserved
         assert settings["other_setting"] is True
@@ -73,10 +73,7 @@ class TestInstallHooks:
         grove_rules = [
             rule
             for rule in pre_rules
-            if any(
-                "grove.dash" in h.get("command", "") or "gw _hook" in h.get("command", "")
-                for h in rule.get("hooks", [])
-            )
+            if any("gw _hook" in h.get("command", "") for h in rule.get("hooks", []))
         ]
         assert len(grove_rules) == 1
 
@@ -112,7 +109,10 @@ class TestUninstallHooks:
             "hooks": {
                 "PreToolUse": [
                     {"matcher": "", "hooks": [{"type": "command", "command": "my-custom-hook"}]},
-                    {"matcher": "", "hooks": [{"type": "command", "command": "grove.dash x"}]},
+                    {
+                        "matcher": "",
+                        "hooks": [{"type": "command", "command": "gw _hook --event PreToolUse"}],
+                    },
                 ]
             }
         }

--- a/tests/test_dash_installer.py
+++ b/tests/test_dash_installer.py
@@ -58,7 +58,7 @@ class TestInstallHooks:
         assert len(pre_rules) == 2
         all_cmds = [h["command"] for rule in pre_rules for h in rule.get("hooks", [])]
         assert "my-custom-hook" in all_cmds
-        assert any("grove.dash" in c for c in all_cmds)
+        assert any("grove.dash" in c or "gw _hook" in c for c in all_cmds)
 
         # Other settings preserved
         assert settings["other_setting"] is True
@@ -73,7 +73,10 @@ class TestInstallHooks:
         grove_rules = [
             rule
             for rule in pre_rules
-            if any("grove.dash" in h.get("command", "") for h in rule.get("hooks", []))
+            if any(
+                "grove.dash" in h.get("command", "") or "gw _hook" in h.get("command", "")
+                for h in rule.get("hooks", [])
+            )
         ]
         assert len(grove_rules) == 1
 


### PR DESCRIPTION
## Summary
- Hook commands used `sys.executable` (versioned Python path like `Cellar/grove/0.12.0/...`) which broke after Homebrew/uv upgrades
- Now uses the stable `gw` entry point via `shutil.which("gw")`, which resolves to the Homebrew symlink that survives version changes
- Added hidden `gw _hook --event X` CLI command as the new hook entry point
- Auto-migrates old hooks when user runs `gw dash install` (detects both old `grove.dash` and new `gw _hook` formats)

## Test plan
- [x] All 328 tests pass
- [ ] `gw dash install` on fresh install writes `gw _hook` commands
- [ ] `gw dash install` on existing install replaces old python-path hooks
- [ ] `gw dash uninstall` removes both old and new format hooks
- [ ] Hooks survive `brew upgrade grove`

🤖 Generated with [Claude Code](https://claude.com/claude-code)