### PR TITLE
Add plugin system and interactive preset mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ gw preset list                                         # list presets (compact)
 gw preset show backend                                 # show preset details
 gw preset remove backend
 gw create my-feature -p backend                        # use a preset instead of -r
+
+# Plugins — extend gw with external commands
+gw plugin install nicksenap/gw-dash                    # install from GitHub
+gw plugin list                                         # list installed plugins
+gw plugin upgrade                                      # upgrade all plugins
+gw plugin remove dash                                  # uninstall a plugin
 ```
 
 All interactive menus support **type-to-search** filtering, arrow-key navigation (single-select), or arrow + tab (multi-select) with an `(all)` shortcut.
@@ -100,6 +106,7 @@ All interactive menus support **type-to-search** filtering, arrow-key navigation
 ## Documentation
 
 - [Per-repo config & hooks](docs/hooks.md) — `.grove.toml`, lifecycle hooks, `gw run`
+- [Plugins](docs/plugins.md) — extend gw with external commands
 - [Agent dashboard](docs/dashboard.md) — `gw dash`, Zellij integration
 - [AI coding tools](docs/ai-tools.md) — Claude Code workflows, MCP server
 
@@ -126,10 +133,11 @@ The Go version covers the core workflow. What's missing are the TUI features.
 | `shell-init` | Done | |
 | `mcp-serve` | Done | JSON-RPC server for Claude Code |
 | `hook` | Done | Claude Code hook handler |
+| `plugin` | Done | Install, list, upgrade, remove |
 | `run` | Partial | Inline prefix output, no split-pane TUI |
-| `dash` | Not yet | Planned as separate plugin/binary |
+| `dash` | Plugin | [`gw-dash`](https://github.com/nicksenap/gw-dash) — install with `gw plugin install nicksenap/gw-dash` |
 
-285 tests passing (226 unit + 59 e2e).
+299 tests passing (229 unit + 70 e2e).
 
 ### Performance
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,74 @@
+# Plugins
+
+Grove supports external plugins that add new commands. Plugins are standalone executables named `gw-<name>` — when you run `gw foo`, Grove looks for a `gw-foo` binary and executes it.
+
+## Install methods
+
+### From GitHub
+
+```bash
+gw plugin install nicksenap/gw-dash
+gw plugin install github.com/user/gw-something
+```
+
+This downloads the latest release binary for your OS/architecture from the repo's GitHub Releases. The naming convention follows [goreleaser](https://goreleaser.com/) defaults: `gw-dash_0.1.0_darwin_arm64.tar.gz`.
+
+### Manual
+
+Drop any executable named `gw-<name>` into `~/.grove/plugins/`:
+
+```bash
+cp my-plugin ~/.grove/plugins/gw-myplugin
+chmod +x ~/.grove/plugins/gw-myplugin
+```
+
+Or place it anywhere on your `$PATH`.
+
+## Managing plugins
+
+```bash
+gw plugin list                    # list installed plugins
+gw plugin upgrade dash            # re-fetch latest release
+gw plugin upgrade                 # upgrade all plugins
+gw plugin remove dash             # uninstall
+```
+
+`upgrade` works for plugins installed via `gw plugin install` — it remembers the source repo. Manually installed plugins are skipped.
+
+## How plugins work
+
+When you run `gw <name>`, Grove first checks its built-in commands. If no match is found, it looks for `gw-<name>` in:
+
+1. `~/.grove/plugins/`
+2. `$PATH`
+
+If found, Grove replaces its own process with the plugin (`exec`), passing these environment variables:
+
+| Variable | Description |
+|---|---|
+| `GROVE_DIR` | Path to `~/.grove` |
+| `GROVE_CONFIG` | Path to `config.toml` |
+| `GROVE_STATE` | Path to `state.json` |
+| `GROVE_WORKSPACE` | Current workspace name (if cwd is inside one) |
+
+The plugin gets full control of the terminal — this means TUI plugins (like `gw-dash`) work seamlessly.
+
+## Writing a plugin
+
+A plugin can be any executable in any language. The simplest plugin is a shell script:
+
+```bash
+#!/bin/sh
+# ~/.grove/plugins/gw-hello
+echo "Hello! GROVE_DIR=$GROVE_DIR"
+```
+
+For distributable plugins, use Go with [goreleaser](https://goreleaser.com/) so that `gw plugin install` can find the right binary. See [gw-dash](https://github.com/nicksenap/gw-dash) for a reference implementation.
+
+### Reading Grove state
+
+Plugins read Grove's data files directly — no shared libraries or IPC:
+
+- **`$GROVE_DIR/state.json`** — array of workspaces, each with name, path, branch, and repos
+- **`$GROVE_DIR/config.toml`** — global config (repo_dirs, workspace_dir, presets)
+- **`$GROVE_DIR/status/*.json`** — live agent state files (for dashboard-style plugins)

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -42,6 +42,8 @@ done
 GROVE_SRC="${GROVE_SRC:-/src/grove}"
 if [ -d "${GROVE_SRC}/.git" ]; then
     git clone -q --local "${GROVE_SRC}" "${REPOS_DIR}/grove"
+    # Ensure we're on a named branch (CI checkouts may be detached HEAD)
+    (cd "${REPOS_DIR}/grove" && git checkout -q -B main HEAD 2>/dev/null || true)
     echo "Cloned Grove repo ($(cd "${REPOS_DIR}/grove" && git rev-list --count HEAD) commits)"
 else
     # Fallback: create a bare origin + clone so we have proper remote refs
@@ -285,7 +287,7 @@ WS_DIR="${GROVE_HOME}/.grove/workspaces/test-ws"
 section "Sync"
 
 # Use the Grove clone — a real repo with full commit history
-GROVE_BASE=$(cd "${REPOS_DIR}/grove" && git symbolic-ref --short HEAD)
+GROVE_BASE=$(cd "${REPOS_DIR}/grove" && git symbolic-ref --short HEAD 2>/dev/null || echo "main")
 
 gw create sync-ws --branch feat/sync-test --repos grove
 SYNC_WS_DIR="${GROVE_HOME}/.grove/workspaces/sync-ws"

--- a/go/cmd/addrepo.go
+++ b/go/cmd/addrepo.go
@@ -35,7 +35,7 @@ var addRepoCmd = &cobra.Command{
 			}
 			selected, err := picker.PickOne("Select workspace:", choices)
 			if err != nil {
-				exitError(err.Error())
+				exitOnPickerErr(err)
 			}
 			wsName = selected
 		}
@@ -74,7 +74,7 @@ var addRepoCmd = &cobra.Command{
 			}
 			selected, err := picker.PickMany("Select repos to add:", choices)
 			if err != nil {
-				exitError(err.Error())
+				exitOnPickerErr(err)
 			}
 			repoNames = selected
 		}

--- a/go/cmd/create.go
+++ b/go/cmd/create.go
@@ -51,29 +51,62 @@ var createCmd = &cobra.Command{
 			}
 		} else {
 			// Interactive
-			choices := make([]string, len(repos))
+			repoChoices := make([]string, len(repos))
 			for i, r := range repos {
-				choices[i] = r.Name
+				repoChoices[i] = r.Name
 			}
-			selected, err := picker.PickMany("Select repos for workspace:", choices)
-			if err != nil {
-				exitError(err.Error())
-			}
-			repoNames = selected
 
-			// Offer to save as preset
-			if len(cfg.Presets) == 0 && console.IsTerminal(os.Stdin) {
-				if console.Confirm("Save this selection as a preset?", false) {
-					presetName := console.Prompt("Preset name")
-					if presetName != "" {
-						if cfg.Presets == nil {
-							cfg.Presets = make(map[string]models.Preset)
+			// If presets exist, offer them first with a "Pick manually..." escape hatch
+			if len(cfg.Presets) > 0 {
+				presetNames := make([]string, 0, len(cfg.Presets))
+				presetChoices := make([]string, 0, len(cfg.Presets))
+				for name, p := range cfg.Presets {
+					presetNames = append(presetNames, name)
+					presetChoices = append(presetChoices, name+"  ("+strings.Join(p.Repos, ", ")+")")
+				}
+				presetChoices = append(presetChoices, "Pick manually…")
+
+				choice, err := picker.PickOne("Select repos from:", presetChoices)
+				if err != nil {
+					exitOnPickerErr(err)
+				}
+
+				if choice != "Pick manually…" {
+					// Extract preset name (before the double space)
+					for i, display := range presetChoices {
+						if display == choice && i < len(presetNames) {
+							repoNames = cfg.Presets[presetNames[i]].Repos
+							break
 						}
-						cfg.Presets[presetName] = models.Preset{Repos: repoNames}
-						if err := config.Save(cfg); err != nil {
-							console.Warningf("Could not save preset: %s", err)
-						} else {
-							console.Successf("Saved preset %q", presetName)
+					}
+				} else {
+					selected, err := picker.PickMany("Select repos for workspace:", repoChoices)
+					if err != nil {
+						exitOnPickerErr(err)
+					}
+					repoNames = selected
+				}
+			} else {
+				selected, err := picker.PickMany("Select repos for workspace:", repoChoices)
+				if err != nil {
+					exitOnPickerErr(err)
+				}
+				repoNames = selected
+
+				// Offer to save as preset when none exist yet
+				if console.IsTerminal(os.Stdin) && len(selected) < len(repos) {
+					if console.Confirm("Save this selection as a preset?", false) {
+						presetName := console.Prompt("Preset name")
+						if presetName != "" {
+							if cfg.Presets == nil {
+								cfg.Presets = make(map[string]models.Preset)
+							}
+							cfg.Presets[presetName] = models.Preset{Repos: repoNames}
+							if err := config.Save(cfg); err != nil {
+								console.Warningf("Could not save preset: %s", err)
+							} else {
+								console.Successf("Saved preset %q", presetName)
+							}
 						}
 					}
 				}

--- a/go/cmd/delete.go
+++ b/go/cmd/delete.go
@@ -37,7 +37,7 @@ var deleteCmd = &cobra.Command{
 			}
 			selected, err := picker.PickMany("Select workspaces to delete:", choices)
 			if err != nil {
-				exitError(err.Error())
+				exitOnPickerErr(err)
 			}
 			names = selected
 		}

--- a/go/cmd/dirs.go
+++ b/go/cmd/dirs.go
@@ -54,7 +54,7 @@ var removeDirCmd = &cobra.Command{
 		} else {
 			selected, err := picker.PickOne("Select directory to remove:", cfg.RepoDirs)
 			if err != nil {
-				exitError(err.Error())
+				exitOnPickerErr(err)
 			}
 			absPath = selected
 		}

--- a/go/cmd/go_cmd.go
+++ b/go/cmd/go_cmd.go
@@ -131,7 +131,7 @@ func resolveGoBack() string {
 	// Multiple parent dirs — let user pick
 	picked, err := picker.PickOne("Select repo directory:", parentList)
 	if err != nil {
-		exitError(err.Error())
+		exitOnPickerErr(err)
 	}
 	return picked
 }
@@ -162,7 +162,7 @@ func pickWorkspaceForGo() string {
 
 	picked, err := picker.PickOne("Select workspace", choices)
 	if err != nil {
-		exitError(err.Error())
+		exitOnPickerErr(err)
 	}
 
 	if picked == backToRepos {
@@ -172,7 +172,7 @@ func pickWorkspaceForGo() string {
 		} else if len(cfg.RepoDirs) > 1 {
 			dir, err := picker.PickOne("Select repo directory", cfg.RepoDirs)
 			if err != nil {
-				exitError(err.Error())
+				exitOnPickerErr(err)
 			}
 			return dir
 		}

--- a/go/cmd/plugin.go
+++ b/go/cmd/plugin.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nicksenap/grove/internal/console"
+	"github.com/nicksenap/grove/internal/plugin"
+	"github.com/spf13/cobra"
+)
+
+var pluginCmd = &cobra.Command{
+	Use:   "plugin",
+	Short: "Manage gw plugins",
+	Long: `Install, list, and remove external plugins that extend gw with new commands.
+
+Plugins are executables named gw-<name>. Any unknown command "gw foo" will
+look for a "gw-foo" plugin and run it.
+
+Install methods:
+  gw plugin install <repo>     Download from a GitHub release
+  Manual: place gw-<name> in ~/.grove/plugins/
+  Manual: place gw-<name> anywhere on $PATH`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var pluginInstallCmd = &cobra.Command{
+	Use:   "install <repo>",
+	Short: "Install a plugin from GitHub",
+	Long: `Download and install a plugin from a GitHub repository's latest release.
+
+Examples:
+  gw plugin install nicksenap/gw-dash
+  gw plugin install github.com/nicksenap/gw-dash`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := plugin.Install(args[0]); err != nil {
+			exitError(err.Error())
+		}
+	},
+}
+
+var pluginListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List installed plugins",
+	Run: func(cmd *cobra.Command, args []string) {
+		plugins, err := plugin.List()
+		if err != nil {
+			exitError(err.Error())
+		}
+
+		if len(plugins) == 0 {
+			console.Info("No plugins installed")
+			fmt.Fprintf(os.Stderr, "  Install one with: gw plugin install <owner/repo>\n")
+			return
+		}
+
+		table := console.NewTable(os.Stdout, []string{"Plugin", "Path"})
+		for _, p := range plugins {
+			table.AddRow([]string{p.Name, p.Path})
+		}
+		table.Render()
+	},
+}
+
+var pluginRemoveCmd = &cobra.Command{
+	Use:     "remove <name>",
+	Aliases: []string{"rm", "uninstall"},
+	Short:   "Remove an installed plugin",
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := plugin.Remove(args[0]); err != nil {
+			exitError(err.Error())
+		}
+		console.Successf("Removed plugin %s", args[0])
+	},
+}
+
+var pluginUpgradeCmd = &cobra.Command{
+	Use:   "upgrade [name]",
+	Short: "Upgrade installed plugin(s) to the latest release",
+	Long: `Re-fetch the latest release for a plugin. Without arguments, upgrades all
+plugins that were installed via "gw plugin install".`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 1 {
+			if err := plugin.Upgrade(args[0]); err != nil {
+				exitError(err.Error())
+			}
+			return
+		}
+
+		upgraded, err := plugin.UpgradeAll()
+		if err != nil {
+			exitError(err.Error())
+		}
+		if len(upgraded) == 0 {
+			console.Info("No plugins to upgrade")
+		}
+	},
+}
+
+func init() {
+	pluginCmd.AddCommand(pluginInstallCmd, pluginListCmd, pluginRemoveCmd, pluginUpgradeCmd)
+}

--- a/go/cmd/preset.go
+++ b/go/cmd/preset.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/nicksenap/grove/internal/config"
 	"github.com/nicksenap/grove/internal/console"
+	"github.com/nicksenap/grove/internal/discover"
 	"github.com/nicksenap/grove/internal/models"
+	"github.com/nicksenap/grove/internal/picker"
 	"github.com/spf13/cobra"
 )
 
@@ -23,28 +25,51 @@ var presetAddCmd = &cobra.Command{
 	Short: "Create or update a preset",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) == 0 {
+		cfg := config.RequireConfig()
+
+		// Interactive name prompt if not provided
+		name := ""
+		if len(args) > 0 {
+			name = args[0]
+		} else if console.IsTerminal(os.Stdin) {
+			name = console.Prompt("Preset name")
+		}
+		if name == "" {
 			exitError("preset name required")
 		}
-		if presetAddRepos == "" {
-			exitError("--repos is required")
-		}
 
-		cfg := config.RequireConfig()
 		if cfg.Presets == nil {
 			cfg.Presets = make(map[string]models.Preset)
 		}
 
-		repos := strings.Split(presetAddRepos, ",")
-		for i := range repos {
-			repos[i] = strings.TrimSpace(repos[i])
+		var repoNames []string
+		if presetAddRepos != "" {
+			repoNames = strings.Split(presetAddRepos, ",")
+			for i := range repoNames {
+				repoNames[i] = strings.TrimSpace(repoNames[i])
+			}
+		} else {
+			// Interactive: pick repos
+			available := discover.FindAllRepos(cfg.RepoDirs)
+			if len(available) == 0 {
+				exitError("No repos found. Run: gw add-dir <path>")
+			}
+			choices := make([]string, len(available))
+			for i, r := range available {
+				choices[i] = r.Name
+			}
+			selected, err := picker.PickMany("Select repos for preset:", choices)
+			if err != nil {
+				exitOnPickerErr(err)
+			}
+			repoNames = selected
 		}
 
-		cfg.Presets[args[0]] = models.Preset{Repos: repos}
+		cfg.Presets[name] = models.Preset{Repos: repoNames}
 		if err := config.Save(cfg); err != nil {
 			exitError(err.Error())
 		}
-		console.Successf("Preset %s saved", args[0])
+		console.Successf("Preset %s saved: %s", name, strings.Join(repoNames, ", "))
 	},
 }
 
@@ -93,20 +118,36 @@ var presetRemoveCmd = &cobra.Command{
 	Short: "Remove a preset",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) == 0 {
-			exitError("preset name required")
-		}
-
 		cfg := config.RequireConfig()
-		if _, ok := cfg.Presets[args[0]]; !ok {
-			exitError(fmt.Sprintf("Preset %s not found", args[0]))
+		if len(cfg.Presets) == 0 {
+			exitError("No presets to remove")
 		}
 
-		delete(cfg.Presets, args[0])
+		name := ""
+		if len(args) > 0 {
+			name = args[0]
+		} else {
+			// Interactive: pick preset to remove
+			names := make([]string, 0, len(cfg.Presets))
+			for n := range cfg.Presets {
+				names = append(names, n)
+			}
+			selected, err := picker.PickOne("Select preset to remove:", names)
+			if err != nil {
+				exitOnPickerErr(err)
+			}
+			name = selected
+		}
+
+		if _, ok := cfg.Presets[name]; !ok {
+			exitError(fmt.Sprintf("Preset %s not found", name))
+		}
+
+		delete(cfg.Presets, name)
 		if err := config.Save(cfg); err != nil {
 			exitError(err.Error())
 		}
-		console.Successf("Preset %s removed", args[0])
+		console.Successf("Preset %s removed", name)
 	},
 }
 

--- a/go/cmd/removerepo.go
+++ b/go/cmd/removerepo.go
@@ -38,7 +38,7 @@ var removeRepoCmd = &cobra.Command{
 			}
 			selected, err := picker.PickOne("Select workspace:", choices)
 			if err != nil {
-				exitError(err.Error())
+				exitOnPickerErr(err)
 			}
 			wsName = selected
 		}
@@ -64,7 +64,7 @@ var removeRepoCmd = &cobra.Command{
 			choices := ws.RepoNames()
 			selected, err := picker.PickMany("Select repos to remove:", choices)
 			if err != nil {
-				exitError(err.Error())
+				exitOnPickerErr(err)
 			}
 			repoNames = selected
 		}

--- a/go/cmd/rename.go
+++ b/go/cmd/rename.go
@@ -31,7 +31,7 @@ var renameCmd = &cobra.Command{
 			}
 			selected, err := picker.PickOne("Select workspace to rename:", choices)
 			if err != nil {
-				exitError(err.Error())
+				exitOnPickerErr(err)
 			}
 			name = selected
 		}

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/nicksenap/grove/internal/config"
@@ -79,10 +81,15 @@ func Execute() {
 				if pluginPath, findErr := plugin.Find(name); findErr == nil {
 					args := pluginArgs(name)
 					if execErr := plugin.Exec(pluginPath, args); execErr != nil {
+						// On Windows, Exec runs a child process — propagate its exit code
+						var exitErr *exec.ExitError
+						if errors.As(execErr, &exitErr) {
+							os.Exit(exitErr.ExitCode())
+						}
 						fmt.Fprintf(os.Stderr, "\033[1;31merror:\033[0m plugin %s: %s\n", name, execErr)
+						os.Exit(1)
 					}
-					// If Exec used syscall.Exec, we never reach here.
-					// On Windows (child process), exit with its code.
+					// If Exec used syscall.Exec (Unix), we never reach here.
 					os.Exit(0)
 				}
 			}
@@ -114,10 +121,11 @@ func extractUnknownCommand(err error) string {
 }
 
 // pluginArgs extracts the args after the plugin name from os.Args.
+// Skips os.Args[0] (the binary itself) to avoid false matches.
 func pluginArgs(name string) []string {
-	for i, arg := range os.Args {
+	for i, arg := range os.Args[1:] {
 		if arg == name {
-			return os.Args[i+1:]
+			return os.Args[i+2:] // +2 because we sliced from [1:]
 		}
 	}
 	return nil

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nicksenap/grove/internal/config"
 	"github.com/nicksenap/grove/internal/logging"
+	"github.com/nicksenap/grove/internal/picker"
 	"github.com/nicksenap/grove/internal/plugin"
 	"github.com/nicksenap/grove/internal/update"
 	"github.com/spf13/cobra"
@@ -135,4 +136,12 @@ func pluginArgs(name string) []string {
 func exitError(msg string) {
 	fmt.Fprintf(os.Stderr, "\033[1;31merror:\033[0m %s\n", msg)
 	os.Exit(1)
+}
+
+// exitOnPickerErr exits silently on user cancellation, or calls exitError for real errors.
+func exitOnPickerErr(err error) {
+	if errors.Is(err, picker.ErrCancelled) {
+		os.Exit(0)
+	}
+	exitError(err.Error())
 }

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/nicksenap/grove/internal/config"
 	"github.com/nicksenap/grove/internal/logging"
+	"github.com/nicksenap/grove/internal/plugin"
 	"github.com/nicksenap/grove/internal/update"
 	"github.com/spf13/cobra"
 )
@@ -33,6 +35,10 @@ func init() {
 	rootCmd.Version = Version
 	rootCmd.SetVersionTemplate("gw {{.Version}}\n")
 
+	// Silence cobra's default error/usage output so we can handle plugin fallback cleanly
+	rootCmd.SilenceErrors = true
+	rootCmd.SilenceUsage = true
+
 	// Register all subcommands
 	rootCmd.AddCommand(
 		initCmd,
@@ -56,6 +62,7 @@ func init() {
 		hookCmd,
 		exploreCmd,
 		mcpServeCmd,
+		pluginCmd,
 	)
 }
 
@@ -66,8 +73,54 @@ func Execute() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
+		// If cobra says "unknown command", try to find a matching plugin
+		if isUnknownCommandErr(err) {
+			if name := extractUnknownCommand(err); name != "" {
+				if pluginPath, findErr := plugin.Find(name); findErr == nil {
+					args := pluginArgs(name)
+					if execErr := plugin.Exec(pluginPath, args); execErr != nil {
+						fmt.Fprintf(os.Stderr, "\033[1;31merror:\033[0m plugin %s: %s\n", name, execErr)
+					}
+					// If Exec used syscall.Exec, we never reach here.
+					// On Windows (child process), exit with its code.
+					os.Exit(0)
+				}
+			}
+		}
+		// Print the error ourselves since we silenced cobra
+		fmt.Fprintf(os.Stderr, "\033[1;31merror:\033[0m %s\n", err)
 		os.Exit(1)
 	}
+}
+
+// isUnknownCommandErr checks if the error is cobra's "unknown command" error.
+func isUnknownCommandErr(err error) bool {
+	return strings.Contains(err.Error(), "unknown command")
+}
+
+// extractUnknownCommand pulls the command name from cobra's error message.
+// Format: `unknown command "foo" for "gw"`
+func extractUnknownCommand(err error) string {
+	msg := err.Error()
+	start := strings.Index(msg, `"`)
+	if start < 0 {
+		return ""
+	}
+	end := strings.Index(msg[start+1:], `"`)
+	if end < 0 {
+		return ""
+	}
+	return msg[start+1 : start+1+end]
+}
+
+// pluginArgs extracts the args after the plugin name from os.Args.
+func pluginArgs(name string) []string {
+	for i, arg := range os.Args {
+		if arg == name {
+			return os.Args[i+1:]
+		}
+	}
+	return nil
 }
 
 // exitError prints error to stderr and exits.

--- a/go/e2e/run.sh
+++ b/go/e2e/run.sh
@@ -634,6 +634,79 @@ fi
 gw delete mcp-ws --force 2>&1
 
 # ---------------------------------------------------------------------------
+# Test: plugin system
+# ---------------------------------------------------------------------------
+section "Plugins"
+
+# plugin list — empty
+plugin_list_out=$(gw plugin list 2>&1)
+if echo "${plugin_list_out}" | grep -q "No plugins"; then
+    pass "plugin list shows empty"
+else
+    fail "plugin list should show empty: ${plugin_list_out}"
+fi
+
+# Install a fake plugin as a shell script
+PLUGINS_DIR="${GROVE_HOME}/.grove/plugins"
+mkdir -p "${PLUGINS_DIR}"
+cat > "${PLUGINS_DIR}/gw-hello" <<'SH'
+#!/bin/sh
+echo "hello-from-plugin GROVE_DIR=${GROVE_DIR} args=$*"
+SH
+chmod +x "${PLUGINS_DIR}/gw-hello"
+
+# plugin list — shows hello
+if gw plugin list 2>&1 | grep -q "hello"; then
+    pass "plugin list shows installed plugin"
+else
+    fail "plugin list missing hello"
+fi
+
+# Unknown command fallback — gw hello should exec the plugin
+hello_out=$(gw hello --test-flag 2>&1)
+if echo "${hello_out}" | grep -q "hello-from-plugin"; then
+    pass "unknown command falls back to plugin"
+else
+    fail "plugin fallback failed: ${hello_out}"
+fi
+
+# Verify env vars are passed
+if echo "${hello_out}" | grep -q "GROVE_DIR="; then
+    pass "GROVE_DIR passed to plugin"
+else
+    fail "GROVE_DIR not passed to plugin"
+fi
+
+# Verify args are forwarded
+if echo "${hello_out}" | grep -q "\-\-test-flag"; then
+    pass "args forwarded to plugin"
+else
+    fail "args not forwarded: ${hello_out}"
+fi
+
+# plugin remove
+gw plugin remove hello 2>&1
+if [ ! -f "${PLUGINS_DIR}/gw-hello" ]; then
+    pass "plugin remove deletes binary"
+else
+    fail "plugin remove did not delete binary"
+fi
+
+# plugin remove nonexistent should fail
+if ! gw plugin remove nonexistent 2>/dev/null; then
+    pass "plugin remove nonexistent exits non-zero"
+else
+    fail "plugin remove nonexistent should fail"
+fi
+
+# Unknown command with no plugin should fail
+if ! gw nonexistent-cmd 2>/dev/null; then
+    pass "unknown command without plugin exits non-zero"
+else
+    fail "unknown command without plugin should fail"
+fi
+
+# ---------------------------------------------------------------------------
 # Cleanup: delete remaining workspace
 # ---------------------------------------------------------------------------
 section "Final cleanup"

--- a/go/internal/picker/picker.go
+++ b/go/internal/picker/picker.go
@@ -2,6 +2,7 @@ package picker
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -9,6 +10,9 @@ import (
 	"github.com/nicksenap/grove/internal/console"
 	"golang.org/x/term"
 )
+
+// ErrCancelled is returned when the user cancels a picker with Escape or Ctrl+C.
+var ErrCancelled = errors.New("selection cancelled")
 
 // PickOne shows a single-select picker with type-to-search.
 // Returns the selected item or error if cancelled.
@@ -30,7 +34,7 @@ func PickOne(prompt string, choices []string) (string, error) {
 	}
 
 	if m.cancelled {
-		return "", fmt.Errorf("selection cancelled")
+		return "", ErrCancelled
 	}
 	return m.selected[0], nil
 }
@@ -56,7 +60,7 @@ func PickMany(prompt string, choices []string) ([]string, error) {
 	}
 
 	if m.cancelled {
-		return nil, fmt.Errorf("selection cancelled")
+		return nil, ErrCancelled
 	}
 	if len(m.selected) == 0 {
 		return nil, fmt.Errorf("no items selected")

--- a/go/internal/plugin/install.go
+++ b/go/internal/plugin/install.go
@@ -1,0 +1,282 @@
+package plugin
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// ghRelease is a subset of the GitHub release API response.
+type ghRelease struct {
+	TagName string    `json:"tag_name"`
+	Assets  []ghAsset `json:"assets"`
+}
+
+// ghAsset is a single release asset.
+type ghAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// Install downloads the latest release of a plugin from GitHub.
+// repo should be like "github.com/nicksenap/gw-dash" or "nicksenap/gw-dash".
+func Install(repo string) error {
+	owner, name, err := parseRepo(repo)
+	if err != nil {
+		return err
+	}
+
+	// Plugin name is the repo name (e.g. "gw-dash" → command name "dash")
+	pluginCmd := strings.TrimPrefix(name, "gw-")
+
+	// Fetch latest release
+	release, err := fetchRelease(owner, name)
+	if err != nil {
+		return fmt.Errorf("fetching release for %s/%s: %w", owner, name, err)
+	}
+
+	// Find matching asset for this OS/arch
+	asset, err := findAsset(release, name)
+	if err != nil {
+		return err
+	}
+
+	// Ensure plugins dir exists
+	dir := Dir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating plugins dir: %w", err)
+	}
+
+	// Download and extract
+	binName := "gw-" + pluginCmd
+	destPath := filepath.Join(dir, binName)
+
+	if err := downloadAndExtract(asset.BrowserDownloadURL, binName, destPath); err != nil {
+		return fmt.Errorf("downloading %s: %w", asset.Name, err)
+	}
+
+	// Save metadata so we know where to upgrade from
+	saveMeta(pluginCmd, owner+"/"+name, release.TagName)
+
+	fmt.Fprintf(os.Stderr, "\033[1;32mok:\033[0m Installed %s %s → %s\n",
+		pluginCmd, release.TagName, destPath)
+	return nil
+}
+
+// pluginMeta is the metadata stored alongside an installed plugin.
+type pluginMeta struct {
+	Repo    string `json:"repo"`
+	Version string `json:"version"`
+}
+
+func metaPath(pluginCmd string) string {
+	return filepath.Join(Dir(), ".gw-"+pluginCmd+".json")
+}
+
+func saveMeta(pluginCmd, repo, version string) {
+	m := pluginMeta{Repo: repo, Version: version}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return
+	}
+	os.WriteFile(metaPath(pluginCmd), data, 0o644)
+}
+
+func loadMeta(pluginCmd string) (*pluginMeta, error) {
+	data, err := os.ReadFile(metaPath(pluginCmd))
+	if err != nil {
+		return nil, err
+	}
+	var m pluginMeta
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// Upgrade re-fetches the latest release for an installed plugin.
+func Upgrade(name string) error {
+	meta, err := loadMeta(name)
+	if err != nil {
+		return fmt.Errorf("plugin %q has no install metadata — reinstall with: gw plugin install <repo>", name)
+	}
+	return Install(meta.Repo)
+}
+
+// UpgradeAll upgrades all installed plugins that have metadata.
+func UpgradeAll() ([]string, error) {
+	plugins, err := List()
+	if err != nil {
+		return nil, err
+	}
+
+	var upgraded []string
+	for _, p := range plugins {
+		if _, err := loadMeta(p.Name); err != nil {
+			continue // manually installed, skip
+		}
+		if err := Upgrade(p.Name); err != nil {
+			fmt.Fprintf(os.Stderr, "\033[1;33mwarn:\033[0m %s: %s\n", p.Name, err)
+			continue
+		}
+		upgraded = append(upgraded, p.Name)
+	}
+	return upgraded, nil
+}
+
+// parseRepo extracts owner/name from various formats.
+func parseRepo(repo string) (owner, name string, err error) {
+	// Strip github.com/ prefix if present
+	repo = strings.TrimPrefix(repo, "https://")
+	repo = strings.TrimPrefix(repo, "github.com/")
+	repo = strings.TrimSuffix(repo, "/")
+
+	parts := strings.SplitN(repo, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid repo format %q (expected owner/repo or github.com/owner/repo)", repo)
+	}
+	return parts[0], parts[1], nil
+}
+
+func fetchRelease(owner, repo string) (*ghRelease, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo)
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "grove-plugin-installer")
+
+	// Use GITHUB_TOKEN if available for higher rate limits
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return nil, fmt.Errorf("repository %s/%s not found or has no releases", owner, repo)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+
+	var release ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("parsing release response: %w", err)
+	}
+	return &release, nil
+}
+
+// findAsset finds the right asset for the current OS/arch.
+// Expects goreleaser naming: {name}_{version}_{os}_{arch}.tar.gz
+func findAsset(release *ghRelease, _ string) (*ghAsset, error) {
+	goos := runtime.GOOS
+	goarch := runtime.GOARCH
+
+	// Try exact match first, then common variations
+	patterns := []string{
+		fmt.Sprintf("%s_%s_%s.tar.gz", goos, goarch, ""),
+		fmt.Sprintf("_%s_%s.tar.gz", goos, goarch),
+	}
+
+	for i := range release.Assets {
+		a := &release.Assets[i]
+		lower := strings.ToLower(a.Name)
+		for _, p := range patterns {
+			if strings.Contains(lower, strings.ToLower(p)) {
+				return a, nil
+			}
+		}
+	}
+
+	// More flexible: just check os and arch are in the name
+	for i := range release.Assets {
+		a := &release.Assets[i]
+		lower := strings.ToLower(a.Name)
+		if strings.Contains(lower, goos) && strings.Contains(lower, goarch) && strings.HasSuffix(lower, ".tar.gz") {
+			return a, nil
+		}
+	}
+
+	available := make([]string, len(release.Assets))
+	for i, a := range release.Assets {
+		available[i] = a.Name
+	}
+	return nil, fmt.Errorf("no asset found for %s/%s in release %s\navailable: %s",
+		goos, goarch, release.TagName, strings.Join(available, ", "))
+}
+
+// downloadAndExtract downloads a .tar.gz and extracts the binary.
+func downloadAndExtract(url, binName, destPath string) error {
+	client := &http.Client{Timeout: 120 * time.Second}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "grove-plugin-installer")
+
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("download returned HTTP %d", resp.StatusCode)
+	}
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return fmt.Errorf("decompressing: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar: %w", err)
+		}
+
+		// Look for the binary — it may be at the root or in a subdirectory
+		base := filepath.Base(hdr.Name)
+		if base == binName && hdr.Typeflag == tar.TypeReg {
+			// Write to temp file then rename (atomic install)
+			tmp := destPath + ".tmp"
+			f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				os.Remove(tmp)
+				return err
+			}
+			f.Close()
+			return os.Rename(tmp, destPath)
+		}
+	}
+
+	return fmt.Errorf("binary %q not found in archive", binName)
+}

--- a/go/internal/plugin/install.go
+++ b/go/internal/plugin/install.go
@@ -59,6 +59,10 @@ func Install(repo string) error {
 	binName := "gw-" + pluginCmd
 	destPath := filepath.Join(dir, binName)
 
+	if !strings.HasPrefix(asset.BrowserDownloadURL, "https://") {
+		return fmt.Errorf("asset URL is not HTTPS: %s", asset.BrowserDownloadURL)
+	}
+
 	if err := downloadAndExtract(asset.BrowserDownloadURL, binName, destPath); err != nil {
 		return fmt.Errorf("downloading %s: %w", asset.Name, err)
 	}
@@ -134,8 +138,9 @@ func UpgradeAll() ([]string, error) {
 
 // parseRepo extracts owner/name from various formats.
 func parseRepo(repo string) (owner, name string, err error) {
-	// Strip github.com/ prefix if present
+	// Strip scheme and host prefix
 	repo = strings.TrimPrefix(repo, "https://")
+	repo = strings.TrimPrefix(repo, "http://")
 	repo = strings.TrimPrefix(repo, "github.com/")
 	repo = strings.TrimSuffix(repo, "/")
 
@@ -175,7 +180,8 @@ func fetchRelease(owner, repo string) (*ghRelease, error) {
 	}
 
 	var release ghRelease
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+	// Limit response body to 1 MiB to prevent memory exhaustion
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&release); err != nil {
 		return nil, fmt.Errorf("parsing release response: %w", err)
 	}
 	return &release, nil
@@ -219,6 +225,8 @@ func findAsset(release *ghRelease, _ string) (*ghAsset, error) {
 	return nil, fmt.Errorf("no asset found for %s/%s in release %s\navailable: %s",
 		goos, goarch, release.TagName, strings.Join(available, ", "))
 }
+
+const maxBinarySize = 256 << 20 // 256 MiB
 
 // downloadAndExtract downloads a .tar.gz and extracts the binary.
 func downloadAndExtract(url, binName, destPath string) error {
@@ -268,10 +276,16 @@ func downloadAndExtract(url, binName, destPath string) error {
 			if err != nil {
 				return err
 			}
-			if _, err := io.Copy(f, tr); err != nil {
+			n, err := io.Copy(f, io.LimitReader(tr, maxBinarySize+1))
+			if err != nil {
 				f.Close()
 				os.Remove(tmp)
 				return err
+			}
+			if n > maxBinarySize {
+				f.Close()
+				os.Remove(tmp)
+				return fmt.Errorf("binary exceeds maximum size (%d MiB)", maxBinarySize>>20)
 			}
 			f.Close()
 			return os.Rename(tmp, destPath)

--- a/go/internal/plugin/install_test.go
+++ b/go/internal/plugin/install_test.go
@@ -1,0 +1,76 @@
+package plugin
+
+import (
+	"testing"
+)
+
+func TestParseRepo(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantOwner string
+		wantName  string
+		wantErr   bool
+	}{
+		{"nicksenap/gw-dash", "nicksenap", "gw-dash", false},
+		{"github.com/nicksenap/gw-dash", "nicksenap", "gw-dash", false},
+		{"https://github.com/nicksenap/gw-dash", "nicksenap", "gw-dash", false},
+		{"github.com/nicksenap/gw-dash/", "nicksenap", "gw-dash", false},
+		{"invalid", "", "", true},
+		{"", "", "", true},
+		{"/only-name", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			owner, name, err := parseRepo(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseRepo(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if owner != tt.wantOwner {
+				t.Errorf("parseRepo(%q) owner = %q, want %q", tt.input, owner, tt.wantOwner)
+			}
+			if name != tt.wantName {
+				t.Errorf("parseRepo(%q) name = %q, want %q", tt.input, name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestFindAsset(t *testing.T) {
+	release := &ghRelease{
+		TagName: "v0.1.0",
+		Assets: []ghAsset{
+			{Name: "gw-dash_0.1.0_darwin_arm64.tar.gz", BrowserDownloadURL: "https://example.com/darwin_arm64.tar.gz"},
+			{Name: "gw-dash_0.1.0_darwin_amd64.tar.gz", BrowserDownloadURL: "https://example.com/darwin_amd64.tar.gz"},
+			{Name: "gw-dash_0.1.0_linux_amd64.tar.gz", BrowserDownloadURL: "https://example.com/linux_amd64.tar.gz"},
+			{Name: "checksums.txt", BrowserDownloadURL: "https://example.com/checksums.txt"},
+		},
+	}
+
+	asset, err := findAsset(release, "gw-dash")
+	if err != nil {
+		t.Fatalf("findAsset() error: %v", err)
+	}
+	// Should find something for the current GOOS/GOARCH
+	if asset == nil {
+		t.Fatal("expected an asset, got nil")
+	}
+	if asset.BrowserDownloadURL == "" {
+		t.Error("expected a download URL")
+	}
+}
+
+func TestFindAssetNoMatch(t *testing.T) {
+	release := &ghRelease{
+		TagName: "v0.1.0",
+		Assets: []ghAsset{
+			{Name: "gw-dash_0.1.0_plan9_mips.tar.gz", BrowserDownloadURL: "https://example.com/plan9.tar.gz"},
+		},
+	}
+
+	_, err := findAsset(release, "gw-dash")
+	if err == nil {
+		t.Fatal("expected error when no matching asset")
+	}
+}

--- a/go/internal/plugin/install_test.go
+++ b/go/internal/plugin/install_test.go
@@ -14,6 +14,7 @@ func TestParseRepo(t *testing.T) {
 		{"nicksenap/gw-dash", "nicksenap", "gw-dash", false},
 		{"github.com/nicksenap/gw-dash", "nicksenap", "gw-dash", false},
 		{"https://github.com/nicksenap/gw-dash", "nicksenap", "gw-dash", false},
+		{"http://github.com/nicksenap/gw-dash", "nicksenap", "gw-dash", false},
 		{"github.com/nicksenap/gw-dash/", "nicksenap", "gw-dash", false},
 		{"invalid", "", "", true},
 		{"", "", "", true},

--- a/go/internal/plugin/plugin.go
+++ b/go/internal/plugin/plugin.go
@@ -3,7 +3,9 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -140,8 +142,11 @@ func Remove(name string) error {
 	bin := "gw-" + name
 	pluginPath := filepath.Join(Dir(), bin)
 
-	if _, err := os.Stat(pluginPath); os.IsNotExist(err) {
-		return fmt.Errorf("plugin %q is not installed", name)
+	if _, err := os.Stat(pluginPath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("plugin %q is not installed", name)
+		}
+		return fmt.Errorf("checking plugin: %w", err)
 	}
 
 	// Clean up metadata file if present

--- a/go/internal/plugin/plugin.go
+++ b/go/internal/plugin/plugin.go
@@ -1,0 +1,157 @@
+// Package plugin implements external binary plugin discovery and execution.
+// Plugins are executables named gw-<name> found in ~/.grove/plugins/ or $PATH.
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/nicksenap/grove/internal/config"
+	"github.com/nicksenap/grove/internal/state"
+)
+
+// Dir returns the plugin directory path.
+func Dir() string {
+	return filepath.Join(config.GroveDir, "plugins")
+}
+
+// Find locates a plugin binary by name. Checks ~/.grove/plugins/ first, then $PATH.
+// Returns the absolute path to the binary, or error if not found.
+func Find(name string) (string, error) {
+	bin := "gw-" + name
+
+	// Check plugins dir first
+	pluginPath := filepath.Join(Dir(), bin)
+	if info, err := os.Stat(pluginPath); err == nil && !info.IsDir() {
+		return pluginPath, nil
+	}
+
+	// Fall back to $PATH
+	if p, err := exec.LookPath(bin); err == nil {
+		return p, nil
+	}
+
+	return "", fmt.Errorf("plugin %q not found (looked for %s in %s and $PATH)", name, bin, Dir())
+}
+
+// Exec replaces the current process with the plugin binary.
+// On Unix this uses syscall.Exec; on Windows it spawns a child process.
+func Exec(pluginPath string, args []string) error {
+	env := pluginEnv()
+
+	argv := append([]string{pluginPath}, args...)
+
+	if runtime.GOOS == "windows" {
+		cmd := exec.Command(pluginPath, args...)
+		cmd.Env = env
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+
+	return syscall.Exec(pluginPath, argv, env)
+}
+
+// pluginEnv returns the current environment with Grove-specific variables added.
+func pluginEnv() []string {
+	env := os.Environ()
+
+	set := func(key, val string) {
+		prefix := key + "="
+		for i, e := range env {
+			if strings.HasPrefix(e, prefix) {
+				env[i] = prefix + val
+				return
+			}
+		}
+		env = append(env, prefix+val)
+	}
+
+	set("GROVE_DIR", config.GroveDir)
+	set("GROVE_CONFIG", config.ConfigPath)
+	set("GROVE_STATE", filepath.Join(config.GroveDir, "state.json"))
+
+	// Try to detect current workspace from cwd
+	if ws := detectWorkspace(); ws != "" {
+		set("GROVE_WORKSPACE", ws)
+	}
+
+	return env
+}
+
+// detectWorkspace returns the current workspace name if cwd is inside a workspace.
+func detectWorkspace() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+
+	ws, err := state.FindWorkspaceByPath(cwd)
+	if err != nil || ws == nil {
+		return ""
+	}
+	return ws.Name
+}
+
+// List returns all installed plugins in the plugins directory.
+func List() ([]InstalledPlugin, error) {
+	dir := Dir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var plugins []InstalledPlugin
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, "gw-") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		// Must be executable
+		if info.Mode()&0o111 == 0 {
+			continue
+		}
+		plugins = append(plugins, InstalledPlugin{
+			Name: strings.TrimPrefix(name, "gw-"),
+			Path: filepath.Join(dir, name),
+		})
+	}
+	return plugins, nil
+}
+
+// Remove deletes a plugin and its metadata from the plugins directory.
+func Remove(name string) error {
+	bin := "gw-" + name
+	pluginPath := filepath.Join(Dir(), bin)
+
+	if _, err := os.Stat(pluginPath); os.IsNotExist(err) {
+		return fmt.Errorf("plugin %q is not installed", name)
+	}
+
+	// Clean up metadata file if present
+	os.Remove(metaPath(name))
+
+	return os.Remove(pluginPath)
+}
+
+// InstalledPlugin describes a plugin found in the plugins directory.
+type InstalledPlugin struct {
+	Name string
+	Path string
+}

--- a/go/internal/plugin/plugin_test.go
+++ b/go/internal/plugin/plugin_test.go
@@ -1,0 +1,173 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nicksenap/grove/internal/config"
+)
+
+func setupPluginDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	config.GroveDir = dir
+	pluginsDir := filepath.Join(dir, "plugins")
+	os.MkdirAll(pluginsDir, 0o755)
+	return pluginsDir
+}
+
+func createFakePlugin(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, "gw-"+name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho hello\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestDirUsesGroveDir(t *testing.T) {
+	config.GroveDir = "/tmp/test-grove"
+	got := Dir()
+	want := "/tmp/test-grove/plugins"
+	if got != want {
+		t.Errorf("Dir() = %q, want %q", got, want)
+	}
+}
+
+func TestFindInPluginsDir(t *testing.T) {
+	dir := setupPluginDir(t)
+	createFakePlugin(t, dir, "hello")
+
+	path, err := Find("hello")
+	if err != nil {
+		t.Fatalf("Find(hello) error: %v", err)
+	}
+	if path != filepath.Join(dir, "gw-hello") {
+		t.Errorf("Find(hello) = %q, want %q", path, filepath.Join(dir, "gw-hello"))
+	}
+}
+
+func TestFindNotFound(t *testing.T) {
+	setupPluginDir(t)
+
+	_, err := Find("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing plugin")
+	}
+}
+
+func TestListEmpty(t *testing.T) {
+	setupPluginDir(t)
+
+	plugins, err := List()
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(plugins) != 0 {
+		t.Errorf("expected empty list, got %d", len(plugins))
+	}
+}
+
+func TestListFindsPlugins(t *testing.T) {
+	dir := setupPluginDir(t)
+	createFakePlugin(t, dir, "alpha")
+	createFakePlugin(t, dir, "beta")
+
+	// Also create a non-plugin file (should be ignored)
+	os.WriteFile(filepath.Join(dir, "not-a-plugin"), []byte("x"), 0o755)
+
+	// And a non-executable file with gw- prefix (should be ignored)
+	os.WriteFile(filepath.Join(dir, "gw-noexec"), []byte("x"), 0o644)
+
+	plugins, err := List()
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(plugins) != 2 {
+		t.Fatalf("expected 2 plugins, got %d", len(plugins))
+	}
+
+	names := map[string]bool{}
+	for _, p := range plugins {
+		names[p.Name] = true
+	}
+	if !names["alpha"] || !names["beta"] {
+		t.Errorf("expected alpha and beta, got %v", names)
+	}
+}
+
+func TestListNoDirReturnsNil(t *testing.T) {
+	config.GroveDir = filepath.Join(t.TempDir(), "nonexistent")
+
+	plugins, err := List()
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if plugins != nil {
+		t.Errorf("expected nil, got %v", plugins)
+	}
+}
+
+func TestRemovePlugin(t *testing.T) {
+	dir := setupPluginDir(t)
+	createFakePlugin(t, dir, "removeme")
+
+	if err := Remove("removeme"); err != nil {
+		t.Fatalf("Remove() error: %v", err)
+	}
+
+	// Verify it's gone
+	if _, err := os.Stat(filepath.Join(dir, "gw-removeme")); !os.IsNotExist(err) {
+		t.Error("plugin file should have been removed")
+	}
+}
+
+func TestRemoveNotInstalled(t *testing.T) {
+	setupPluginDir(t)
+
+	err := Remove("nothere")
+	if err == nil {
+		t.Fatal("expected error removing non-existent plugin")
+	}
+}
+
+func TestRemoveCleansMeta(t *testing.T) {
+	dir := setupPluginDir(t)
+	createFakePlugin(t, dir, "withmeta")
+	saveMeta("withmeta", "user/gw-withmeta", "v1.0.0")
+
+	if err := Remove("withmeta"); err != nil {
+		t.Fatalf("Remove() error: %v", err)
+	}
+
+	if _, err := os.Stat(metaPath("withmeta")); !os.IsNotExist(err) {
+		t.Error("metadata file should have been removed")
+	}
+}
+
+func TestMetaRoundTrip(t *testing.T) {
+	setupPluginDir(t)
+	saveMeta("dash", "nicksenap/gw-dash", "v0.1.0")
+
+	meta, err := loadMeta("dash")
+	if err != nil {
+		t.Fatalf("loadMeta() error: %v", err)
+	}
+	if meta.Repo != "nicksenap/gw-dash" {
+		t.Errorf("repo = %q, want %q", meta.Repo, "nicksenap/gw-dash")
+	}
+	if meta.Version != "v0.1.0" {
+		t.Errorf("version = %q, want %q", meta.Version, "v0.1.0")
+	}
+}
+
+func TestUpgradeWithoutMeta(t *testing.T) {
+	dir := setupPluginDir(t)
+	createFakePlugin(t, dir, "manual")
+
+	err := Upgrade("manual")
+	if err == nil {
+		t.Fatal("expected error upgrading plugin without metadata")
+	}
+}


### PR DESCRIPTION
## Summary

- **Plugin system** — external binary plugins (kubectl/git pattern). `gw plugin install/list/upgrade/remove` + automatic fallback for unknown commands (`gw dash` → finds `gw-dash` binary)
- **Interactive preset mode** — `gw create` offers preset picker when presets exist, `gw preset add/remove` work interactively without flags
- **Clean picker cancel** — Ctrl+C/Esc exits silently (exit 0) instead of `error: selection cancelled` across all picker call sites
- **gw-dash repo** — scaffolded at [nicksenap/gw-dash](https://github.com/nicksenap/gw-dash) with Bubble Tea TUI, v0.1.0 released

### Plugin details

Plugins are executables named `gw-<name>` found in `~/.grove/plugins/` or `$PATH`. Install from GitHub releases, pass context via env vars (`GROVE_DIR`, `GROVE_CONFIG`, `GROVE_STATE`, `GROVE_WORKSPACE`). Uses `syscall.Exec` on Unix for clean process handoff.

Security: size-limited extraction (256 MiB), HTTPS-only downloads, rate-limit-friendly `GITHUB_TOKEN` support.

### Files

- `go/internal/plugin/` — plugin discovery, execution, install, upgrade (+ 15 unit tests)
- `go/cmd/plugin.go` — cobra commands
- `go/cmd/root.go` — unknown command → plugin fallback
- `go/cmd/create.go`, `go/cmd/preset.go` — interactive preset picker
- `go/e2e/run.sh` — 8 new e2e tests (70 total, all passing)
- `docs/plugins.md` — plugin documentation

## Test plan

- [x] `gw plugin list` — shows empty, then shows installed plugins
- [x] `gw hello` (with script in plugins dir) — falls back to plugin, passes env vars and args
- [x] `gw plugin remove hello` — deletes binary and metadata
- [x] `gw nonexistent` — shows error, exits 1
- [x] All 70 e2e tests pass
- [x] All 229 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)