### PR TITLE
feat(hooks): metadata-driven global hooks with opt-in live output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v1.1.9
+
+### Features
+
+- Global lifecycle hooks (`post_create`, `pre_delete`, `on_close`) can now be written as a **table with metadata**, not just a command string. The new `[hooks.<name>]` form accepts `command`, `description`, `stream`, `timeout`, and `on_failure`:
+
+  ```toml
+  [hooks.post_create]
+  command     = "npm install && npm run build"
+  description = "Install deps and build assets"
+  stream      = true        # stream output live to the terminal
+  timeout     = "5m"         # abort if the hook runs too long
+  on_failure  = "abort"      # "warn" (default) or "abort"
+  ```
+
+  The plain string form (`post_create = "..."`) still works unchanged, and config saved by `gw wizard` keeps metadata-free hooks as bare strings.
+- `stream = true` streams a hook's output **live** to the terminal as it runs, each line prefixed with the hook name (e.g. `[post_create] added 412 packages`) — so a hook that installs dependencies or builds assets shows progress instead of looking hung.
+- When a hook is **not** streaming (the default), its output is captured and **echoed on failure** instead of being discarded — so a failed hook shows the actual command output rather than a bare `exit status 1`. Successful non-streaming hooks stay quiet.
+- `timeout` aborts a runaway hook after a [Go duration](https://pkg.go.dev/time#ParseDuration), and `on_failure = "abort"` lets a hook make its failure fatal to the command. Hook output goes to stderr, keeping Grove's stdout clean for shell integration.
+
+### Internal
+
+- Extracted the per-line prefixing writer (previously private to `gw run`) into a shared `internal/streamio` package, now used by both `gw run` and the hook paths. It also fixes a dropped trailing line (output with no final newline) and a mid-line re-prefix bug on very large unbroken output.
+
 ## v1.1.8
 
 ### Features

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -192,7 +192,10 @@ var createCmd = &cobra.Command{
 			console.Infof("Replacing workspace: deleting %s", currentWs.Name)
 			vars := lifecycle.Vars{Name: currentWs.Name, Path: currentWs.Path, Branch: currentWs.Branch}
 			if err := lifecycle.Run("pre_delete", vars); err != nil && !errors.Is(err, lifecycle.ErrNoHook) {
-				console.Warningf("pre_delete hook failed: %s", err)
+				if lifecycle.ShouldAbort(err) {
+					exitError(err.Error())
+				}
+				console.Warning(err.Error())
 			}
 			if err := workspace.NewService().Delete(currentWs.Name); err != nil {
 				exitError("failed to delete current workspace: " + err.Error())
@@ -239,7 +242,10 @@ var createCmd = &cobra.Command{
 			vars.SourceTitle = source.Title
 		}
 		if err := lifecycle.Run("post_create", vars); err != nil && !errors.Is(err, lifecycle.ErrNoHook) {
-			console.Warningf("post_create hook failed: %s", err)
+			if lifecycle.ShouldAbort(err) {
+				exitError(err.Error())
+			}
+			console.Warning(err.Error())
 		}
 	},
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -75,7 +75,10 @@ func doDelete(args []string, force bool) {
 		if ws != nil {
 			vars := lifecycle.Vars{Name: name, Path: ws.Path, Branch: ws.Branch}
 			if err := lifecycle.Run("pre_delete", vars); err != nil && !errors.Is(err, lifecycle.ErrNoHook) {
-				console.Warningf("pre_delete hook failed: %s", err)
+				if lifecycle.ShouldAbort(err) {
+					exitError(err.Error())
+				}
+				console.Warning(err.Error())
 			}
 		}
 

--- a/cmd/go_cmd.go
+++ b/cmd/go_cmd.go
@@ -45,7 +45,7 @@ var goCmd = &cobra.Command{
 			if err := lifecycle.Run("on_close", lifecycle.Vars{}); errors.Is(err, lifecycle.ErrNoHook) {
 				exitError("No on_close hook configured. Set one in ~/.grove/config.toml:\n\n  [hooks]\n  on_close = \"gw zellij close-pane\"")
 			} else if err != nil {
-				exitError(fmt.Sprintf("on_close hook failed: %s", err))
+				exitError(err.Error())
 			}
 			return
 		}

--- a/cmd/wizard.go
+++ b/cmd/wizard.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nicksenap/grove/internal/config"
 	"github.com/nicksenap/grove/internal/console"
+	"github.com/nicksenap/grove/internal/models"
 	"github.com/nicksenap/grove/internal/plugin"
 	"github.com/spf13/cobra"
 )
@@ -54,10 +55,10 @@ var wizardCmd = &cobra.Command{
 				if _, ok := cfg.Hooks["post_create"]; !ok {
 					if console.Confirm("Configure Claude memory sync hooks?", true) {
 						if cfg.Hooks == nil {
-							cfg.Hooks = make(map[string]string)
+							cfg.Hooks = make(map[string]models.Hook)
 						}
-						cfg.Hooks["post_create"] = "gw claude sync rehydrate {path} && gw claude copy-md {path}"
-						cfg.Hooks["pre_delete"] = "gw claude sync harvest {path}"
+						cfg.Hooks["post_create"] = models.Hook{Command: "gw claude sync rehydrate {path} && gw claude copy-md {path}"}
+						cfg.Hooks["pre_delete"] = models.Hook{Command: "gw claude sync harvest {path}"}
 						changed = true
 						console.Success("Added post_create and pre_delete hooks")
 					}
@@ -107,9 +108,9 @@ var wizardCmd = &cobra.Command{
 				if _, ok := cfg.Hooks["on_close"]; !ok {
 					if console.Confirm("Configure on_close hook for Zellij?", true) {
 						if cfg.Hooks == nil {
-							cfg.Hooks = make(map[string]string)
+							cfg.Hooks = make(map[string]models.Hook)
 						}
-						cfg.Hooks["on_close"] = "gw zellij close-pane"
+						cfg.Hooks["on_close"] = models.Hook{Command: "gw zellij close-pane"}
 						changed = true
 						console.Success("Added on_close hook")
 					}

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -45,6 +45,40 @@ pre_delete = "gw claude sync harvest {path}"
 on_close = "tmux kill-pane"
 ```
 
+### Hook output and behavior
+
+A global hook can be written as a plain command string (above) **or** as a table
+when you want to control how it runs. Both forms are valid and can be mixed:
+
+```toml
+[hooks]
+pre_delete = "gw claude sync harvest {path}"   # simple string form
+
+[hooks.post_create]                            # table form with metadata
+command     = "npm install && npm run build"
+description = "Install deps and build assets"
+stream      = true        # show output live in the terminal
+timeout     = "5m"         # abort the hook if it runs longer than this
+on_failure  = "abort"      # "warn" (default) or "abort"
+```
+
+| Field | Default | Meaning |
+|---|---|---|
+| `command` | — | The shell command to run (required in table form). |
+| `description` | — | What the hook is expected to do. Documents the hook inline. |
+| `stream` | `false` | When `true`, the hook's output streams **live** to the terminal as it runs, each line prefixed with the hook name (e.g. `[post_create] added 412 packages`). Use this for hooks that install dependencies or build assets so the run doesn't look hung. |
+| `timeout` | none | A [Go duration](https://pkg.go.dev/time#ParseDuration) (`30s`, `5m`, `1h`). The hook is aborted if it exceeds this, instead of hanging the terminal indefinitely. |
+| `on_failure` | `warn` | `warn` logs a warning and continues; `abort` makes a hook failure fatal to the command. |
+
+**Output when `stream` is off (the default):** the hook runs quietly and its
+output is captured. On success nothing is printed; **on failure the captured
+output is echoed** (prefixed) so you see what actually went wrong instead of a
+bare `exit status 1`. Turn on `stream` only for hooks whose progress you want to
+watch live.
+
+Hook output goes to **stderr**, keeping Grove's stdout clean for shell
+integration (e.g. `cd "$(gw go my-feature)"`).
+
 ### Skipping hooks
 
 Pass `--no-hooks` (shorthand `-n`) to any command to skip all global hooks for that run — handy for scripting or one-off operations where you don't want side effects to fire:

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/nicksenap/grove/internal/config"
@@ -89,6 +90,7 @@ func Run(hookName string, vars Vars) error {
 	logging.Info("hook %s: %s", hookName, expanded)
 
 	ctx := context.Background()
+	hasTimeout := false
 	if hook.Timeout != "" {
 		d, perr := time.ParseDuration(hook.Timeout)
 		if perr != nil {
@@ -97,10 +99,29 @@ func Run(hookName string, vars Vars) error {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, d)
 			defer cancel()
+			hasTimeout = true
 		}
 	}
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", expanded)
+	if hasTimeout {
+		// Run the hook in its own process group so a timeout can kill the whole
+		// tree. The shell typically spawns the real work (e.g. an installer) as
+		// a child; killing only the shell would leave that child running and
+		// holding the output pipe open, so cmd.Wait would block until the child
+		// finished anyway — defeating the timeout. Killing the group (-pgid)
+		// terminates the children too.
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		cmd.Cancel = func() error {
+			if cmd.Process == nil {
+				return nil
+			}
+			return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		// Backstop: if a stray descendant still holds the output pipe after the
+		// group kill, don't let Wait hang — give it a moment, then force-close.
+		cmd.WaitDelay = 2 * time.Second
+	}
 
 	prefix := fmt.Sprintf("[%s] ", hookName)
 	var captured *bytes.Buffer

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -2,12 +2,19 @@
 package lifecycle
 
 import (
+	"bytes"
+	"context"
 	"errors"
+	"fmt"
+	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/nicksenap/grove/internal/config"
 	"github.com/nicksenap/grove/internal/logging"
+	"github.com/nicksenap/grove/internal/models"
+	"github.com/nicksenap/grove/internal/streamio"
 )
 
 // ErrNoHook is returned when the requested hook is not configured.
@@ -29,7 +36,40 @@ type Vars struct {
 	SourceTitle string
 }
 
+// HookError wraps a hook execution failure. Abort is true when the hook's
+// on_failure is set to "abort", signalling the caller that the failure should
+// be fatal to the command rather than a warning.
+type HookError struct {
+	Hook string
+	Err  error
+	// Abort reflects the hook's on_failure = "abort" setting.
+	Abort bool
+}
+
+func (e *HookError) Error() string {
+	return fmt.Sprintf("%s hook failed: %s", e.Hook, e.Err)
+}
+
+func (e *HookError) Unwrap() error { return e.Err }
+
+// ShouldAbort reports whether err is a hook failure whose on_failure is "abort".
+func ShouldAbort(err error) bool {
+	var he *HookError
+	return errors.As(err, &he) && he.Abort
+}
+
 // Run fires a named hook if configured. Returns ErrNoHook if not set.
+//
+// Output handling depends on the hook's `stream` setting:
+//   - stream = true:  the hook's stdout/stderr stream live to the terminal,
+//     line-prefixed with the hook name (e.g. "[post_create] ..."), so a
+//     long-running hook shows progress instead of looking hung.
+//   - stream = false (default): output is captured quietly and only printed
+//     (prefixed) if the hook fails, so a clean run stays silent while a
+//     failure shows the actual command output rather than just "exit status 1".
+//
+// A non-zero `timeout` aborts the hook after the given duration. On failure the
+// returned error is a *HookError; use ShouldAbort to honour on_failure = "abort".
 func Run(hookName string, vars Vars) error {
 	if Disabled {
 		return ErrNoHook
@@ -40,15 +80,74 @@ func Run(hookName string, vars Vars) error {
 		return ErrNoHook
 	}
 
-	cmd, ok := cfg.Hooks[hookName]
-	if !ok || cmd == "" {
+	hook, ok := cfg.Hooks[hookName]
+	if !ok || hook.Command == "" {
 		return ErrNoHook
 	}
 
-	expanded := expand(cmd, vars)
+	expanded := expand(hook.Command, vars)
 	logging.Info("hook %s: %s", hookName, expanded)
 
-	return exec.Command("sh", "-c", expanded).Run()
+	ctx := context.Background()
+	if hook.Timeout != "" {
+		d, perr := time.ParseDuration(hook.Timeout)
+		if perr != nil {
+			logging.Warn("hook %s: invalid timeout %q, ignoring: %s", hookName, hook.Timeout, perr)
+		} else if d > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, d)
+			defer cancel()
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", expanded)
+
+	prefix := fmt.Sprintf("[%s] ", hookName)
+	var captured *bytes.Buffer
+	if hook.Stream {
+		// Stream live to stderr, prefixed, so progress is visible. stderr keeps
+		// gw's stdout clean for shell integration (e.g. `cd "$(gw go ...)"`).
+		w := &streamio.PrefixWriter{Prefix: prefix, W: os.Stderr}
+		cmd.Stdout = w
+		cmd.Stderr = w
+		runErr := cmd.Run()
+		w.Flush()
+		return wrap(hookName, hook, runErr, ctx)
+	}
+
+	// Quiet: capture combined output, echo it only on failure.
+	captured = &bytes.Buffer{}
+	cmd.Stdout = captured
+	cmd.Stderr = captured
+	runErr := cmd.Run()
+	if runErr != nil && captured.Len() > 0 {
+		echoCaptured(prefix, captured.Bytes())
+	}
+	return wrap(hookName, hook, runErr, ctx)
+}
+
+// wrap converts a raw run error into a *HookError (or nil), annotating it with
+// the hook's on_failure policy and any timeout context.
+func wrap(hookName string, hook models.Hook, runErr error, ctx context.Context) error {
+	if runErr == nil {
+		return nil
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		runErr = fmt.Errorf("timed out after %s", hook.Timeout)
+	}
+	return &HookError{
+		Hook:  hookName,
+		Err:   runErr,
+		Abort: strings.EqualFold(hook.OnFailure, "abort"),
+	}
+}
+
+// echoCaptured prints captured hook output to stderr, prefixing each line so it
+// reads the same as streamed output.
+func echoCaptured(prefix string, out []byte) {
+	w := &streamio.PrefixWriter{Prefix: prefix, W: os.Stderr}
+	w.Write(out)
+	w.Flush()
 }
 
 func expand(cmd string, vars Vars) string {

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -5,7 +5,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -242,8 +244,12 @@ func TestRunOnFailureAbort(t *testing.T) {
 }
 
 // TestRunTimeout verifies a hook exceeding its timeout is aborted and reported.
+// The command forces the shell to spawn a child (background sleep + wait) so the
+// shell cannot be exec-optimized into the sleep itself — this reproduces the
+// real case where killing only the shell would leave a child holding the output
+// pipe open and block Wait until the child exits.
 func TestRunTimeout(t *testing.T) {
-	useTempConfig(t, "[hooks.post_create]\ncommand = \"sleep 5\"\ntimeout = \"100ms\"\n")
+	useTempConfig(t, "[hooks.post_create]\ncommand = \"sleep 30 & wait\"\ntimeout = \"100ms\"\n")
 
 	start := time.Now()
 	err := Run("post_create", Vars{})
@@ -257,5 +263,37 @@ func TestRunTimeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Errorf("error = %q, want it to mention the timeout", err.Error())
+	}
+}
+
+// TestRunTimeoutKillsChildren verifies the timeout kills the hook's child
+// processes, not just the shell — otherwise a hook like "npm install" would
+// leave the real work running after the timeout fired.
+func TestRunTimeoutKillsChildren(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "child.pid")
+	// Spawn a long sleep, record its PID, then wait on it. If the group kill
+	// works, the recorded PID is dead shortly after Run returns.
+	cmd := "sleep 30 & echo $! > " + pidFile + "; wait"
+	useTempConfig(t, "[hooks.post_create]\ncommand = \""+cmd+"\"\ntimeout = \"200ms\"\n")
+
+	if err := Run("post_create", Vars{}); err == nil {
+		t.Fatal("Run = nil, want timeout failure")
+	}
+
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatalf("read child pid: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("parse child pid %q: %v", data, err)
+	}
+
+	// Give the kill a moment to propagate, then confirm the child is gone.
+	time.Sleep(200 * time.Millisecond)
+	if err := syscall.Kill(pid, 0); err == nil {
+		syscall.Kill(pid, syscall.SIGKILL) // clean up the leak
+		t.Errorf("child process %d still alive after timeout; group kill did not reap it", pid)
 	}
 }

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -2,12 +2,52 @@ package lifecycle
 
 import (
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/nicksenap/grove/internal/config"
 )
+
+// useTempConfig points config.ConfigPath at a temp file containing the given
+// TOML body and restores it on cleanup.
+func useTempConfig(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	origPath := config.ConfigPath
+	config.ConfigPath = filepath.Join(dir, "config.toml")
+	t.Cleanup(func() { config.ConfigPath = origPath })
+	if err := os.WriteFile(config.ConfigPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+// captureStderr redirects os.Stderr for the duration of fn and returns whatever
+// was written to it.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var b strings.Builder
+		io.Copy(&b, r)
+		done <- b.String()
+	}()
+
+	fn()
+
+	w.Close()
+	os.Stderr = orig
+	return <-done
+}
 
 func TestShellQuote(t *testing.T) {
 	tests := []struct {
@@ -130,5 +170,92 @@ func TestRunDisabled(t *testing.T) {
 	}
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("hook did not fire when enabled: %v", err)
+	}
+}
+
+// TestRunStreamsWhenConfigured verifies stream = true sends hook output live to
+// stderr, prefixed with the hook name.
+func TestRunStreamsWhenConfigured(t *testing.T) {
+	useTempConfig(t, "[hooks.post_create]\ncommand = \"echo hello-from-hook\"\nstream = true\n")
+
+	var runErr error
+	out := captureStderr(t, func() { runErr = Run("post_create", Vars{}) })
+
+	if runErr != nil {
+		t.Fatalf("Run = %v, want nil", runErr)
+	}
+	if !strings.Contains(out, "[post_create] hello-from-hook") {
+		t.Errorf("streamed output missing prefixed line, got: %q", out)
+	}
+}
+
+// TestRunSilentOnSuccess verifies a non-streaming hook produces no output when
+// it succeeds.
+func TestRunSilentOnSuccess(t *testing.T) {
+	useTempConfig(t, "[hooks]\npost_create = \"echo should-not-appear\"\n")
+
+	var runErr error
+	out := captureStderr(t, func() { runErr = Run("post_create", Vars{}) })
+
+	if runErr != nil {
+		t.Fatalf("Run = %v, want nil", runErr)
+	}
+	if strings.Contains(out, "should-not-appear") {
+		t.Errorf("non-streaming successful hook should be silent, got: %q", out)
+	}
+}
+
+// TestRunCapturesAndEchoesOnFailure verifies a non-streaming hook that fails has
+// its captured output echoed to stderr (so failures are not opaque).
+func TestRunCapturesAndEchoesOnFailure(t *testing.T) {
+	useTempConfig(t, "[hooks]\npost_create = \"echo boom-details; exit 1\"\n")
+
+	var runErr error
+	out := captureStderr(t, func() { runErr = Run("post_create", Vars{}) })
+
+	if runErr == nil {
+		t.Fatal("Run = nil, want failure")
+	}
+	var he *HookError
+	if !errors.As(runErr, &he) {
+		t.Fatalf("error type = %T, want *HookError", runErr)
+	}
+	if he.Abort {
+		t.Error("Abort should be false without on_failure = abort")
+	}
+	if !strings.Contains(out, "[post_create] boom-details") {
+		t.Errorf("failed hook output should be echoed, got: %q", out)
+	}
+}
+
+// TestRunOnFailureAbort verifies on_failure = "abort" marks the error abortable.
+func TestRunOnFailureAbort(t *testing.T) {
+	useTempConfig(t, "[hooks.post_create]\ncommand = \"exit 7\"\non_failure = \"abort\"\n")
+
+	err := Run("post_create", Vars{})
+	if err == nil {
+		t.Fatal("Run = nil, want failure")
+	}
+	if !ShouldAbort(err) {
+		t.Errorf("ShouldAbort = false, want true for on_failure = abort")
+	}
+}
+
+// TestRunTimeout verifies a hook exceeding its timeout is aborted and reported.
+func TestRunTimeout(t *testing.T) {
+	useTempConfig(t, "[hooks.post_create]\ncommand = \"sleep 5\"\ntimeout = \"100ms\"\n")
+
+	start := time.Now()
+	err := Run("post_create", Vars{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Run = nil, want timeout failure")
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("hook ran for %s, timeout did not abort it", elapsed)
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error = %q, want it to mention the timeout", err.Error())
 	}
 }

--- a/internal/models/hook_test.go
+++ b/internal/models/hook_test.go
@@ -1,0 +1,97 @@
+package models
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// TestHookUnmarshalStringForm verifies a bare string hook parses into Command
+// with no metadata (backward compatibility).
+func TestHookUnmarshalStringForm(t *testing.T) {
+	in := `[hooks]
+pre_delete = "gw harvest {path}"
+`
+	var cfg Config
+	if err := toml.Unmarshal([]byte(in), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	h, ok := cfg.Hooks["pre_delete"]
+	if !ok {
+		t.Fatal("pre_delete hook not parsed")
+	}
+	if h.Command != "gw harvest {path}" {
+		t.Errorf("Command = %q, want %q", h.Command, "gw harvest {path}")
+	}
+	if h.Stream || h.Description != "" || h.Timeout != "" || h.OnFailure != "" {
+		t.Errorf("string-form hook should carry no metadata, got %+v", h)
+	}
+}
+
+// TestHookUnmarshalTableForm verifies the table form parses command + metadata.
+func TestHookUnmarshalTableForm(t *testing.T) {
+	in := `[hooks.post_create]
+command = "npm install"
+description = "install deps"
+stream = true
+timeout = "5m"
+on_failure = "abort"
+`
+	var cfg Config
+	if err := toml.Unmarshal([]byte(in), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	h := cfg.Hooks["post_create"]
+	want := Hook{
+		Command:     "npm install",
+		Description: "install deps",
+		Stream:      true,
+		Timeout:     "5m",
+		OnFailure:   "abort",
+	}
+	if h != want {
+		t.Errorf("parsed hook = %+v, want %+v", h, want)
+	}
+}
+
+// TestHookMarshalKeepsBareString verifies a metadata-free hook is written back
+// as a bare string, so config.Save() never bloats a plain hook into a table.
+func TestHookMarshalKeepsBareString(t *testing.T) {
+	cfg := Config{Hooks: map[string]Hook{
+		"pre_delete": {Command: "gw harvest {path}"},
+	}}
+	var b bytes.Buffer
+	if err := toml.NewEncoder(&b).Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got := b.String()
+	if !bytes.Contains(b.Bytes(), []byte(`pre_delete = "gw harvest {path}"`)) {
+		t.Errorf("bare hook should encode as a string, got:\n%s", got)
+	}
+	if bytes.Contains(b.Bytes(), []byte("command =")) {
+		t.Errorf("bare hook should NOT encode as a table, got:\n%s", got)
+	}
+}
+
+// TestHookRoundTrip verifies both forms survive an encode/decode cycle, and a
+// hook with metadata is preserved as a table.
+func TestHookRoundTrip(t *testing.T) {
+	orig := Config{Hooks: map[string]Hook{
+		"pre_delete":  {Command: "gw harvest {path}"},
+		"post_create": {Command: "npm install", Stream: true, Description: "deps", OnFailure: "abort"},
+	}}
+	var b bytes.Buffer
+	if err := toml.NewEncoder(&b).Encode(orig); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	var back Config
+	if err := toml.Unmarshal(b.Bytes(), &back); err != nil {
+		t.Fatalf("decode: %v\nencoded:\n%s", err, b.String())
+	}
+	for name, want := range orig.Hooks {
+		if got := back.Hooks[name]; got != want {
+			t.Errorf("hook %q round-trip: got %+v, want %+v\nencoded:\n%s", name, got, want, b.String())
+		}
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -3,6 +3,8 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -87,9 +89,95 @@ type Config struct {
 	RepoDirs     []string          `toml:"repo_dirs"`
 	WorkspaceDir string            `toml:"workspace_dir"`
 	Presets      map[string]Preset `toml:"presets"`
-	Hooks        map[string]string `toml:"hooks"`
+	Hooks        map[string]Hook   `toml:"hooks"`
 	// Legacy field — auto-migrated to RepoDirs
 	ReposDir string `toml:"repos_dir"`
+}
+
+// Hook is a global lifecycle hook in ~/.grove/config.toml [hooks]. It accepts
+// either a bare command string or a table that adds metadata describing what
+// the hook does and how it should run:
+//
+//	[hooks]
+//	pre_delete = "gw claude sync harvest {path}"   # bare string (simple form)
+//
+//	[hooks.post_create]                            # table form (with metadata)
+//	command     = "npm install && npm run build"
+//	description = "Install deps and build assets"
+//	stream      = true                             # stream output live
+//	timeout     = "5m"                             # abort if it runs too long
+//	on_failure  = "warn"                           # "warn" (default) or "abort"
+//
+// When stream is false (the default) the hook's output is captured and only
+// shown if the hook fails, so a clean run stays quiet but failures are no
+// longer an opaque "exit status 1".
+type Hook struct {
+	Command     string `toml:"command"`
+	Description string `toml:"description"`
+	Stream      bool   `toml:"stream"`
+	// Timeout is a Go duration string (e.g. "30s", "5m"). Empty means no limit.
+	Timeout string `toml:"timeout"`
+	// OnFailure is "warn" (default — log a warning and continue) or "abort"
+	// (treat a hook failure as a fatal error for the command).
+	OnFailure string `toml:"on_failure"`
+}
+
+// UnmarshalTOML accepts either a bare command string or a table with metadata,
+// so existing string-form hooks keep working unchanged.
+func (h *Hook) UnmarshalTOML(data interface{}) error {
+	switch v := data.(type) {
+	case string:
+		h.Command = v
+	case map[string]interface{}:
+		if c, ok := v["command"].(string); ok {
+			h.Command = c
+		}
+		if d, ok := v["description"].(string); ok {
+			h.Description = d
+		}
+		if s, ok := v["stream"].(bool); ok {
+			h.Stream = s
+		}
+		if t, ok := v["timeout"].(string); ok {
+			h.Timeout = t
+		}
+		if f, ok := v["on_failure"].(string); ok {
+			h.OnFailure = f
+		}
+	default:
+		return fmt.Errorf("expected a hook command string or table, got %T", data)
+	}
+	return nil
+}
+
+// MarshalTOML keeps the on-disk format minimal: a hook with no metadata is
+// written back as a bare string (matching how most users author it), while a
+// hook carrying metadata is written as an inline table. This means
+// config.Save() never rewrites a plain string hook into a verbose table.
+func (h Hook) MarshalTOML() ([]byte, error) {
+	if h.isBare() {
+		return []byte(strconv.Quote(h.Command)), nil
+	}
+	var parts []string
+	parts = append(parts, "command = "+strconv.Quote(h.Command))
+	if h.Description != "" {
+		parts = append(parts, "description = "+strconv.Quote(h.Description))
+	}
+	if h.Stream {
+		parts = append(parts, "stream = true")
+	}
+	if h.Timeout != "" {
+		parts = append(parts, "timeout = "+strconv.Quote(h.Timeout))
+	}
+	if h.OnFailure != "" {
+		parts = append(parts, "on_failure = "+strconv.Quote(h.OnFailure))
+	}
+	return []byte("{" + strings.Join(parts, ", ") + "}"), nil
+}
+
+// isBare reports whether the hook carries no metadata beyond its command.
+func (h Hook) isBare() bool {
+	return h.Description == "" && !h.Stream && h.Timeout == "" && h.OnFailure == ""
 }
 
 // GroveConfig is per-repo .grove.toml configuration.

--- a/internal/streamio/prefix.go
+++ b/internal/streamio/prefix.go
@@ -1,0 +1,88 @@
+// Package streamio provides shared io helpers for streaming subprocess output
+// live to the terminal with a per-line prefix, so concurrent or long-running
+// commands (hooks, dev servers) remain attributable and never look hung.
+package streamio
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// maxLineBuffer caps the partial-line buffer so a process emitting a very long
+// run of bytes without a newline cannot grow memory without bound.
+const maxLineBuffer = 65536
+
+// PrefixWriter wraps an io.Writer and prepends Prefix to every complete line it
+// forwards. A partial line (no trailing newline) is buffered until the next
+// Write completes it, the buffer exceeds maxLineBuffer, or Flush is called.
+//
+// Use one PrefixWriter per logical output stream. Write and Flush are safe for
+// concurrent use on a single instance, which lets a command funnel both its
+// stdout and stderr into the same PrefixWriter and keep chronological,
+// single-prefix output. Call Flush once after the subprocess exits so a final
+// line that lacks a trailing newline is not lost.
+type PrefixWriter struct {
+	Prefix string
+	W      io.Writer
+
+	mu  sync.Mutex
+	buf []byte
+	// midLine is true when the last bytes forwarded to W were an unterminated
+	// partial line (a forced flush past maxLineBuffer). The continuation must
+	// not be re-prefixed mid-line.
+	midLine bool
+}
+
+// Write implements io.Writer. It forwards each complete line prefixed with
+// Prefix and buffers any trailing partial line.
+func (pw *PrefixWriter) Write(p []byte) (int, error) {
+	pw.mu.Lock()
+	defer pw.mu.Unlock()
+
+	pw.buf = append(pw.buf, p...)
+	for {
+		idx := bytes.IndexByte(pw.buf, '\n')
+		if idx < 0 {
+			break
+		}
+		pw.emit(pw.buf[:idx], true)
+		pw.buf = pw.buf[idx+1:]
+	}
+	// Prevent unbounded growth: flush the oversized partial line without a
+	// newline and remember we're mid-line so the continuation isn't prefixed.
+	if len(pw.buf) > maxLineBuffer {
+		pw.emit(pw.buf, false)
+		pw.buf = pw.buf[:0]
+	}
+	return len(p), nil
+}
+
+// emit writes one (possibly partial) line to W. It adds Prefix only at the
+// start of a fresh line and a trailing newline only when newline is true.
+func (pw *PrefixWriter) emit(line []byte, newline bool) {
+	if !pw.midLine {
+		fmt.Fprint(pw.W, pw.Prefix)
+	}
+	pw.W.Write(line)
+	if newline {
+		fmt.Fprint(pw.W, "\n")
+		pw.midLine = false
+	} else {
+		pw.midLine = true
+	}
+}
+
+// Flush emits any buffered partial line, terminating it with a newline so the
+// final line of a process that did not end in a newline is still shown. It is a
+// no-op when nothing is buffered. Call once after the subprocess exits.
+func (pw *PrefixWriter) Flush() {
+	pw.mu.Lock()
+	defer pw.mu.Unlock()
+
+	if len(pw.buf) > 0 {
+		pw.emit(pw.buf, true)
+		pw.buf = pw.buf[:0]
+	}
+}

--- a/internal/streamio/prefix_test.go
+++ b/internal/streamio/prefix_test.go
@@ -1,0 +1,103 @@
+package streamio
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestPrefixWriterLines verifies complete lines are prefixed and a partial line
+// is held until a later Write completes it.
+func TestPrefixWriterLines(t *testing.T) {
+	var buf bytes.Buffer
+	pw := &PrefixWriter{Prefix: "[test] ", W: &buf}
+
+	pw.Write([]byte("hello\nworld\n"))
+	pw.Write([]byte("partial"))
+	pw.Write([]byte(" line\ndone\n"))
+	pw.Flush()
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	expected := []string{
+		"[test] hello",
+		"[test] world",
+		"[test] partial line",
+		"[test] done",
+	}
+	if len(lines) != len(expected) {
+		t.Fatalf("expected %d lines, got %d: %v", len(expected), len(lines), lines)
+	}
+	for i, line := range lines {
+		if line != expected[i] {
+			t.Errorf("line %d: got %q, want %q", i, line, expected[i])
+		}
+	}
+}
+
+// TestPrefixWriterFlushPartial verifies Flush emits a trailing line that lacks
+// a newline (the original prefixWriter silently dropped it).
+func TestPrefixWriterFlushPartial(t *testing.T) {
+	var buf bytes.Buffer
+	pw := &PrefixWriter{Prefix: "[p] ", W: &buf}
+
+	pw.Write([]byte("no-newline-tail"))
+	if buf.Len() != 0 {
+		t.Fatalf("partial line should be buffered until Flush, got %q", buf.String())
+	}
+	pw.Flush()
+
+	if got := buf.String(); got != "[p] no-newline-tail\n" {
+		t.Errorf("Flush output = %q, want %q", got, "[p] no-newline-tail\n")
+	}
+}
+
+// TestPrefixWriterOversizedLine verifies a line longer than maxLineBuffer is
+// force-flushed and its continuation is NOT re-prefixed mid-line.
+func TestPrefixWriterOversizedLine(t *testing.T) {
+	var buf bytes.Buffer
+	pw := &PrefixWriter{Prefix: "[x] ", W: &buf}
+
+	big := bytes.Repeat([]byte("a"), maxLineBuffer+1000)
+	pw.Write(big)
+	pw.Write([]byte("more"))
+	pw.Write([]byte("\n"))
+	pw.Flush()
+
+	out := buf.String()
+	if n := strings.Count(out, "[x] "); n != 1 {
+		t.Errorf("prefix should appear exactly once for an oversized line, got %d: %.40q...", n, out)
+	}
+	if !strings.HasSuffix(out, "more\n") {
+		t.Errorf("continuation should be appended without a new prefix, got tail %q", out[len(out)-10:])
+	}
+}
+
+// TestPrefixWriterConcurrentWrites verifies Write/Flush are safe under -race
+// and every emitted line carries the prefix.
+func TestPrefixWriterConcurrentWrites(t *testing.T) {
+	var buf bytes.Buffer
+	pw := &PrefixWriter{Prefix: "[c] ", W: &buf}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			fmt.Fprintf(pw, "line-%d\n", n)
+		}(i)
+	}
+	wg.Wait()
+	pw.Flush()
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 50 {
+		t.Fatalf("expected 50 lines, got %d", len(lines))
+	}
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "[c] ") {
+			t.Errorf("line missing prefix: %q", line)
+		}
+	}
+}

--- a/internal/workspace/run.go
+++ b/internal/workspace/run.go
@@ -1,7 +1,6 @@
 package workspace
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,6 +14,7 @@ import (
 	"github.com/nicksenap/grove/internal/console"
 	"github.com/nicksenap/grove/internal/gitops"
 	"github.com/nicksenap/grove/internal/models"
+	"github.com/nicksenap/grove/internal/streamio"
 )
 
 // RunnableRepo holds a repo's run commands.
@@ -83,8 +83,10 @@ func Run(wsName string) error {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 		// Prefix output with repo name
-		cmd.Stdout = &prefixWriter{prefix: fmt.Sprintf("[%s] ", r.RepoName), w: os.Stdout}
-		cmd.Stderr = &prefixWriter{prefix: fmt.Sprintf("[%s] ", r.RepoName), w: os.Stderr}
+		outW := &streamio.PrefixWriter{Prefix: fmt.Sprintf("[%s] ", r.RepoName), W: os.Stdout}
+		errW := &streamio.PrefixWriter{Prefix: fmt.Sprintf("[%s] ", r.RepoName), W: os.Stderr}
+		cmd.Stdout = outW
+		cmd.Stderr = errW
 
 		if err := cmd.Start(); err != nil {
 			console.Warningf("%s: failed to start: %s", r.RepoName, err)
@@ -97,16 +99,20 @@ func Run(wsName string) error {
 		mu.Unlock()
 
 		wg.Add(1)
-		go func(name string, c *exec.Cmd) {
+		go func(name string, c *exec.Cmd, outW, errW *streamio.PrefixWriter) {
 			defer wg.Done()
-			if err := c.Wait(); err != nil {
+			err := c.Wait()
+			// Emit any trailing line the process printed without a newline.
+			outW.Flush()
+			errW.Flush()
+			if err != nil {
 				if !shuttingDown.Load() {
 					console.Warningf("%s: exited with error: %s", name, err)
 				}
 			} else {
 				console.Infof("%s: exited (0)", name)
 			}
-		}(r.RepoName, cmd)
+		}(r.RepoName, cmd, outW, errW)
 	}
 
 	// Wait for signal or all processes to complete
@@ -182,29 +188,4 @@ func runHooks(runnable []RunnableRepo, hookName string, getCmd func(RunnableRepo
 		}(r, cmdStr)
 	}
 	wg.Wait()
-}
-
-// prefixWriter prefixes each line written with a string.
-type prefixWriter struct {
-	prefix string
-	w      *os.File
-	buf    []byte
-}
-
-func (pw *prefixWriter) Write(p []byte) (int, error) {
-	pw.buf = append(pw.buf, p...)
-	for {
-		idx := bytes.IndexByte(pw.buf, '\n')
-		if idx < 0 {
-			break
-		}
-		fmt.Fprintf(pw.w, "%s%s\n", pw.prefix, pw.buf[:idx])
-		pw.buf = pw.buf[idx+1:]
-	}
-	// Prevent unbounded growth: flush partial line if buffer exceeds 64KB
-	if len(pw.buf) > 65536 {
-		fmt.Fprintf(pw.w, "%s%s", pw.prefix, pw.buf)
-		pw.buf = pw.buf[:0]
-	}
-	return len(p), nil
 }

--- a/internal/workspace/run_test.go
+++ b/internal/workspace/run_test.go
@@ -106,38 +106,3 @@ func TestSignalTerminatesProcessGroup(t *testing.T) {
 		}
 	}
 }
-
-// TestPrefixWriterUsesIndexByte verifies the prefixWriter handles
-// various output patterns correctly.
-func TestPrefixWriterLines(t *testing.T) {
-	f, _ := os.CreateTemp(t.TempDir(), "pw")
-	defer f.Close()
-
-	// We can't easily test with *os.File to a string, so test the logic
-	// by writing to a temp file and reading back
-	pw := &prefixWriter{prefix: "[test] ", w: f}
-
-	pw.Write([]byte("hello\nworld\n"))
-	pw.Write([]byte("partial"))
-	pw.Write([]byte(" line\ndone\n"))
-
-	f.Seek(0, 0)
-	data, _ := os.ReadFile(f.Name())
-
-	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
-	expected := []string{
-		"[test] hello",
-		"[test] world",
-		"[test] partial line",
-		"[test] done",
-	}
-
-	if len(lines) != len(expected) {
-		t.Fatalf("expected %d lines, got %d: %v", len(expected), len(lines), lines)
-	}
-	for i, line := range lines {
-		if line != expected[i] {
-			t.Errorf("line %d: got %q, want %q", i, line, expected[i])
-		}
-	}
-}


### PR DESCRIPTION
Global lifecycle hooks (`post_create`, `pre_delete`, `on_close`) can now be declared as a table with metadata, not just a command string:

```toml
[hooks.post_create]
command     = "npm install && npm run build"
description = "Install deps and build assets"
stream      = true        # stream output live to the terminal
timeout     = "5m"         # abort a runaway hook
on_failure  = "abort"      # "warn" (default) or "abort"
```

## What changed

- **`stream = true`** streams a hook's output **live** to the terminal as it runs, each line prefixed with the hook name (e.g. `[post_create] added 412 packages`), so a hook that installs deps or builds assets shows progress instead of looking hung.
- When a hook is **not** streaming (the default), its output is **captured and echoed on failure** — so a failed hook shows the actual command output rather than a bare `exit status 1`. Successful non-streaming hooks stay quiet.
- **`timeout`** (a Go duration like `5m`) aborts a runaway hook instead of hanging the terminal indefinitely.
- **`on_failure`** is `warn` (default — log a warning and continue) or `abort` (treat the failure as fatal to the command).
- Hook output goes to **stderr**, keeping Grove's stdout clean for shell integration (e.g. `cd "$(gw go ...)"`).

## Backward compatibility

- The plain string form (`post_create = "..."`) still works unchanged.
- `config.Save` keeps metadata-free hooks as **bare strings** (custom `MarshalTOML`), so `gw wizard` never rewrites a simple hook into a verbose table.

## Internal

- Extracts the per-line prefixing writer (previously private to `gw run`) into a shared **`internal/streamio`** package, now used by both `gw run` and the hook paths. It also fixes a dropped trailing line (output with no final newline) and a mid-line re-prefix bug on very large unbroken output.

## Testing

- `go test ./...`, `go vet`, `gofmt`, `gocyclo -over 20`, and `staticcheck` all clean.
- `-race` on the touched packages (`streamio`, `lifecycle`, `models`).
- New tests cover the `Hook` string-or-table round-trip and all lifecycle behaviors (stream, silent-on-success, capture-echo-on-failure, abort, timeout).
- End-to-end verified with the built `gw` binary: streaming (prefixed, with flushed no-newline tail), silent success, echo-on-failure, and `on_failure = abort` exiting non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)