### PR TITLE
Replace CLAUDE.md copy with post_create lifecycle hook

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +9,7 @@ import (
 	"github.com/nicksenap/grove/internal/config"
 	"github.com/nicksenap/grove/internal/console"
 	"github.com/nicksenap/grove/internal/discover"
+	"github.com/nicksenap/grove/internal/lifecycle"
 	"github.com/nicksenap/grove/internal/models"
 	"github.com/nicksenap/grove/internal/picker"
 	"github.com/nicksenap/grove/internal/workspace"
@@ -15,11 +17,10 @@ import (
 )
 
 var (
-	createBranch      string
-	createRepos       string
-	createPreset      string
-	createAll         bool
-	createCopyClaudeMD *bool
+	createBranch  string
+	createRepos   string
+	createPreset  string
+	createAll     bool
 )
 
 var createCmd = &cobra.Command{
@@ -143,25 +144,14 @@ var createCmd = &cobra.Command{
 			exitError(err.Error())
 		}
 
-		// Copy CLAUDE.md if requested
+		// Fire post_create hook if configured
 		wsPath := filepath.Join(cfg.WorkspaceDir, name)
-		if createCopyClaudeMD != nil {
-			if *createCopyClaudeMD {
-				copyCLAUDEmd(repoMap, repoNames, wsPath)
-			}
-		} else if console.IsTerminal(os.Stdin) {
-			// Auto-detect: check if any repo has a CLAUDE.md
-			for _, repoName := range repoNames {
-				if src, ok := repoMap[repoName]; ok {
-					claudeMD := filepath.Join(src, "CLAUDE.md")
-					if _, err := os.Stat(claudeMD); err == nil {
-						if console.Confirm("Copy CLAUDE.md into workspace?", true) {
-							copyCLAUDEmd(repoMap, repoNames, wsPath)
-						}
-						break
-					}
-				}
-			}
+		vars := lifecycle.Vars{Name: name, Path: wsPath, Branch: branch}
+		if err := lifecycle.Run("post_create", vars); errors.Is(err, lifecycle.ErrNoHook) {
+			// TODO: remove when matured — legacy fallback for users without [hooks] config.
+			copyParentCLAUDEmd(wsPath)
+		} else if err != nil {
+			console.Warningf("post_create hook failed: %s", err)
 		}
 	},
 }
@@ -171,39 +161,20 @@ func init() {
 	createCmd.Flags().StringVarP(&createRepos, "repos", "r", "", "Comma-separated repo names")
 	createCmd.Flags().StringVarP(&createPreset, "preset", "p", "", "Use named preset")
 	createCmd.Flags().BoolVar(&createAll, "all", false, "Use all discovered repos")
-	createCmd.Flags().Bool("copy-claude-md", false, "Copy CLAUDE.md into workspace dir")
-	createCmd.Flags().Bool("no-copy-claude-md", false, "Don't copy CLAUDE.md")
 
 	createCmd.RegisterFlagCompletionFunc("repos", completeRepoNames)
 	createCmd.RegisterFlagCompletionFunc("preset", completePresetNames)
-
-	// Resolve --copy-claude-md / --no-copy-claude-md
-	createCmd.PreRun = func(cmd *cobra.Command, args []string) {
-		if cmd.Flags().Changed("copy-claude-md") {
-			v := true
-			createCopyClaudeMD = &v
-		} else if cmd.Flags().Changed("no-copy-claude-md") {
-			v := false
-			createCopyClaudeMD = &v
-		}
-	}
 }
 
-func copyCLAUDEmd(repoMap map[string]string, repoNames []string, wsPath string) {
-	for _, repoName := range repoNames {
-		src, ok := repoMap[repoName]
-		if !ok {
-			continue
-		}
-		claudeMD := filepath.Join(src, "CLAUDE.md")
-		data, err := os.ReadFile(claudeMD)
-		if err != nil {
-			continue
-		}
-		dst := filepath.Join(wsPath, "CLAUDE.md")
-		os.WriteFile(dst, data, 0o644)
-		return // only copy from first repo that has it
+
+// TODO: remove when matured — legacy fallback for users without [hooks] config.
+func copyParentCLAUDEmd(wsPath string) {
+	src := filepath.Join(wsPath, "..", "CLAUDE.md")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return
 	}
+	os.WriteFile(filepath.Join(wsPath, "CLAUDE.md"), data, 0o644)
 }
 
 func deriveName(branch string) string {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -166,7 +166,6 @@ func init() {
 	createCmd.RegisterFlagCompletionFunc("preset", completePresetNames)
 }
 
-
 // TODO: remove when matured — legacy fallback for users without [hooks] config.
 func copyParentCLAUDEmd(wsPath string) {
 	src := filepath.Join(wsPath, "..", "CLAUDE.md")
@@ -174,7 +173,9 @@ func copyParentCLAUDEmd(wsPath string) {
 	if err != nil {
 		return
 	}
-	os.WriteFile(filepath.Join(wsPath, "CLAUDE.md"), data, 0o644)
+	if err := os.WriteFile(filepath.Join(wsPath, "CLAUDE.md"), data, 0o644); err != nil {
+		console.Warningf("legacy CLAUDE.md copy failed: %s", err)
+	}
 }
 
 func deriveName(branch string) string {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/nicksenap/grove/internal/config"
 	"github.com/nicksenap/grove/internal/console"
@@ -77,11 +78,15 @@ func checkMissingHooks() []models.DoctorIssue {
 	}
 
 	if _, ok := cfg.Hooks["post_create"]; !ok {
-		issues = append(issues, models.DoctorIssue{
-			Workspace:       "—",
-			Issue:           "no post_create hook configured (using legacy CLAUDE.md copy)",
-			SuggestedAction: `add [hooks] post_create = "cp {path}/../CLAUDE.md {path}/CLAUDE.md 2>/dev/null || true"`,
-		})
+		// Only flag if ~/.claude exists — user is a Claude Code user.
+		home, _ := os.UserHomeDir()
+		if _, err := os.Stat(filepath.Join(home, ".claude")); err == nil {
+			issues = append(issues, models.DoctorIssue{
+				Workspace:       "—",
+				Issue:           "no post_create hook configured (using legacy CLAUDE.md copy)",
+				SuggestedAction: `add [hooks] post_create = "cp {path}/../CLAUDE.md {path}/CLAUDE.md 2>/dev/null || true"`,
+			})
+		}
 	}
 
 	return issues

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -63,20 +63,28 @@ func checkMissingHooks() []models.DoctorIssue {
 		return nil
 	}
 
-	if _, ok := cfg.Hooks["on_close"]; ok {
-		return nil
+	var issues []models.DoctorIssue
+
+	if _, ok := cfg.Hooks["on_close"]; !ok {
+		// Only flag if Zellij is present — that's what the old hardcoded behavior supported.
+		if os.Getenv("ZELLIJ_SESSION_NAME") != "" {
+			issues = append(issues, models.DoctorIssue{
+				Workspace:       "—",
+				Issue:           "no on_close hook configured (using legacy Zellij fallback)",
+				SuggestedAction: "add [hooks] on_close to ~/.grove/config.toml",
+			})
+		}
 	}
 
-	// Only flag if Zellij is present — that's what the old hardcoded behavior supported.
-	if os.Getenv("ZELLIJ_SESSION_NAME") == "" {
-		return nil
+	if _, ok := cfg.Hooks["post_create"]; !ok {
+		issues = append(issues, models.DoctorIssue{
+			Workspace:       "—",
+			Issue:           "no post_create hook configured (using legacy CLAUDE.md copy)",
+			SuggestedAction: `add [hooks] post_create = "cp {path}/../CLAUDE.md {path}/CLAUDE.md 2>/dev/null || true"`,
+		})
 	}
 
-	return []models.DoctorIssue{{
-		Workspace:       "—",
-		Issue:           "no on_close hook configured (using legacy Zellij fallback)",
-		SuggestedAction: "add [hooks] on_close to ~/.grove/config.toml",
-	}}
+	return issues
 }
 
 func init() {


### PR DESCRIPTION
## Summary
- Replace hardcoded CLAUDE.md copy + interactive prompt with `post_create` lifecycle hook
- Legacy fallback copies from parent dir when no hook is configured (same deprecation pattern as `on_close`/Zellij)
- Doctor nudges Claude Code users to migrate to the hook (gated on `~/.claude` existing)

Users configure via:
```toml
[hooks]
post_create = "cp {path}/../CLAUDE.md {path}/CLAUDE.md 2>/dev/null || true"
```

## Test plan
- [ ] `gw create` without `post_create` hook copies CLAUDE.md from parent (legacy fallback)
- [ ] `gw create` with `post_create` hook runs the hook instead
- [ ] `gw doctor` only shows post_create nudge when `~/.claude` exists
- [ ] `gw doctor` still shows on_close nudge when Zellij is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)