### PR TITLE
feat(create): seed workspaces from a source (PR/task/thread)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v1.1.8
+
+### Features
+
+- `gw create` can now seed a workspace from an **existing remote branch** with `--track` (e.g. a pull-request head): instead of creating a new branch from the base, it checks out `origin/<branch>` as a tracking worktree. If the remote branch is missing (deleted, force-pushed, or a fork PR whose head lives on another remote), it falls back to creating a new branch from base with a warning.
+- `gw create` records where a workspace came from. New `--source-url`, `--source-provider`, `--source-ref`, and `--source-title` flags persist an opaque `source` link on the workspace, which is surfaced in `gw status` (and its `--json`) and exposed to the `post_create` hook via the new `{source_url}`, `{source_ref}`, and `{source_title}` placeholders.
+- `gw create --repos` now accepts git URLs and clones them into the first configured repo dir (matching `gw add-repo` behavior).
+- New `gw repos` command lists discovered repos with their origin remote and derived `owner/repo` name. `gw repos --json` gives machine-readable output so external tooling can map a remote `owner/repo` back to a local clone.
+
+These primitives are provider-agnostic building blocks: they let an external plugin (e.g. `gw-grab`) turn a GitHub PR / Notion / Slack URL into a ready-to-work workspace, while Grove core stays a pure git worktree orchestrator.
+
+### Internal
+
+- e2e suite now covers `gw repos`, `gw create --track` (incl. the missing-remote fallback), source-link persistence/surfacing, and the `post_create` `{source_*}` placeholders. The MCP e2e tests now use a portable timeout wrapper (`gtimeout` fallback) so the suite runs green on macOS.
+
 ## v1.1.7
 
 ### Fixes

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nicksenap/grove/internal/config"
 	"github.com/nicksenap/grove/internal/console"
 	"github.com/nicksenap/grove/internal/discover"
+	"github.com/nicksenap/grove/internal/gitops"
 	"github.com/nicksenap/grove/internal/lifecycle"
 	"github.com/nicksenap/grove/internal/models"
 	"github.com/nicksenap/grove/internal/picker"
@@ -18,12 +19,17 @@ import (
 )
 
 var (
-	createBranch  string
-	createRepos   string
-	createPreset  string
-	createAll     bool
-	createReplace bool
-	createForce   bool
+	createBranch        string
+	createRepos         string
+	createPreset        string
+	createAll           bool
+	createReplace       bool
+	createForce         bool
+	createTrack         bool
+	createSourceURL     string
+	createSourceProvide string
+	createSourceRef     string
+	createSourceTitle   string
 )
 
 var createCmd = &cobra.Command{
@@ -52,6 +58,27 @@ var createCmd = &cobra.Command{
 			repoNames = strings.Split(createRepos, ",")
 			for i := range repoNames {
 				repoNames[i] = strings.TrimSpace(repoNames[i])
+			}
+			// Clone any remote git URLs into the first repo_dir (mirrors add-repo).
+			// This lets a resolver pass an unmatched repo as a clone URL.
+			for i, name := range repoNames {
+				if !gitops.IsGitURL(name) {
+					continue
+				}
+				if len(cfg.RepoDirs) == 0 {
+					exitError("No repo_dirs configured — cannot clone remote repo")
+				}
+				console.Infof("Cloning %s ...", name)
+				clonedPath, repoName, err := gitops.Clone(name, cfg.RepoDirs[0])
+				if err != nil {
+					exitError(err.Error())
+				}
+				if existing, ok := repoMap[repoName]; ok && existing != clonedPath {
+					exitError("repo name conflict: " + repoName + " already exists locally at " + existing)
+				}
+				repoMap[repoName] = clonedPath
+				repoNames[i] = repoName
+				console.Successf("Cloned %s into %s", repoName, clonedPath)
 			}
 		} else {
 			// Interactive
@@ -173,7 +200,30 @@ var createCmd = &cobra.Command{
 			replacedName = currentWs.Name
 		}
 
-		if err := workspace.NewService().Create(name, branch, repoNames, repoMap, cfg); err != nil {
+		// Build provenance + branch-mode options. A source URL is opaque to core;
+		// --track checks out an existing remote branch (e.g. a PR head) instead
+		// of creating a new one, falling back to create-mode if it is missing.
+		var source *models.WorkspaceSource
+		if createSourceURL != "" || createSourceProvide != "" {
+			source = &models.WorkspaceSource{
+				Provider: createSourceProvide,
+				URL:      createSourceURL,
+				Ref:      createSourceRef,
+				Title:    createSourceTitle,
+			}
+		}
+		opts := workspace.CreateOpts{
+			Branch:  branch,
+			Repos:   repoNames,
+			RepoMap: repoMap,
+			Cfg:     cfg,
+			Source:  source,
+		}
+		if createTrack {
+			opts.BranchMode = workspace.BranchModeTrack
+		}
+
+		if err := workspace.NewService().CreateWithOpts(name, opts); err != nil {
 			if replacedName != "" {
 				exitError("failed to create new workspace (old workspace " + replacedName + " was already deleted): " + err.Error())
 			}
@@ -183,6 +233,11 @@ var createCmd = &cobra.Command{
 		// Fire post_create hook if configured
 		wsPath := filepath.Join(cfg.WorkspaceDir, name)
 		vars := lifecycle.Vars{Name: name, Path: wsPath, Branch: branch}
+		if source != nil {
+			vars.SourceURL = source.URL
+			vars.SourceRef = source.Ref
+			vars.SourceTitle = source.Title
+		}
 		if err := lifecycle.Run("post_create", vars); err != nil && !errors.Is(err, lifecycle.ErrNoHook) {
 			console.Warningf("post_create hook failed: %s", err)
 		}
@@ -196,6 +251,11 @@ func init() {
 	createCmd.Flags().BoolVar(&createAll, "all", false, "Use all discovered repos")
 	createCmd.Flags().BoolVar(&createReplace, "replace", false, "Delete the current workspace (detected from cwd) before creating the new one")
 	createCmd.Flags().BoolVarP(&createForce, "force", "f", false, "Skip --replace confirmation prompt")
+	createCmd.Flags().BoolVar(&createTrack, "track", false, "Check out an existing remote branch (e.g. a PR head) instead of creating a new one")
+	createCmd.Flags().StringVar(&createSourceURL, "source-url", "", "Record the source URL this workspace was seeded from")
+	createCmd.Flags().StringVar(&createSourceProvide, "source-provider", "", "Source provider label (e.g. github, notion, slack)")
+	createCmd.Flags().StringVar(&createSourceRef, "source-ref", "", "Source ref (PR number, page id, message ts)")
+	createCmd.Flags().StringVar(&createSourceTitle, "source-title", "", "Human-readable source title for display")
 
 	createCmd.RegisterFlagCompletionFunc("repos", completeRepoNames)
 	createCmd.RegisterFlagCompletionFunc("preset", completePresetNames)

--- a/cmd/repos.go
+++ b/cmd/repos.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nicksenap/grove/internal/config"
+	"github.com/nicksenap/grove/internal/console"
+	"github.com/nicksenap/grove/internal/discover"
+	"github.com/spf13/cobra"
+)
+
+var reposJSON bool
+
+// repoEntry is the machine-readable shape emitted by `gw repos --json`.
+// It pairs each discovered repo's local path with its remote identity so that
+// resolver tooling (e.g. a source-URL plugin) can map an "owner/repo" from a
+// PR/MR URL back to a local clone.
+type repoEntry struct {
+	Name        string `json:"name"`         // folder name
+	Path        string `json:"path"`         // absolute local path
+	Remote      string `json:"remote"`       // origin URL (may be empty)
+	DisplayName string `json:"display_name"` // "owner/repo" from remote, or folder name
+}
+
+var reposCmd = &cobra.Command{
+	Use:   "repos",
+	Short: "List discovered repos with their remotes",
+	Long: "Lists git repositories found in the configured repo directories, " +
+		"including each repo's origin remote and derived owner/repo name. " +
+		"Use --json for machine-readable output.",
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := config.RequireConfig()
+		if len(cfg.RepoDirs) == 0 {
+			console.Error("No repo directories configured. Run: gw add-dir <path>")
+			return
+		}
+
+		infos := discover.DiscoverReposWithCache(cfg.RepoDirs)
+		entries := make([]repoEntry, len(infos))
+		for i, r := range infos {
+			entries[i] = repoEntry{
+				Name:        r.Name,
+				Path:        r.Path,
+				Remote:      r.Remote,
+				DisplayName: r.DisplayName,
+			}
+		}
+
+		if reposJSON {
+			data, _ := json.MarshalIndent(entries, "", "  ")
+			fmt.Println(string(data))
+			return
+		}
+
+		if len(entries) == 0 {
+			console.Info("No repos found.")
+			return
+		}
+
+		home, _ := os.UserHomeDir()
+		table := console.NewTable(os.Stdout, []string{"Name", "Owner/Repo", "Path"})
+		for _, e := range entries {
+			path := e.Path
+			if home != "" {
+				path = strings.Replace(path, home, "~", 1)
+			}
+			table.AddRow([]string{e.Name, e.DisplayName, path})
+		}
+		table.Render()
+	},
+}
+
+func init() {
+	reposCmd.Flags().BoolVarP(&reposJSON, "json", "j", false, "Output as JSON")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,7 @@ func init() {
 		statusCmd,
 		addRepoCmd,
 		removeRepoCmd,
+		reposCmd,
 		renameCmd,
 		syncCmd,
 		doctorCmd,

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -21,6 +21,17 @@ fi
 
 gw() { "${GW_BIN}" "$@"; }
 
+# Portable timeout wrapper: macOS ships `gtimeout` (coreutils) rather than
+# `timeout`. Fall back to running the command without a timeout if neither
+# exists so the suite still works everywhere.
+if command -v timeout >/dev/null 2>&1; then
+    timeout_cmd() { timeout "$@"; }
+elif command -v gtimeout >/dev/null 2>&1; then
+    timeout_cmd() { gtimeout "$@"; }
+else
+    timeout_cmd() { shift; "$@"; }  # drop the duration arg, run unbounded
+fi
+
 # ---------------------------------------------------------------------------
 # Setup: create test repos
 # ---------------------------------------------------------------------------
@@ -203,6 +214,159 @@ if gw status test-ws > /dev/null 2>&1; then
 else
     fail "status command failed"
 fi
+
+# ---------------------------------------------------------------------------
+# Test: gw repos (discovered repos + remotes, machine-readable)
+# ---------------------------------------------------------------------------
+section "Repos listing"
+
+repos_json=$(gw repos --json 2>/dev/null)
+if echo "${repos_json}" | jq -e '.[] | select(.name == "svc-auth")' > /dev/null 2>&1; then
+    pass "gw repos --json lists discovered repos"
+else
+    fail "gw repos --json missing svc-auth: ${repos_json}"
+fi
+
+if echo "${repos_json}" | jq -e '.[0] | has("name") and has("path") and has("remote") and has("display_name")' > /dev/null 2>&1; then
+    pass "gw repos --json entries have name/path/remote/display_name"
+else
+    fail "gw repos --json missing expected fields: ${repos_json}"
+fi
+
+# Plain (non-JSON) output should mention a known repo.
+# Capture first, then grep: piping `gw` straight into `grep -q` can race under
+# `set -o pipefail` (grep exits on match, gw gets SIGPIPE, pipeline fails).
+repos_table=$(gw repos 2>&1)
+if echo "${repos_table}" | grep -q "svc-auth"; then
+    pass "gw repos (table) lists repos"
+else
+    fail "gw repos table missing svc-auth"
+fi
+
+# ---------------------------------------------------------------------------
+# Test: create --track (check out an existing remote branch, e.g. a PR head)
+# ---------------------------------------------------------------------------
+section "Create --track (existing remote branch)"
+
+# Build a repo whose origin has a 'PR head' branch that does NOT exist locally,
+# so create --track must resolve it from the remote.
+git init -q --bare "${GROVE_HOME}/pr-svc-origin.git"
+git clone -q "${GROVE_HOME}/pr-svc-origin.git" "${REPOS_DIR}/pr-svc"
+(cd "${REPOS_DIR}/pr-svc" \
+    && git config user.email "e2e@grove.test" \
+    && git config user.name "Grove E2E" \
+    && echo base > README.md && git add . && git commit -q -m initial && git push -q origin HEAD \
+    && git checkout -q -b feat/pr-head \
+    && echo "pr work" > pr-marker.txt && git add . && git commit -q -m "pr work" \
+    && git push -q origin feat/pr-head \
+    && git checkout -q - \
+    && git branch -q -D feat/pr-head \
+    && git update-ref -d refs/remotes/origin/feat/pr-head)
+
+gw create pr-ws --repos pr-svc --branch feat/pr-head --track \
+    --source-url "https://github.com/acme/pr-svc/pull/42" \
+    --source-provider github --source-ref 42 --source-title "Add the thing" 2>&1
+pass "create --track succeeded"
+
+PR_WS_DIR="${GROVE_HOME}/.grove/workspaces/pr-ws"
+
+# The PR head's content must be present — we checked out the existing branch,
+# not a fresh branch from base.
+if [ -f "${PR_WS_DIR}/pr-svc/pr-marker.txt" ]; then
+    pass "create --track checked out existing PR head (content present)"
+else
+    fail "create --track did not check out PR head content"
+fi
+
+# The new local branch should track origin/feat/pr-head.
+pr_upstream=$(cd "${PR_WS_DIR}/pr-svc" && git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || echo none)
+if [ "${pr_upstream}" = "origin/feat/pr-head" ]; then
+    pass "create --track set upstream to origin/feat/pr-head"
+else
+    fail "expected upstream origin/feat/pr-head, got ${pr_upstream}"
+fi
+
+# Source provenance persisted on the workspace.
+if gw ws show pr-ws --json 2>/dev/null | jq -e '.source.provider == "github" and .source.ref == "42"' > /dev/null 2>&1; then
+    pass "source persisted on workspace (provider + ref)"
+else
+    fail "source not persisted correctly: $(gw ws show pr-ws --json 2>/dev/null | jq -c .source)"
+fi
+
+# Source surfaced in status --json.
+status_src=$(gw status pr-ws --json 2>/dev/null | jq -r '.source.url')
+if [ "${status_src}" = "https://github.com/acme/pr-svc/pull/42" ]; then
+    pass "gw status --json surfaces source url"
+else
+    fail "status --json source url wrong: ${status_src}"
+fi
+
+# Source surfaced in status table. Capture first, then grep (see note above:
+# `gw ... | grep -q` races under pipefail once grep matches and exits early).
+status_table=$(gw status pr-ws 2>&1)
+if echo "${status_table}" | grep -q "Source: github 42"; then
+    pass "gw status table shows Source line"
+else
+    fail "status table missing Source line: ${status_table}"
+fi
+
+gw delete pr-ws --force 2>&1
+
+# ---------------------------------------------------------------------------
+# Test: create --track fallback (remote branch missing → new branch, no error)
+# ---------------------------------------------------------------------------
+section "Create --track fallback"
+
+gw create fallback-ws --repos pr-svc --branch feat/ghost-pr --track 2>&1
+pass "create --track with missing remote branch did not error"
+
+fb_branch=$(cd "${GROVE_HOME}/.grove/workspaces/fallback-ws/pr-svc" && git branch --show-current)
+if [ "${fb_branch}" = "feat/ghost-pr" ]; then
+    pass "fallback created a new branch from base"
+else
+    fail "expected feat/ghost-pr, got ${fb_branch}"
+fi
+
+gw delete fallback-ws --force 2>&1
+
+# ---------------------------------------------------------------------------
+# Test: post_create hook receives source_* placeholders
+# ---------------------------------------------------------------------------
+section "post_create source placeholders"
+
+SRC_HOOK_MARKER="${GROVE_HOME}/src_hook_out"
+cat > "${GROVE_HOME}/.grove/config.toml" <<EOF
+repo_dirs = ["${REPOS_DIR}"]
+workspace_dir = "${GROVE_HOME}/.grove/workspaces"
+
+[hooks]
+post_create = "echo url={source_url} ref={source_ref} title={source_title} > ${SRC_HOOK_MARKER}"
+EOF
+
+gw create hooksrc-ws --repos svc-auth --branch feat/hooksrc \
+    --source-url "https://example.com/x" --source-provider notion \
+    --source-ref pageid123 --source-title "My Task" 2>&1
+
+if [ -f "${SRC_HOOK_MARKER}" ] \
+    && grep -q "url=https://example.com/x" "${SRC_HOOK_MARKER}" \
+    && grep -q "ref=pageid123" "${SRC_HOOK_MARKER}" \
+    && grep -q "title=My Task" "${SRC_HOOK_MARKER}"; then
+    pass "post_create hook received source_url/ref/title"
+else
+    fail "post_create source vars wrong: $(cat "${SRC_HOOK_MARKER}" 2>/dev/null)"
+fi
+
+gw delete hooksrc-ws --force 2>&1
+rm -f "${SRC_HOOK_MARKER}"
+
+# Restore config without hooks for subsequent tests.
+cat > "${GROVE_HOME}/.grove/config.toml" <<EOF
+repo_dirs = ["${REPOS_DIR}"]
+workspace_dir = "${GROVE_HOME}/.grove/workspaces"
+EOF
+
+# Remove the throwaway PR repo so it doesn't affect later discovery.
+rm -rf "${REPOS_DIR}/pr-svc" "${GROVE_HOME}/pr-svc-origin.git"
 
 # ---------------------------------------------------------------------------
 # Test: add-repo
@@ -763,7 +927,7 @@ mcp_test() {
     local expected_id="$2"
 
     # Send all messages and capture output
-    echo "$input" | timeout 10 gw mcp-serve --workspace mcp-ws 2>/dev/null || true
+    echo "$input" | timeout_cmd 10 gw mcp-serve --workspace mcp-ws 2>/dev/null || true
 }
 
 # Test initialize + tools/list + announce + get_announcements + list_workspaces
@@ -778,7 +942,7 @@ MCP_INPUT=$(cat <<'JSONRPC'
 JSONRPC
 )
 
-MCP_OUT=$(echo "${MCP_INPUT}" | timeout 10 "${GW_BIN}" mcp-serve --workspace mcp-ws 2>/dev/null || true)
+MCP_OUT=$(echo "${MCP_INPUT}" | timeout_cmd 10 "${GW_BIN}" mcp-serve --workspace mcp-ws 2>/dev/null || true)
 
 # Check initialize response
 if echo "${MCP_OUT}" | grep -q '"protocolVersion"'; then

--- a/internal/gitops/gitops.go
+++ b/internal/gitops/gitops.go
@@ -162,6 +162,22 @@ func WorktreeAdd(repo, path, branch string) error {
 	return err
 }
 
+// WorktreeAddTracking creates a worktree on a new local branch that tracks
+// origin/<branch>. Used to check out an existing remote branch (e.g. a PR head)
+// rather than creating a fresh branch from the base. The remote-tracking ref
+// (refs/remotes/origin/<branch>) must already exist — fetch first.
+func WorktreeAddTracking(repo, path, branch string) error {
+	_, err := runGit(repo, "worktree", "add", "--track", "-b", branch, path, "origin/"+branch)
+	return err
+}
+
+// RemoteBranchExists reports whether refs/remotes/origin/<branch> exists locally.
+// Run Fetch first to ensure the remote-tracking ref is up to date.
+func RemoteBranchExists(repo, branch string) bool {
+	_, err := runGit(repo, "rev-parse", "--verify", "--quiet", "refs/remotes/origin/"+branch)
+	return err == nil
+}
+
 // WorktreeRemove removes a worktree.
 func WorktreeRemove(repo, path string) error {
 	_, err := runGit(repo, "worktree", "remove", path, "--force")
@@ -456,6 +472,66 @@ func PRStatus(path string) *PRInfo {
 	}
 
 	return nil
+}
+
+// PRRef holds the resolved head branch and metadata for a pull request.
+// Used to seed a workspace from a PR URL (check out the existing head branch).
+type PRRef struct {
+	Number      int    `json:"number"`
+	HeadRefName string `json:"headRefName"`
+	Title       string `json:"title"`
+	State       string `json:"state"`
+	URL         string `json:"url"`
+	// HeadRepositoryOwner is the owner of the head repo. For fork PRs this
+	// differs from the base repo owner, meaning origin/<head> won't exist.
+	HeadRepositoryOwner string `json:"headRepositoryOwner"`
+}
+
+// GhPRResolve resolves a pull request's head branch + metadata via the gh CLI.
+// repoSlug is "owner/repo"; host is the GitHub host ("" defaults to github.com,
+// gh honors GH_HOST / its own config for enterprise). Returns an error if gh is
+// unavailable or the PR cannot be resolved.
+func GhPRResolve(repoSlug string, number int, host string) (*PRRef, error) {
+	ghPath, err := exec.LookPath("gh")
+	if err != nil {
+		return nil, fmt.Errorf("gh CLI not found")
+	}
+	args := []string{"pr", "view", strconv.Itoa(number),
+		"--json", "number,headRefName,title,state,url,headRepositoryOwner"}
+	if repoSlug != "" {
+		args = append(args, "--repo", repoSlug)
+	}
+	cmd := exec.Command(ghPath, args...)
+	cmd.Stdin = nil
+	if host != "" {
+		cmd.Env = append(os.Environ(), "GH_HOST="+host)
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh pr view %d: %w", number, err)
+	}
+	// gh nests headRepositoryOwner as an object {login: ...}; decode loosely.
+	var raw struct {
+		Number              int    `json:"number"`
+		HeadRefName         string `json:"headRefName"`
+		Title               string `json:"title"`
+		State               string `json:"state"`
+		URL                 string `json:"url"`
+		HeadRepositoryOwner struct {
+			Login string `json:"login"`
+		} `json:"headRepositoryOwner"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parsing gh output: %w", err)
+	}
+	return &PRRef{
+		Number:              raw.Number,
+		HeadRefName:         raw.HeadRefName,
+		Title:               raw.Title,
+		State:               raw.State,
+		URL:                 raw.URL,
+		HeadRepositoryOwner: raw.HeadRepositoryOwner.Login,
+	}, nil
 }
 
 func ghPRStatus(path string) *PRInfo {

--- a/internal/gitops/gitops_test.go
+++ b/internal/gitops/gitops_test.go
@@ -156,6 +156,62 @@ func TestWorktreeAddAndRemove(t *testing.T) {
 	}
 }
 
+func TestRemoteBranchExists(t *testing.T) {
+	repo := initTestRepo(t)
+
+	// Push a new branch to origin so a remote-tracking ref can exist.
+	run(t, repo, "git", "checkout", "-b", "feat/remote-only")
+	run(t, repo, "git", "push", "origin", "feat/remote-only")
+	run(t, repo, "git", "checkout", "-")
+	// Drop the local branch; only the remote-tracking ref should remain.
+	run(t, repo, "git", "branch", "-D", "feat/remote-only")
+
+	if !RemoteBranchExists(repo, "feat/remote-only") {
+		t.Error("expected remote-tracking ref for feat/remote-only to exist")
+	}
+	if RemoteBranchExists(repo, "feat/does-not-exist") {
+		t.Error("expected false for a branch with no remote-tracking ref")
+	}
+}
+
+func TestWorktreeAddTracking(t *testing.T) {
+	repo := initTestRepo(t)
+
+	// Simulate a PR head branch living on origin.
+	run(t, repo, "git", "checkout", "-b", "feat/pr-head")
+	os.WriteFile(filepath.Join(repo, "pr.txt"), []byte("pr work"), 0o644)
+	run(t, repo, "git", "add", ".")
+	run(t, repo, "git", "commit", "-m", "pr commit")
+	run(t, repo, "git", "push", "origin", "feat/pr-head")
+	run(t, repo, "git", "checkout", "-")
+	run(t, repo, "git", "branch", "-D", "feat/pr-head")
+
+	wtPath := filepath.Join(t.TempDir(), "pr-worktree")
+	if err := WorktreeAddTracking(repo, wtPath, "feat/pr-head"); err != nil {
+		t.Fatalf("tracking add: %v", err)
+	}
+
+	// The worktree should be on the PR branch with the PR's file present.
+	if _, err := os.Stat(filepath.Join(wtPath, "pr.txt")); os.IsNotExist(err) {
+		t.Error("expected PR head content (pr.txt) in tracking worktree")
+	}
+	br, err := CurrentBranch(wtPath)
+	if err != nil {
+		t.Fatalf("current branch: %v", err)
+	}
+	if br != "feat/pr-head" {
+		t.Errorf("expected worktree on feat/pr-head, got %q", br)
+	}
+
+	// The new local branch should track origin/feat/pr-head.
+	upstream, _ := runGit(wtPath, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+	if upstream != "origin/feat/pr-head" {
+		t.Errorf("expected upstream origin/feat/pr-head, got %q", upstream)
+	}
+
+	WorktreeRemove(repo, wtPath)
+}
+
 func TestWorktreeHasBranch(t *testing.T) {
 	repo := initTestRepo(t)
 

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -14,11 +14,16 @@ import (
 var ErrNoHook = errors.New("hook not configured")
 
 // Vars is a set of placeholder values expanded in hook commands.
-// Use {name}, {path}, {branch} in hook commands.
+// Use {name}, {path}, {branch}, {source_url}, {source_ref}, {source_title} in
+// hook commands. The source_* values are empty unless the workspace was seeded
+// from a source URL (e.g. a GitHub PR, Notion page, or Slack thread).
 type Vars struct {
-	Name   string
-	Path   string
-	Branch string
+	Name        string
+	Path        string
+	Branch      string
+	SourceURL   string
+	SourceRef   string
+	SourceTitle string
 }
 
 // Run fires a named hook if configured. Returns ErrNoHook if not set.
@@ -44,6 +49,9 @@ func expand(cmd string, vars Vars) string {
 		"{name}", shellQuote(vars.Name),
 		"{path}", shellQuote(vars.Path),
 		"{branch}", shellQuote(vars.Branch),
+		"{source_url}", shellQuote(vars.SourceURL),
+		"{source_ref}", shellQuote(vars.SourceRef),
+		"{source_title}", shellQuote(vars.SourceTitle),
 	)
 	return r.Replace(cmd)
 }

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -67,6 +67,18 @@ func TestExpand(t *testing.T) {
 			vars: Vars{},
 			want: "do-thing ",
 		},
+		{
+			name: "source placeholders",
+			cmd:  "seed {source_url} {source_ref} {source_title}",
+			vars: Vars{SourceURL: "https://github.com/o/r/pull/7", SourceRef: "7", SourceTitle: "Fix bug"},
+			want: "seed 'https://github.com/o/r/pull/7' '7' 'Fix bug'",
+		},
+		{
+			name: "empty source placeholders expand to nothing",
+			cmd:  "seed {source_url}{source_ref}{source_title}",
+			vars: Vars{Name: "ws"},
+			want: "seed ",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -16,11 +16,24 @@ type RepoWorktree struct {
 
 // Workspace represents a named collection of worktrees.
 type Workspace struct {
-	Name      string         `json:"name"`
-	Path      string         `json:"path"`
-	Branch    string         `json:"branch"`
-	CreatedAt string         `json:"created_at"`
-	Repos     []RepoWorktree `json:"repos"`
+	Name      string           `json:"name"`
+	Path      string           `json:"path"`
+	Branch    string           `json:"branch"`
+	CreatedAt string           `json:"created_at"`
+	Repos     []RepoWorktree   `json:"repos"`
+	Source    *WorkspaceSource `json:"source,omitempty"`
+}
+
+// WorkspaceSource records where a workspace was seeded from (e.g. a GitHub PR,
+// a Notion page, a Slack thread). All fields are opaque to Grove core — they are
+// stored and displayed but never interpreted here; resolution lives in plugins.
+// The pointer + omitempty keeps existing state.json entries round-tripping
+// unchanged (a nil Source is omitted entirely).
+type WorkspaceSource struct {
+	Provider string `json:"provider"`        // e.g. "github", "gitlab", "notion", "slack"
+	URL      string `json:"url"`             // the original source URL
+	Ref      string `json:"ref,omitempty"`   // provider ref: PR number, page id, message ts
+	Title    string `json:"title,omitempty"` // human-readable title for display
 }
 
 // NewWorkspace creates a workspace with the current timestamp.

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -130,6 +131,47 @@ func TestWorkspaceJSONRoundtrip(t *testing.T) {
 	}
 	if ws2.Repos[0].RepoName != "api" {
 		t.Errorf("repo_name: got %q, want 'api'", ws2.Repos[0].RepoName)
+	}
+}
+
+func TestWorkspaceSourceRoundtrip(t *testing.T) {
+	ws := Workspace{
+		Name:   "pr-feature",
+		Path:   "/ws/pr-feature",
+		Branch: "feat/data-status",
+		Source: &WorkspaceSource{
+			Provider: "github",
+			URL:      "https://github.com/funnel-io/conversational-analytics/pull/1172",
+			Ref:      "1172",
+			Title:    "Surface data source status",
+		},
+	}
+
+	data, err := json.Marshal(ws)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var ws2 Workspace
+	if err := json.Unmarshal(data, &ws2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ws2.Source == nil {
+		t.Fatal("expected non-nil Source after roundtrip")
+	}
+	if *ws2.Source != *ws.Source {
+		t.Errorf("source roundtrip mismatch: got %+v, want %+v", *ws2.Source, *ws.Source)
+	}
+}
+
+func TestWorkspaceSourceOmittedWhenNil(t *testing.T) {
+	ws := Workspace{Name: "plain", Path: "/ws/plain", Branch: "main"}
+	data, err := json.Marshal(ws)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "source") {
+		t.Errorf("expected no 'source' key for nil Source, got: %s", data)
 	}
 }
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -14,9 +14,65 @@ import (
 	"github.com/nicksenap/grove/internal/models"
 )
 
+// BranchMode determines how a worktree's branch is provisioned.
+type BranchMode int
+
+const (
+	// BranchModeCreate creates a new branch from the resolved base branch.
+	// This is the default and matches Grove's historical behavior.
+	BranchModeCreate BranchMode = iota
+	// BranchModeTrack checks out an existing remote branch (e.g. a pull-request
+	// head) as a tracking branch instead of creating a new one from base.
+	BranchModeTrack
+)
+
+// CreateOpts carries the inputs for creating a workspace. It groups the original
+// positional Create parameters and adds optional branch-mode and provenance.
+type CreateOpts struct {
+	Branch  string
+	Repos   []string
+	RepoMap map[string]string // repo name → source path
+	Cfg     *models.Config
+
+	// BranchMode is the mode applied to the repos selected by TrackBranchRepo.
+	// When TrackBranchRepo is empty, BranchMode applies to every repo; when set,
+	// it applies only to that one repo and all others use BranchModeCreate.
+	//
+	// A PR URL identifies exactly one repo+branch, so a resolver names that repo
+	// in TrackBranchRepo — sibling repos added to the same workspace then still
+	// get fresh branches from base rather than coincidentally tracking a remote
+	// branch of the same name. Track mode always falls back to create mode for
+	// any repo where the remote branch does not exist, so a blanket
+	// (empty-TrackBranchRepo) track is safe too.
+	BranchMode      BranchMode
+	TrackBranchRepo string
+
+	// Source, when set, is persisted on the workspace as provenance (e.g. the
+	// GitHub PR / Notion page / Slack thread it was seeded from). Opaque to core.
+	Source *models.WorkspaceSource
+}
+
 // Create creates a new workspace with worktrees for the given repos.
-// repoMap is name→source_path.
+// repoMap is name→source_path. It preserves the historical positional signature
+// by delegating to CreateWithOpts.
 func (s *Service) Create(name, branch string, repoNames []string, repoMap map[string]string, cfg *models.Config) error {
+	return s.CreateWithOpts(name, CreateOpts{
+		Branch:  branch,
+		Repos:   repoNames,
+		RepoMap: repoMap,
+		Cfg:     cfg,
+	})
+}
+
+// CreateWithOpts creates a new workspace from the given options. It is the full
+// implementation behind Create, additionally supporting per-repo branch tracking
+// (BranchMode/TrackBranchRepo) and a persisted Source link.
+func (s *Service) CreateWithOpts(name string, opts CreateOpts) error {
+	branch := opts.Branch
+	repoNames := opts.Repos
+	repoMap := opts.RepoMap
+	cfg := opts.Cfg
+
 	// Check duplicate
 	existing, err := s.State.GetWorkspace(name)
 	if err != nil {
@@ -34,6 +90,7 @@ func (s *Service) Create(name, branch string, repoNames []string, repoMap map[st
 	}
 
 	ws := models.NewWorkspace(name, wsPath, branch)
+	ws.Source = opts.Source
 
 	// Validate all repo names first
 	sourcePaths := make([]string, len(repoNames))
@@ -64,7 +121,13 @@ func (s *Service) Create(name, branch string, repoNames []string, repoMap map[st
 	var created []models.RepoWorktree
 	for i, repoName := range repoNames {
 		console.Infof("[%d/%d] %s", i+1, len(repoNames), repoName)
-		rw, err := provisionWorktreeNoFetch(sourcePaths[i], repoName, wsPath, branch)
+		// Resolve the per-repo mode. With no TrackBranchRepo set, opts.BranchMode
+		// applies to every repo; otherwise only the named repo uses it.
+		mode := opts.BranchMode
+		if opts.TrackBranchRepo != "" && repoName != opts.TrackBranchRepo {
+			mode = BranchModeCreate
+		}
+		rw, err := provisionWorktreeNoFetch(sourcePaths[i], repoName, wsPath, branch, mode)
 		if err != nil {
 			logging.Error("workspace creation failed for %q — rolled back", name)
 			rollback(created)
@@ -108,16 +171,38 @@ func (s *Service) Create(name, branch string, repoNames []string, repoMap map[st
 
 func provisionWorktree(sourcePath, repoName, wsPath, branch string) (*models.RepoWorktree, error) {
 	_ = gitops.Fetch(sourcePath)
-	return provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch)
+	return provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch, BranchModeCreate)
 }
 
-func provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch string) (*models.RepoWorktree, error) {
+func provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch string, mode BranchMode) (*models.RepoWorktree, error) {
 	wtPath := filepath.Join(wsPath, repoName)
 
 	// Check if branch already has a worktree
 	hasWT, _ := gitops.WorktreeHasBranch(sourcePath, branch)
 	if hasWT {
 		return nil, fmt.Errorf("branch %s already has a worktree in %s", branch, repoName)
+	}
+
+	// Track mode: check out an existing remote branch (e.g. a PR head) rather
+	// than creating a new branch. Only meaningful when the branch does not
+	// already exist locally; otherwise fall through to the normal add below.
+	if mode == BranchModeTrack && !gitops.BranchExists(sourcePath, branch) {
+		if gitops.RemoteBranchExists(sourcePath, branch) {
+			logging.Info("tracking existing remote branch %q in %s", branch, repoName)
+			if err := gitops.WorktreeAddTracking(sourcePath, wtPath, branch); err != nil {
+				return nil, fmt.Errorf("adding tracking worktree: %w", err)
+			}
+			return &models.RepoWorktree{
+				RepoName:     repoName,
+				SourceRepo:   sourcePath,
+				WorktreePath: wtPath,
+				Branch:       branch,
+			}, nil
+		}
+		// Remote branch missing (deleted, force-pushed, or a fork PR whose head
+		// lives on another remote). Fall back to create-mode with a warning
+		// rather than failing mid-creation.
+		console.Warningf("%s: remote branch %s not found — creating a new branch from base instead", repoName, branch)
 	}
 
 	// Create branch if needed
@@ -648,6 +733,29 @@ func formatPR(pr *gitops.PRInfo) string {
 	}
 }
 
+// formatSourceLine renders a workspace's source provenance as a single line for
+// status output, or "" if there is no source. e.g.
+// "Source: github 1172 — Surface data source status  (https://github.com/...)".
+func formatSourceLine(src *models.WorkspaceSource) string {
+	if src == nil {
+		return ""
+	}
+	label := src.Provider
+	if label == "" {
+		label = "source"
+	}
+	if src.Ref != "" {
+		label += " " + src.Ref
+	}
+	if src.Title != "" {
+		label += " — " + src.Title
+	}
+	if src.URL != "" {
+		label += "  (" + src.URL + ")"
+	}
+	return "Source: " + label
+}
+
 // StatusOptions controls status output.
 type StatusOptions struct {
 	JSON    bool
@@ -695,13 +803,15 @@ func (s *Service) fetchStatusResults(repos []models.RepoWorktree, withPR bool) [
 
 func (s *Service) printStatusJSON(ws *models.Workspace, results []repoStatusResult) error {
 	type wsStatus struct {
-		Workspace string             `json:"workspace"`
-		Path      string             `json:"path"`
-		Repos     []repoStatusResult `json:"repos"`
+		Workspace string                  `json:"workspace"`
+		Path      string                  `json:"path"`
+		Source    *models.WorkspaceSource `json:"source,omitempty"`
+		Repos     []repoStatusResult      `json:"repos"`
 	}
 	data, _ := json.MarshalIndent(wsStatus{
 		Workspace: ws.Name,
 		Path:      ws.Path,
+		Source:    ws.Source,
 		Repos:     results,
 	}, "", "  ")
 	fmt.Println(string(data))
@@ -709,7 +819,11 @@ func (s *Service) printStatusJSON(ws *models.Workspace, results []repoStatusResu
 }
 
 func (s *Service) printStatusTable(ws *models.Workspace, results []repoStatusResult, opts StatusOptions) {
-	fmt.Fprintf(os.Stdout, "Workspace: %s  (%s)\n\n", ws.Name, ws.Path)
+	fmt.Fprintf(os.Stdout, "Workspace: %s  (%s)\n", ws.Name, ws.Path)
+	if line := formatSourceLine(ws.Source); line != "" {
+		fmt.Fprintf(os.Stdout, "%s\n", line)
+	}
+	fmt.Fprintln(os.Stdout)
 
 	headers := []string{"Repo", "Branch", "↑↓", "Status"}
 	if opts.PR {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -223,6 +223,136 @@ func TestCreateAutoCreatesBranch(t *testing.T) {
 	}
 }
 
+// pushRemoteBranch creates a branch in repo, commits a marker file, pushes it to
+// origin, then deletes the local branch — leaving only origin/<branch>. This
+// simulates a PR head branch that exists on the remote but not locally.
+func (e *testEnv) pushRemoteBranch(repo, branch, marker string) {
+	e.t.Helper()
+	e.run(repo, "git", "checkout", "-q", "-b", branch)
+	os.WriteFile(filepath.Join(repo, marker), []byte(marker), 0o644)
+	e.run(repo, "git", "add", ".")
+	e.run(repo, "git", "commit", "-q", "-m", "remote work on "+branch)
+	e.run(repo, "git", "push", "-q", "origin", branch)
+	e.run(repo, "git", "checkout", "-q", "-")
+	e.run(repo, "git", "branch", "-q", "-D", branch)
+	// Forget the just-pushed ref locally so creation must rely on fetch.
+	e.run(repo, "git", "update-ref", "-d", "refs/remotes/origin/"+branch)
+}
+
+func TestCreateTrackModeChecksOutExistingBranch(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepoWithRemote("api")
+	env.pushRemoteBranch(env.repoMap["api"], "feat/pr-head", "pr-marker.txt")
+
+	err := env.svc.CreateWithOpts("pr-ws", CreateOpts{
+		Branch:          "feat/pr-head",
+		Repos:           []string{"api"},
+		RepoMap:         env.repoMap,
+		Cfg:             env.cfg,
+		BranchMode:      BranchModeTrack,
+		TrackBranchRepo: "api",
+	})
+	if err != nil {
+		t.Fatalf("create track: %v", err)
+	}
+
+	wt := filepath.Join(env.wsDir, "pr-ws", "api")
+	// The PR head's marker file must be present (we checked out the existing branch).
+	if _, err := os.Stat(filepath.Join(wt, "pr-marker.txt")); os.IsNotExist(err) {
+		t.Error("expected PR head content (pr-marker.txt) in tracking worktree")
+	}
+	// The worktree branch must track origin/feat/pr-head.
+	upstream := env.run(wt, "git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+	if upstream != "origin/feat/pr-head" {
+		t.Errorf("expected upstream origin/feat/pr-head, got %q", upstream)
+	}
+}
+
+func TestCreateTrackModeFallsBackWhenRemoteMissing(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepoWithRemote("api")
+
+	// Track mode requested but no such remote branch exists → fall back to
+	// creating a new branch from base (no error).
+	err := env.svc.CreateWithOpts("fallback-ws", CreateOpts{
+		Branch:          "feat/ghost-pr",
+		Repos:           []string{"api"},
+		RepoMap:         env.repoMap,
+		Cfg:             env.cfg,
+		BranchMode:      BranchModeTrack,
+		TrackBranchRepo: "api",
+	})
+	if err != nil {
+		t.Fatalf("expected graceful fallback, got error: %v", err)
+	}
+
+	wt := filepath.Join(env.wsDir, "fallback-ws", "api")
+	branch := env.run(wt, "git", "branch", "--show-current")
+	if branch != "feat/ghost-pr" {
+		t.Errorf("expected new branch feat/ghost-pr, got %q", branch)
+	}
+}
+
+func TestCreateTrackModeOnlyAppliesToDesignatedRepo(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepoWithRemote("api")
+	env.createRepoWithRemote("web")
+	env.pushRemoteBranch(env.repoMap["api"], "feat/shared", "api-pr.txt")
+
+	// Both repos share the branch name, but only "api" is the track repo;
+	// "web" should create a fresh branch from base (no api-pr.txt leakage).
+	err := env.svc.CreateWithOpts("mixed-ws", CreateOpts{
+		Branch:          "feat/shared",
+		Repos:           []string{"api", "web"},
+		RepoMap:         env.repoMap,
+		Cfg:             env.cfg,
+		BranchMode:      BranchModeTrack,
+		TrackBranchRepo: "api",
+	})
+	if err != nil {
+		t.Fatalf("create mixed: %v", err)
+	}
+
+	apiWT := filepath.Join(env.wsDir, "mixed-ws", "api")
+	if _, err := os.Stat(filepath.Join(apiWT, "api-pr.txt")); os.IsNotExist(err) {
+		t.Error("api worktree should have tracked the PR head (api-pr.txt missing)")
+	}
+	webWT := filepath.Join(env.wsDir, "mixed-ws", "web")
+	if _, err := os.Stat(filepath.Join(webWT, "api-pr.txt")); err == nil {
+		t.Error("web worktree should NOT contain api's PR content — create mode expected")
+	}
+}
+
+func TestCreateWithOptsPersistsSource(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+
+	src := &models.WorkspaceSource{
+		Provider: "github",
+		URL:      "https://github.com/funnel-io/conversational-analytics/pull/1172",
+		Ref:      "1172",
+		Title:    "Surface data source status",
+	}
+	err := env.svc.CreateWithOpts("src-ws", CreateOpts{
+		Branch:  "feat/src",
+		Repos:   []string{"api"},
+		RepoMap: env.repoMap,
+		Cfg:     env.cfg,
+		Source:  src,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	ws, _ := env.svc.State.GetWorkspace("src-ws")
+	if ws == nil || ws.Source == nil {
+		t.Fatal("expected persisted Source on workspace")
+	}
+	if *ws.Source != *src {
+		t.Errorf("source mismatch: got %+v, want %+v", *ws.Source, *src)
+	}
+}
+
 func TestCreateWritesMCPConfig(t *testing.T) {
 	env := setupTestEnv(t)
 	env.createRepo("api")
@@ -663,6 +793,38 @@ func TestRemoveReposNonexistent(t *testing.T) {
 // ---------------------------------------------------------------------------
 // Status tests
 // ---------------------------------------------------------------------------
+
+func TestFormatSourceLine(t *testing.T) {
+	tests := []struct {
+		name string
+		src  *models.WorkspaceSource
+		want string
+	}{
+		{"nil", nil, ""},
+		{
+			"full",
+			&models.WorkspaceSource{Provider: "github", Ref: "1172", Title: "Surface data source status", URL: "https://github.com/o/r/pull/1172"},
+			"Source: github 1172 — Surface data source status  (https://github.com/o/r/pull/1172)",
+		},
+		{
+			"url only",
+			&models.WorkspaceSource{Provider: "slack", URL: "https://x.slack.com/archives/C/p1"},
+			"Source: slack  (https://x.slack.com/archives/C/p1)",
+		},
+		{
+			"no provider",
+			&models.WorkspaceSource{Title: "untitled"},
+			"Source: source — untitled",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatSourceLine(tt.src); got != tt.want {
+				t.Errorf("formatSourceLine() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestStatusSuccess(t *testing.T) {
 	env := setupTestEnv(t)


### PR DESCRIPTION
## What

Adds **provider-agnostic primitives** so a workspace can be seeded from an *existing* branch and carry a link back to where it came from. This is the core foundation for a "magic" `gw grab <url>` plugin (GitHub PR / Notion / Slack → ready-to-work workspace) — but Grove core stays a pure git worktree orchestrator and learns nothing about those services.

## Why

`gw create` could only ever make a **new** branch from base. Checking out an existing remote branch (e.g. a PR head to review/continue) wasn't possible, and workspaces had no memory of what task/PR/thread they were for. These primitives close both gaps in a way that's useful on their own *and* composable by external resolver plugins.

## What's in core (none of it mentions GitHub/Notion/Slack)

- **`gitops`** — `RemoteBranchExists`, `WorktreeAddTracking` (`git worktree add --track -b <b> <path> origin/<b>`), and `GhPRResolve`/`PRRef` (resolve a PR head + title via `gh`).
- **`workspace`** — `BranchMode` (Create/Track) + `CreateOpts` + `CreateWithOpts`. `Create()` is kept as a thin wrapper, so all existing callers/tests are untouched. Track mode **falls back to create-mode with a warning** when `origin/<branch>` is missing (deleted/force-pushed heads, fork PRs). Per-repo `TrackBranchRepo` keeps multi-repo workspaces correct — only the matched repo tracks; siblings branch from base.
- **`models`** — `Workspace.Source` (`*WorkspaceSource`, `omitempty`) persists opaque provenance. **Zero `state.json` migration** (nil → field omitted; old entries round-trip).
- **`cmd/create`** — `--track` and `--source-url` / `--source-provider` / `--source-ref` / `--source-title` flags; `--repos` now clones git URLs (mirrors `add-repo`); source values flow into the `post_create` hook.
- **`lifecycle`** — new `{source_url}` / `{source_ref}` / `{source_title}` hook placeholders.
- **`cmd/repos`** — new `gw repos [--json]` listing repos with their origin remote + derived `owner/repo`, so a resolver can map a remote back to a local clone.
- **`status`** — `Source:` line in the table and a `source` object in `--json`.

## Example

```
gw create feat-data-status -r conversational-analytics -b feat/data-source-status --track \
  --source-url https://github.com/funnel-io/conversational-analytics/pull/1172 \
  --source-provider github --source-ref 1172 --source-title "Surface data source status"
```

→ checks out the PR's existing head branch (not a fresh one), and `gw status` shows:

```
Source: github 1172 — Surface data source status  (https://github.com/.../pull/1172)
```

## Tests

**Unit** — gitops (`RemoteBranchExists`, `WorktreeAddTracking` w/ upstream + content checks), workspace (track-mode checkout, missing-remote fallback, per-repo track isolation, `Source` persistence), models (`Source` round-trip + `omitempty`), lifecycle (new placeholders), `formatSourceLine`.

**e2e** (`e2e/run.sh`) — new sections for `gw repos [--json]`, `gw create --track` (content + upstream + persisted source + status table/JSON surfacing), the missing-remote fallback, and `post_create` `{source_*}` placeholders. Also made the MCP e2e tests portable (`gtimeout` fallback) so the suite is green on macOS: **116 pass / 0 fail** (was 98/6 on master due to a pre-existing missing-`timeout` issue).

`just check` passes (test / vet / gofmt / gocyclo / staticcheck). `CHANGELOG.md` gets a `## v1.1.8` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)