### PR TITLE
Add gw ws delete and global lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ All interactive menus support **type-to-search** filtering, arrow-key navigation
 
 ## Documentation
 
-- [Per-repo config & hooks](docs/hooks.md) — `.grove.toml`, lifecycle hooks, `gw run`
+- [Hooks](docs/hooks.md) — global hooks (terminal integration) & per-repo hooks (`.grove.toml`, `gw run`)
 - [Plugins](docs/plugins.md) — extend gw with external commands
 - [AI coding tools](docs/ai-tools.md) — Claude Code workflows, MCP server
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -11,7 +11,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var deleteForce bool
+var (
+	deleteCmdForce   bool
+	wsDeleteCmdForce bool
+)
 
 // deleteCmd is the top-level "gw delete" command.
 var deleteCmd = &cobra.Command{
@@ -19,7 +22,7 @@ var deleteCmd = &cobra.Command{
 	Short: "Delete a workspace (shortcut for gw ws delete)",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		doDelete(args)
+		doDelete(args, deleteCmdForce)
 	},
 }
 
@@ -29,11 +32,11 @@ var wsDeleteCmd = &cobra.Command{
 	Short: "Delete a workspace",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		doDelete(args)
+		doDelete(args, wsDeleteCmdForce)
 	},
 }
 
-func doDelete(args []string) {
+func doDelete(args []string, force bool) {
 	var names []string
 
 	if len(args) > 0 {
@@ -58,7 +61,7 @@ func doDelete(args []string) {
 		names = selected
 	}
 
-	if !deleteForce {
+	if !force {
 		if !console.Confirm(fmt.Sprintf("Delete %s?", strings.Join(names, ", ")), false) {
 			return
 		}
@@ -72,9 +75,9 @@ func doDelete(args []string) {
 }
 
 func init() {
-	deleteCmd.Flags().BoolVarP(&deleteForce, "force", "f", false, "Skip confirmation")
+	deleteCmd.Flags().BoolVarP(&deleteCmdForce, "force", "f", false, "Skip confirmation")
 	deleteCmd.ValidArgsFunction = completeWorkspaceNames
 
-	wsDeleteCmd.Flags().BoolVarP(&deleteForce, "force", "f", false, "Skip confirmation")
+	wsDeleteCmd.Flags().BoolVarP(&wsDeleteCmdForce, "force", "f", false, "Skip confirmation")
 	wsDeleteCmd.ValidArgsFunction = completeWorkspaceNames
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -13,50 +13,68 @@ import (
 
 var deleteForce bool
 
+// deleteCmd is the top-level "gw delete" command.
 var deleteCmd = &cobra.Command{
+	Use:   "delete [NAME]",
+	Short: "Delete a workspace (shortcut for gw ws delete)",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		doDelete(args)
+	},
+}
+
+// wsDeleteCmd is "gw ws delete".
+var wsDeleteCmd = &cobra.Command{
 	Use:   "delete [NAME]",
 	Short: "Delete a workspace",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		var names []string
-
-		if len(args) > 0 {
-			names = []string{args[0]}
-		} else {
-			// Interactive multi-select
-			workspaces, err := state.Load()
-			if err != nil {
-				exitError(err.Error())
-			}
-			if len(workspaces) == 0 {
-				exitError("No workspaces to delete")
-			}
-			choices := make([]string, len(workspaces))
-			for i, ws := range workspaces {
-				choices[i] = ws.Name
-			}
-			selected, err := picker.PickMany("Select workspaces to delete:", choices)
-			if err != nil {
-				exitOnPickerErr(err)
-			}
-			names = selected
-		}
-
-		if !deleteForce {
-			if !console.Confirm(fmt.Sprintf("Delete %s?", strings.Join(names, ", ")), false) {
-				return
-			}
-		}
-
-		for _, name := range names {
-			if err := workspace.NewService().Delete(name); err != nil {
-				exitError(err.Error())
-			}
-		}
+		doDelete(args)
 	},
+}
+
+func doDelete(args []string) {
+	var names []string
+
+	if len(args) > 0 {
+		names = []string{args[0]}
+	} else {
+		// Interactive multi-select
+		workspaces, err := state.Load()
+		if err != nil {
+			exitError(err.Error())
+		}
+		if len(workspaces) == 0 {
+			exitError("No workspaces to delete")
+		}
+		choices := make([]string, len(workspaces))
+		for i, ws := range workspaces {
+			choices[i] = ws.Name
+		}
+		selected, err := picker.PickMany("Select workspaces to delete:", choices)
+		if err != nil {
+			exitOnPickerErr(err)
+		}
+		names = selected
+	}
+
+	if !deleteForce {
+		if !console.Confirm(fmt.Sprintf("Delete %s?", strings.Join(names, ", ")), false) {
+			return
+		}
+	}
+
+	for _, name := range names {
+		if err := workspace.NewService().Delete(name); err != nil {
+			exitError(err.Error())
+		}
+	}
 }
 
 func init() {
 	deleteCmd.Flags().BoolVarP(&deleteForce, "force", "f", false, "Skip confirmation")
 	deleteCmd.ValidArgsFunction = completeWorkspaceNames
+
+	wsDeleteCmd.Flags().BoolVarP(&deleteForce, "force", "f", false, "Skip confirmation")
+	wsDeleteCmd.ValidArgsFunction = completeWorkspaceNames
 }

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/nicksenap/grove/internal/config"
 	"github.com/nicksenap/grove/internal/console"
+	"github.com/nicksenap/grove/internal/models"
 	"github.com/nicksenap/grove/internal/workspace"
 	"github.com/spf13/cobra"
 )
@@ -23,6 +25,9 @@ var doctorCmd = &cobra.Command{
 		if err != nil {
 			exitError(err.Error())
 		}
+
+		// TODO: remove when matured — nudge users to migrate to [hooks] config.
+		issues = append(issues, checkMissingHooks()...)
 
 		if doctorJSON {
 			data, _ := json.MarshalIndent(issues, "", "  ")
@@ -49,6 +54,29 @@ var doctorCmd = &cobra.Command{
 			console.Successf("Fixed %d issue(s)", fixed)
 		}
 	},
+}
+
+// TODO: remove when matured — nudge users to migrate to [hooks] config.
+func checkMissingHooks() []models.DoctorIssue {
+	cfg, err := config.Load()
+	if err != nil || cfg == nil {
+		return nil
+	}
+
+	if _, ok := cfg.Hooks["on_close"]; ok {
+		return nil
+	}
+
+	// Only flag if Zellij is present — that's what the old hardcoded behavior supported.
+	if os.Getenv("ZELLIJ_SESSION_NAME") == "" {
+		return nil
+	}
+
+	return []models.DoctorIssue{{
+		Workspace:       "—",
+		Issue:           "no on_close hook configured (using legacy Zellij fallback)",
+		SuggestedAction: "add [hooks] on_close to ~/.grove/config.toml",
+	}}
 }
 
 func init() {

--- a/cmd/go_cmd.go
+++ b/cmd/go_cmd.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"errors"
 	"os/exec"
 	"syscall"
 
@@ -41,14 +42,12 @@ var goCmd = &cobra.Command{
 					deleteAsync(ws.Name)
 				}
 			}
-			if lifecycle.Has("on_close") {
-				if err := lifecycle.Run("on_close", lifecycle.Vars{}); err != nil {
-					exitError(fmt.Sprintf("on_close hook failed: %s", err))
-				}
-			} else {
+			if err := lifecycle.Run("on_close", lifecycle.Vars{}); errors.Is(err, lifecycle.ErrNoHook) {
 				// TODO: remove when matured — legacy Zellij fallback for users who
 				// upgraded before the [hooks] system existed.
 				zellijCloseFallback()
+			} else if err != nil {
+				exitError(fmt.Sprintf("on_close hook failed: %s", err))
 			}
 			return
 		}

--- a/cmd/go_cmd.go
+++ b/cmd/go_cmd.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nicksenap/grove/internal/config"
 	"github.com/nicksenap/grove/internal/console"
+	"github.com/nicksenap/grove/internal/lifecycle"
 	"github.com/nicksenap/grove/internal/picker"
 	"github.com/nicksenap/grove/internal/state"
 	"github.com/spf13/cobra"
@@ -30,7 +31,7 @@ var goCmd = &cobra.Command{
 	Long:  "Prints workspace path to stdout. Auto-detects from cwd for --back.",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		// --close-tab: close current Zellij tab/pane
+		// --close-tab: fire on_close lifecycle hook
 		if goCloseTab {
 			if goDelete {
 				// Delete current workspace first
@@ -40,8 +41,15 @@ var goCmd = &cobra.Command{
 					deleteAsync(ws.Name)
 				}
 			}
-			// Close Zellij pane
-			zellijClose()
+			if lifecycle.Has("on_close") {
+				if err := lifecycle.Run("on_close", lifecycle.Vars{}); err != nil {
+					exitError(fmt.Sprintf("on_close hook failed: %s", err))
+				}
+			} else {
+				// TODO: remove when matured — legacy Zellij fallback for users who
+				// upgraded before the [hooks] system existed.
+				zellijCloseFallback()
+			}
 			return
 		}
 
@@ -198,18 +206,17 @@ func deleteAsync(name string) {
 	cmd.Start() // fire and forget
 }
 
-func zellijClose() {
-	sessionName := os.Getenv("ZELLIJ_SESSION_NAME")
-	if sessionName == "" {
-		exitError("Not inside a Zellij session")
+// TODO: remove when matured — legacy Zellij fallback for users without [hooks] config.
+func zellijCloseFallback() {
+	if os.Getenv("ZELLIJ_SESSION_NAME") == "" {
+		exitError("No on_close hook configured. Set one in ~/.grove/config.toml:\n\n  [hooks]\n  on_close = \"zellij action close-pane\"")
 	}
-	cmd := exec.Command("zellij", "action", "close-pane")
-	cmd.Run()
+	exec.Command("zellij", "action", "close-pane").Run()
 }
 
 func init() {
 	goCmd.Flags().BoolVarP(&goBack, "back", "b", false, "Go back to source repo")
 	goCmd.Flags().BoolVarP(&goDelete, "delete", "d", false, "Delete workspace after navigating away")
-	goCmd.Flags().BoolVarP(&goCloseTab, "close-tab", "c", false, "Close current Zellij pane/tab")
+	goCmd.Flags().BoolVarP(&goCloseTab, "close-tab", "c", false, "Fire on_close hook (e.g. close terminal pane)")
 	goCmd.ValidArgsFunction = completeWorkspaceNames
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -59,7 +59,7 @@ func init() {
 	wsListCmd.Flags().BoolVarP(&listJSON, "json", "j", false, "Output as JSON")
 	wsListCmd.Flags().BoolVarP(&listStatus, "status", "s", false, "Include git status")
 	wsShowCmd.Flags().BoolVarP(&wsShowJSON, "json", "j", false, "Output as JSON")
-	wsCmd.AddCommand(wsListCmd, wsShowCmd)
+	wsCmd.AddCommand(wsListCmd, wsShowCmd, wsDeleteCmd)
 
 	listCmd.Flags().BoolVarP(&listJSON, "json", "j", false, "Output as JSON")
 	listCmd.Flags().BoolVarP(&listStatus, "status", "s", false, "Include git status")

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -11,7 +11,7 @@ Global hooks live in `~/.grove/config.toml` under `[hooks]`. Grove fires these o
 on_close = "zellij action close-pane"
 ```
 
-`gw init` auto-detects your terminal multiplexer (Zellij, tmux) and bootstraps sensible defaults.
+Run `gw doctor` to check if you're missing any recommended hooks.
 
 ### Available hooks
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,4 +1,36 @@
-# Per-repo config & hooks
+# Hooks
+
+Grove has two levels of hooks: **global hooks** for workspace-level actions, and **per-repo hooks** for repo-specific lifecycle events.
+
+## Global hooks
+
+Global hooks live in `~/.grove/config.toml` under `[hooks]`. Grove fires these on workspace-level actions — they're how you integrate with your terminal multiplexer or trigger notifications.
+
+```toml
+[hooks]
+on_close = "zellij action close-pane"
+```
+
+`gw init` auto-detects your terminal multiplexer (Zellij, tmux) and bootstraps sensible defaults.
+
+### Available hooks
+
+| Hook | Fired by | Example |
+|------|----------|---------|
+| `on_close` | `gw go -c` | `zellij action close-pane`, `tmux kill-pane` |
+
+### Placeholders
+
+Hook commands can use `{name}`, `{path}`, and `{branch}` — Grove expands them before execution.
+
+```toml
+[hooks]
+on_close = "tmux kill-pane"
+```
+
+---
+
+## Per-repo hooks
 
 Drop a `.grove.toml` in any repo to override defaults:
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -413,6 +413,30 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test: gw ws delete (subcommand parity with gw delete)
+# ---------------------------------------------------------------------------
+section "ws delete subcommand"
+
+gw create ws-del-sub --branch feat/ws-del --repos svc-auth 2>&1
+pass "workspace for ws delete test created"
+
+gw ws delete ws-del-sub --force 2>&1
+pass "gw ws delete succeeded"
+
+count=$(gw list --json 2>/dev/null | jq 'length')
+if [ "${count}" = "1" ]; then
+    pass "workspace removed by gw ws delete"
+else
+    fail "expected 1 workspace after gw ws delete, got ${count}"
+fi
+
+if [ ! -d "${GROVE_HOME}/.grove/workspaces/ws-del-sub" ]; then
+    pass "workspace directory cleaned up by ws delete"
+else
+    fail "ws-del-sub directory still exists after ws delete"
+fi
+
+# ---------------------------------------------------------------------------
 # Test: presets
 # ---------------------------------------------------------------------------
 section "Presets"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 
@@ -117,6 +118,7 @@ func Init(dirs []string) (*models.Config, error) {
 			RepoDirs:     []string{},
 			WorkspaceDir: DefaultWorkspaceDir,
 			Presets:      make(map[string]models.Preset),
+			Hooks:        detectDefaultHooks(),
 		}
 	}
 
@@ -156,4 +158,22 @@ func Init(dirs []string) (*models.Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// detectDefaultHooks returns lifecycle hooks bootstrapped from the current terminal environment.
+func detectDefaultHooks() map[string]string {
+	hooks := make(map[string]string)
+
+	if os.Getenv("ZELLIJ_SESSION_NAME") != "" || isOnPath("zellij") {
+		hooks["on_close"] = "zellij action close-pane"
+	} else if os.Getenv("TMUX") != "" || isOnPath("tmux") {
+		hooks["on_close"] = "tmux kill-pane"
+	}
+
+	return hooks
+}
+
+func isOnPath(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,9 +164,16 @@ func Init(dirs []string) (*models.Config, error) {
 func detectDefaultHooks() map[string]string {
 	hooks := make(map[string]string)
 
-	if os.Getenv("ZELLIJ_SESSION_NAME") != "" || isOnPath("zellij") {
+	// Prefer active session over binary-on-PATH to avoid bootstrapping
+	// the wrong multiplexer when both are installed.
+	switch {
+	case os.Getenv("ZELLIJ_SESSION_NAME") != "":
 		hooks["on_close"] = "zellij action close-pane"
-	} else if os.Getenv("TMUX") != "" || isOnPath("tmux") {
+	case os.Getenv("TMUX") != "":
+		hooks["on_close"] = "tmux kill-pane"
+	case isOnPath("zellij"):
+		hooks["on_close"] = "zellij action close-pane"
+	case isOnPath("tmux"):
 		hooks["on_close"] = "tmux kill-pane"
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 
@@ -118,7 +117,6 @@ func Init(dirs []string) (*models.Config, error) {
 			RepoDirs:     []string{},
 			WorkspaceDir: DefaultWorkspaceDir,
 			Presets:      make(map[string]models.Preset),
-			Hooks:        detectDefaultHooks(),
 		}
 	}
 
@@ -158,29 +156,4 @@ func Init(dirs []string) (*models.Config, error) {
 	}
 
 	return cfg, nil
-}
-
-// detectDefaultHooks returns lifecycle hooks bootstrapped from the current terminal environment.
-func detectDefaultHooks() map[string]string {
-	hooks := make(map[string]string)
-
-	// Prefer active session over binary-on-PATH to avoid bootstrapping
-	// the wrong multiplexer when both are installed.
-	switch {
-	case os.Getenv("ZELLIJ_SESSION_NAME") != "":
-		hooks["on_close"] = "zellij action close-pane"
-	case os.Getenv("TMUX") != "":
-		hooks["on_close"] = "tmux kill-pane"
-	case isOnPath("zellij"):
-		hooks["on_close"] = "zellij action close-pane"
-	case isOnPath("tmux"):
-		hooks["on_close"] = "tmux kill-pane"
-	}
-
-	return hooks
-}
-
-func isOnPath(name string) bool {
-	_, err := exec.LookPath(name)
-	return err == nil
 }

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -2,13 +2,16 @@
 package lifecycle
 
 import (
-	"fmt"
+	"errors"
 	"os/exec"
 	"strings"
 
 	"github.com/nicksenap/grove/internal/config"
 	"github.com/nicksenap/grove/internal/logging"
 )
+
+// ErrNoHook is returned when the requested hook is not configured.
+var ErrNoHook = errors.New("hook not configured")
 
 // Vars is a set of placeholder values expanded in hook commands.
 // Use {name}, {path}, {branch} in hook commands.
@@ -18,32 +21,22 @@ type Vars struct {
 	Branch string
 }
 
-// Run fires a named hook if configured. Returns error if not set or execution fails.
+// Run fires a named hook if configured. Returns ErrNoHook if not set.
 func Run(hookName string, vars Vars) error {
 	cfg, err := config.Load()
 	if err != nil || cfg == nil {
-		return nil
+		return ErrNoHook
 	}
 
 	cmd, ok := cfg.Hooks[hookName]
 	if !ok || cmd == "" {
-		return fmt.Errorf("no hook configured for %q", hookName)
+		return ErrNoHook
 	}
 
 	expanded := expand(cmd, vars)
 	logging.Info("hook %s: %s", hookName, expanded)
 
 	return exec.Command("sh", "-c", expanded).Run()
-}
-
-// Has returns true if a hook is configured for the given name.
-func Has(hookName string) bool {
-	cfg, err := config.Load()
-	if err != nil || cfg == nil {
-		return false
-	}
-	cmd, ok := cfg.Hooks[hookName]
-	return ok && cmd != ""
 }
 
 func expand(cmd string, vars Vars) string {

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -1,0 +1,65 @@
+// Package lifecycle runs global lifecycle hooks defined in ~/.grove/config.toml [hooks].
+package lifecycle
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/nicksenap/grove/internal/config"
+	"github.com/nicksenap/grove/internal/logging"
+)
+
+// Vars is a set of placeholder values expanded in hook commands.
+// Use {name}, {path}, {branch} in hook commands.
+type Vars struct {
+	Name   string
+	Path   string
+	Branch string
+}
+
+// Run fires a named hook if configured. Returns error if not set or execution fails.
+func Run(hookName string, vars Vars) error {
+	cfg, err := config.Load()
+	if err != nil || cfg == nil {
+		return nil
+	}
+
+	cmd, ok := cfg.Hooks[hookName]
+	if !ok || cmd == "" {
+		return fmt.Errorf("no hook configured for %q", hookName)
+	}
+
+	expanded := expand(cmd, vars)
+	logging.Info("hook %s: %s", hookName, expanded)
+
+	return exec.Command("sh", "-c", expanded).Run()
+}
+
+// Has returns true if a hook is configured for the given name.
+func Has(hookName string) bool {
+	cfg, err := config.Load()
+	if err != nil || cfg == nil {
+		return false
+	}
+	cmd, ok := cfg.Hooks[hookName]
+	return ok && cmd != ""
+}
+
+func expand(cmd string, vars Vars) string {
+	r := strings.NewReplacer(
+		"{name}", shellQuote(vars.Name),
+		"{path}", shellQuote(vars.Path),
+		"{branch}", shellQuote(vars.Branch),
+	)
+	return r.Replace(cmd)
+}
+
+// shellQuote wraps a value in single quotes, escaping any embedded single quotes.
+// Empty strings are not quoted so unused placeholders expand to nothing.
+func shellQuote(s string) string {
+	if s == "" {
+		return ""
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -1,0 +1,80 @@
+package lifecycle
+
+import "testing"
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"simple", "my-workspace", "'my-workspace'"},
+		{"spaces", "my workspace", "'my workspace'"},
+		{"single quotes", "it's", "'it'\\''s'"},
+		{"semicolon injection", "x; rm -rf ~", "'x; rm -rf ~'"},
+		{"subshell injection", "$(whoami)", "'$(whoami)'"},
+		{"backtick injection", "`whoami`", "'`whoami`'"},
+		{"pipe injection", "x | cat /etc/passwd", "'x | cat /etc/passwd'"},
+		{"ampersand injection", "x && echo pwned", "'x && echo pwned'"},
+		{"newline injection", "x\nrm -rf /", "'x\nrm -rf /'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shellQuote(tt.in)
+			if got != tt.want {
+				t.Errorf("shellQuote(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpand(t *testing.T) {
+	tests := []struct {
+		name   string
+		cmd    string
+		vars   Vars
+		want   string
+	}{
+		{
+			name: "no placeholders",
+			cmd:  "zellij action close-pane",
+			vars: Vars{},
+			want: "zellij action close-pane",
+		},
+		{
+			name: "all placeholders",
+			cmd:  "echo {name} {path} {branch}",
+			vars: Vars{Name: "ws-1", Path: "/tmp/ws", Branch: "feat/login"},
+			want: "echo 'ws-1' '/tmp/ws' 'feat/login'",
+		},
+		{
+			name: "injection in branch name",
+			cmd:  "echo {branch}",
+			vars: Vars{Branch: "feat/x; rm -rf ~"},
+			want: "echo 'feat/x; rm -rf ~'",
+		},
+		{
+			name: "injection via subshell",
+			cmd:  "echo {name}",
+			vars: Vars{Name: "$(rm -rf /)"},
+			want: "echo '$(rm -rf /)'",
+		},
+		{
+			name: "empty vars expand to nothing",
+			cmd:  "do-thing {name}",
+			vars: Vars{},
+			want: "do-thing ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := expand(tt.cmd, tt.vars)
+			if got != tt.want {
+				t.Errorf("expand(%q, %+v) = %q, want %q", tt.cmd, tt.vars, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -75,6 +75,7 @@ type Config struct {
 	WorkspaceDir     string            `toml:"workspace_dir"`
 	ClaudeMemorySync bool              `toml:"claude_memory_sync"`
 	Presets          map[string]Preset `toml:"presets"`
+	Hooks            map[string]string `toml:"hooks"`
 	// Legacy field — auto-migrated to RepoDirs
 	ReposDir string `toml:"repos_dir"`
 }


### PR DESCRIPTION
## Summary

- Add `gw ws delete` with interactive multi-select, matching `gw delete` behavior
- Introduce global `[hooks]` system in `~/.grove/config.toml` — `gw go -c` now fires `on_close` hook instead of hardcoded Zellij close
- New `internal/lifecycle` package with shell-quoted placeholder expansion (`{name}`, `{path}`, `{branch}`) to prevent injection
- Legacy Zellij fallback for existing users without `[hooks]` config (marked TODO for removal)
- `gw doctor` flags missing `on_close` hook when running inside Zellij

## Test plan

- [x] Unit tests for shell quoting and placeholder expansion (injection vectors covered)
- [x] E2E test for `gw ws delete --force`
- [x] All 93 e2e tests pass
- [x] All unit tests pass
- [ ] Manual: verify `gw go -c` works with `[hooks] on_close` configured
- [ ] Manual: verify `gw go -c` falls back to Zellij without `[hooks]` config
- [ ] Manual: verify `gw doctor` reports missing hook inside Zellij

🤖 Generated with [Claude Code](https://claude.com/claude-code)