### PR TITLE
feat: add --no-hooks flag to skip lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `gw create` records where a workspace came from. New `--source-url`, `--source-provider`, `--source-ref`, and `--source-title` flags persist an opaque `source` link on the workspace, which is surfaced in `gw status` (and its `--json`) and exposed to the `post_create` hook via the new `{source_url}`, `{source_ref}`, and `{source_title}` placeholders.
 - `gw create --repos` now accepts git URLs and clones them into the first configured repo dir (matching `gw add-repo` behavior).
 - New `gw repos` command lists discovered repos with their origin remote and derived `owner/repo` name. `gw repos --json` gives machine-readable output so external tooling can map a remote `owner/repo` back to a local clone.
+- New global `--no-hooks` flag skips all global lifecycle hooks (`post_create`, `pre_delete`, `on_close`) for a single command — useful for scripting or one-off operations. Per-repo `.grove.toml` hooks are unaffected.
 
 These primitives are provider-agnostic building blocks: they let an external plugin (e.g. `gw-grab`) turn a GitHub PR / Notion / Slack URL into a ready-to-work workspace, while Grove core stays a pure git worktree orchestrator.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - `gw create` records where a workspace came from. New `--source-url`, `--source-provider`, `--source-ref`, and `--source-title` flags persist an opaque `source` link on the workspace, which is surfaced in `gw status` (and its `--json`) and exposed to the `post_create` hook via the new `{source_url}`, `{source_ref}`, and `{source_title}` placeholders.
 - `gw create --repos` now accepts git URLs and clones them into the first configured repo dir (matching `gw add-repo` behavior).
 - New `gw repos` command lists discovered repos with their origin remote and derived `owner/repo` name. `gw repos --json` gives machine-readable output so external tooling can map a remote `owner/repo` back to a local clone.
-- New global `--no-hooks` flag skips all global lifecycle hooks (`post_create`, `pre_delete`, `on_close`) for a single command — useful for scripting or one-off operations. Per-repo `.grove.toml` hooks are unaffected.
+- New global `--no-hooks` flag (shorthand `-n`) skips all global lifecycle hooks (`post_create`, `pre_delete`, `on_close`) for a single command — useful for scripting or one-off operations. Per-repo `.grove.toml` hooks are unaffected.
 
 These primitives are provider-agnostic building blocks: they let an external plugin (e.g. `gw-grab`) turn a GitHub PR / Notion / Slack URL into a ready-to-work workspace, while Grove core stays a pure git worktree orchestrator.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Enable debug logging")
-	rootCmd.PersistentFlags().BoolVar(&lifecycle.Disabled, "no-hooks", false, "Skip lifecycle hooks")
+	rootCmd.PersistentFlags().BoolVarP(&lifecycle.Disabled, "no-hooks", "n", false, "Skip lifecycle hooks")
 	rootCmd.Version = Version
 	rootCmd.SetVersionTemplate("gw {{.Version}}\n")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/nicksenap/grove/internal/config"
+	"github.com/nicksenap/grove/internal/lifecycle"
 	"github.com/nicksenap/grove/internal/logging"
 	"github.com/nicksenap/grove/internal/picker"
 	"github.com/nicksenap/grove/internal/plugin"
@@ -35,6 +36,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Enable debug logging")
+	rootCmd.PersistentFlags().BoolVar(&lifecycle.Disabled, "no-hooks", false, "Skip lifecycle hooks")
 	rootCmd.Version = Version
 	rootCmd.SetVersionTemplate("gw {{.Version}}\n")
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -45,6 +45,17 @@ pre_delete = "gw claude sync harvest {path}"
 on_close = "tmux kill-pane"
 ```
 
+### Skipping hooks
+
+Pass `--no-hooks` to any command to skip all global hooks for that run — handy for scripting or one-off operations where you don't want side effects to fire:
+
+```sh
+gw --no-hooks create my-feature --repos svc-auth
+gw --no-hooks delete my-feature --force
+```
+
+Per-repo hooks (`.grove.toml`) are unaffected.
+
 ---
 
 ## Per-repo hooks

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -47,11 +47,11 @@ on_close = "tmux kill-pane"
 
 ### Skipping hooks
 
-Pass `--no-hooks` to any command to skip all global hooks for that run — handy for scripting or one-off operations where you don't want side effects to fire:
+Pass `--no-hooks` (shorthand `-n`) to any command to skip all global hooks for that run — handy for scripting or one-off operations where you don't want side effects to fire:
 
 ```sh
 gw --no-hooks create my-feature --repos svc-auth
-gw --no-hooks delete my-feature --force
+gw -n delete my-feature --force
 ```
 
 Per-repo hooks (`.grove.toml`) are unaffected.

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -760,11 +760,12 @@ else
     fail "--no-hooks did not skip post_create hook"
 fi
 
-gw --no-hooks delete nohook-ws --force 2>&1
+# Use the -n shorthand here to cover both spellings.
+gw -n delete nohook-ws --force 2>&1
 if [ ! -f "${PRE_DELETE_MARKER}" ]; then
-    pass "--no-hooks skipped pre_delete hook"
+    pass "-n (--no-hooks shorthand) skipped pre_delete hook"
 else
-    fail "--no-hooks did not skip pre_delete hook"
+    fail "-n did not skip pre_delete hook"
 fi
 
 rm -f "${POST_CREATE_MARKER}" "${PRE_DELETE_MARKER}"

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -746,6 +746,29 @@ fi
 
 rm -f "${POST_CREATE_MARKER}" "${PRE_DELETE_MARKER}"
 
+# ---------------------------------------------------------------------------
+# Test: --no-hooks skips lifecycle hooks
+# ---------------------------------------------------------------------------
+section "--no-hooks flag"
+
+# Hooks are still configured from the previous section. With --no-hooks the
+# create + delete should run but neither marker should appear.
+gw --no-hooks create nohook-ws --branch feat/no-hooks --repos svc-auth 2>&1
+if [ ! -f "${POST_CREATE_MARKER}" ]; then
+    pass "--no-hooks skipped post_create hook"
+else
+    fail "--no-hooks did not skip post_create hook"
+fi
+
+gw --no-hooks delete nohook-ws --force 2>&1
+if [ ! -f "${PRE_DELETE_MARKER}" ]; then
+    pass "--no-hooks skipped pre_delete hook"
+else
+    fail "--no-hooks did not skip pre_delete hook"
+fi
+
+rm -f "${POST_CREATE_MARKER}" "${PRE_DELETE_MARKER}"
+
 # Restore config without hooks for subsequent tests
 cat > "${GROVE_HOME}/.grove/config.toml" <<EOF
 repo_dirs = ["${REPOS_DIR}"]

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -13,6 +13,9 @@ import (
 // ErrNoHook is returned when the requested hook is not configured.
 var ErrNoHook = errors.New("hook not configured")
 
+// Disabled, when true, skips all hooks. Set by the --no-hooks flag.
+var Disabled bool
+
 // Vars is a set of placeholder values expanded in hook commands.
 // Use {name}, {path}, {branch}, {source_url}, {source_ref}, {source_title} in
 // hook commands. The source_* values are empty unless the workspace was seeded
@@ -28,6 +31,10 @@ type Vars struct {
 
 // Run fires a named hook if configured. Returns ErrNoHook if not set.
 func Run(hookName string, vars Vars) error {
+	if Disabled {
+		return ErrNoHook
+	}
+
 	cfg, err := config.Load()
 	if err != nil || cfg == nil {
 		return ErrNoHook

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -1,6 +1,13 @@
 package lifecycle
 
-import "testing"
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nicksenap/grove/internal/config"
+)
 
 func TestShellQuote(t *testing.T) {
 	tests := []struct {
@@ -88,5 +95,40 @@ func TestExpand(t *testing.T) {
 				t.Errorf("expand(%q, %+v) = %q, want %q", tt.cmd, tt.vars, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRunDisabled(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "fired")
+
+	// Point config at a temp config.toml with a post_create hook that writes a marker.
+	origPath := config.ConfigPath
+	config.ConfigPath = filepath.Join(dir, "config.toml")
+	t.Cleanup(func() { config.ConfigPath = origPath })
+
+	cfg := "[hooks]\npost_create = \"touch " + marker + "\"\n"
+	if err := os.WriteFile(config.ConfigPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// With Disabled set, Run must skip the hook entirely and report ErrNoHook.
+	Disabled = true
+	t.Cleanup(func() { Disabled = false })
+
+	if err := Run("post_create", Vars{}); !errors.Is(err, ErrNoHook) {
+		t.Fatalf("Run(disabled) = %v, want ErrNoHook", err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("hook fired despite Disabled (marker exists: %v)", err)
+	}
+
+	// Sanity: with Disabled cleared, the same hook fires.
+	Disabled = false
+	if err := Run("post_create", Vars{}); err != nil {
+		t.Fatalf("Run(enabled) = %v, want nil", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("hook did not fire when enabled: %v", err)
 	}
 }


### PR DESCRIPTION
## What

Adds a global `--no-hooks` flag to skip all global lifecycle hooks (`post_create`, `pre_delete`, `on_close`) for a single command.

## Why

No way to bypass hooks today — every call site fires `lifecycle.Run` unconditionally. Useful for scripting / one-off ops where side effects shouldn't fire.

## How

- Persistent flag on `rootCmd` (mirrors `--verbose`), wired to a package-level `lifecycle.Disabled`.
- `lifecycle.Run` returns `ErrNoHook` early when `Disabled` — all four call sites already treat `ErrNoHook` as a no-op, so no per-command edits.
- Per-repo `.grove.toml` hooks are unaffected.

~4 lines of behavior change, single source of truth, no config schema change.

## Tests

- Unit: `TestRunDisabled` — asserts hook skipped when disabled, fires when enabled.
- e2e: new `--no-hooks flag` section verifies post_create + pre_delete are skipped (118 pass / 0 fail locally).
- Docs: `docs/hooks.md` "Skipping hooks" section + CHANGELOG entry under v1.1.8.