### PR TITLE
docs: align hook docs with metadata + --no-hooks; widen test coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Tool-specific integrations (Claude Code memory sync, Zellij, archive, dashboard)
 - **internal/console/** — Colored output helpers and table rendering.
 - **internal/discover/** — Finds git repos in configured directories. Caches remote URLs on disk.
 - **internal/gitops/** — Thin wrappers around `git` subprocess calls. Includes `ReadGroveConfig()`.
-- **internal/lifecycle/** — Runs global lifecycle hooks (`on_close`, `pre_delete`, etc.) defined in `[hooks]`. Plugins register here.
+- **internal/lifecycle/** — Runs global lifecycle hooks (`post_create`, `pre_delete`, `on_close`) defined in `[hooks]`. Hooks may be bare command strings or tables with metadata (`stream`, `timeout`, `on_failure`); the global `--no-hooks`/`-n` flag skips them all. Plugins register here.
 - **internal/logging/** — Structured logging.
 - **internal/mcp/** — MCP JSON-RPC server exposing workspace state to Claude Code.
 - **internal/models/** — Data structs with JSON serialization.
@@ -51,5 +51,6 @@ Tool-specific integrations (Claude Code memory sync, Zellij, archive, dashboard)
 - **internal/plugin/** — Plugin install/upgrade/remove from GitHub releases.
 - **internal/state/** — Workspace state persisted to `~/.grove/state.json`. Uses atomic writes.
 - **internal/stats/** — Workspace usage stats and heatmap.
+- **internal/streamio/** — Per-line prefixing writer (e.g. `[post_create] ...`). Shared by `gw run` and the lifecycle hook paths for live/streamed output.
 - **internal/update/** — Non-blocking version check.
 - **internal/workspace/** — Core worktree orchestration (create, delete, status, sync). Uses goroutines for concurrent multi-repo operations.

--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ gw add-dir ~/other/repos
 gw remove-dir ~/old/repos
 gw explore                                             # deep-scan for repos (2–3 levels)
 
-# Workspaces
-gw create my-feature -r svc-a,svc-b -b feat/login     # create workspace
+# Workspaces — recommended: name the branch with -b and let Grove derive the
+# workspace name; grab repos from a saved preset (-p) or an ad-hoc list (-r).
+gw create -b feat/login -p backend                     # → workspace "feat-login" (name derived from branch)
+gw create -b feat/login -r svc-a,svc-b                 # ad-hoc repos instead of a preset
+gw create my-feature -r svc-a,svc-b -b feat/login      # …or pass an explicit workspace name
 gw list                                                # list workspaces (compact)
 gw list -s                                             # list with git status summary
 gw ws show my-feature                                  # show workspace details

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -76,6 +76,11 @@ output is echoed** (prefixed) so you see what actually went wrong instead of a
 bare `exit status 1`. Turn on `stream` only for hooks whose progress you want to
 watch live.
 
+> **Platform note:** `timeout` aborts a runaway hook by killing its whole
+> process group, which relies on Unix process-group semantics. Grove ships for
+> macOS and Linux only, so this is always available on supported platforms; the
+> rest of the hook behavior is platform-independent.
+
 Hook output goes to **stderr**, keeping Grove's stdout clean for shell
 integration (e.g. `cd "$(gw go my-feature)"`).
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -777,6 +777,71 @@ workspace_dir = "${GROVE_HOME}/.grove/workspaces"
 EOF
 
 # ---------------------------------------------------------------------------
+# Test: hook metadata (stream + on_failure)
+# ---------------------------------------------------------------------------
+section "Hook metadata (stream + on_failure)"
+
+# stream = true should send the hook's output live to stderr, each line
+# prefixed with the hook name.
+cat > "${GROVE_HOME}/.grove/config.toml" <<EOF
+repo_dirs = ["${REPOS_DIR}"]
+workspace_dir = "${GROVE_HOME}/.grove/workspaces"
+
+[hooks.post_create]
+command = "echo hello-from-stream"
+stream = true
+EOF
+
+stream_out=$(gw create stream-ws --branch feat/stream --repos svc-auth 2>&1)
+if echo "${stream_out}" | grep -q '\[post_create\] hello-from-stream'; then
+    pass "stream = true streamed prefixed hook output"
+else
+    fail "stream hook output missing [post_create] prefix: ${stream_out}"
+fi
+gw delete stream-ws --force 2>&1
+
+# on_failure = "abort" should make a failing hook fatal — gw exits non-zero.
+cat > "${GROVE_HOME}/.grove/config.toml" <<EOF
+repo_dirs = ["${REPOS_DIR}"]
+workspace_dir = "${GROVE_HOME}/.grove/workspaces"
+
+[hooks.post_create]
+command = "echo boom-details; exit 1"
+on_failure = "abort"
+EOF
+
+if gw create abort-ws --branch feat/abort --repos svc-auth 2>&1; then
+    fail "on_failure = abort did not make the failing hook fatal"
+else
+    pass "on_failure = abort made the failing hook fatal (gw exited non-zero)"
+fi
+# The workspace is created before post_create runs, so it still exists. Only
+# pre_delete fires on delete (unset here), so cleanup succeeds cleanly.
+gw delete abort-ws --force 2>&1
+
+# Default on_failure ("warn") should NOT abort — a failing hook only warns.
+cat > "${GROVE_HOME}/.grove/config.toml" <<EOF
+repo_dirs = ["${REPOS_DIR}"]
+workspace_dir = "${GROVE_HOME}/.grove/workspaces"
+
+[hooks.post_create]
+command = "echo boom-details; exit 1"
+EOF
+
+if gw create warn-ws --branch feat/warn --repos svc-auth 2>&1; then
+    pass "default on_failure = warn did not abort on hook failure"
+else
+    fail "default on_failure = warn should not abort the command"
+fi
+gw delete warn-ws --force 2>&1
+
+# Restore config without hooks for subsequent tests
+cat > "${GROVE_HOME}/.grove/config.toml" <<EOF
+repo_dirs = ["${REPOS_DIR}"]
+workspace_dir = "${GROVE_HOME}/.grove/workspaces"
+EOF
+
+# ---------------------------------------------------------------------------
 # Test: gw ws delete (subcommand parity with gw delete)
 # ---------------------------------------------------------------------------
 section "ws delete subcommand"

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -266,6 +266,22 @@ func TestRunTimeout(t *testing.T) {
 	}
 }
 
+// TestRunInvalidTimeoutFailsOpen verifies an unparseable timeout string is
+// ignored (logged as a warning) and the hook still runs unbounded, rather than
+// being rejected — so a typo in `timeout` never silently stops a hook firing.
+func TestRunInvalidTimeoutFailsOpen(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "fired")
+	useTempConfig(t, "[hooks.post_create]\ncommand = \"touch "+marker+"\"\ntimeout = \"banana\"\n")
+
+	if err := Run("post_create", Vars{}); err != nil {
+		t.Fatalf("Run = %v, want nil (invalid timeout should be ignored, not fatal)", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("hook did not fire despite only an invalid timeout: %v", err)
+	}
+}
+
 // TestRunTimeoutKillsChildren verifies the timeout kills the hook's child
 // processes, not just the shell — otherwise a hook like "npm install" would
 // leave the real work running after the timeout fired.


### PR DESCRIPTION
## Summary

Two recently merged features — metadata-driven global hooks (#52) and the `--no-hooks` flag (#50) — updated `docs/hooks.md` and `CHANGELOG.md` inline but left the architecture docs and parts of the test suite behind. This PR brings everything in line and closes the coverage gaps surfaced in a post-merge sweep.

## Changes

**Docs**
- **CLAUDE.md** — the `internal/lifecycle` entry now reflects the `[hooks.<name>]` table form (`stream`, `timeout`, `on_failure`) and the global `--no-hooks`/`-n` flag; added the new **`internal/streamio`** package to the layout.
- **docs/hooks.md** — added a platform note that the hook `timeout` (process-group kill) is Unix-only, matching GoReleaser's `darwin`/`linux` targets.

**Tests**
- **lifecycle** — new unit test that an unparseable `timeout` string *fails open* (the hook still runs unbounded) rather than being silently skipped — previously an untested branch.
- **e2e** — new `Hook metadata` section covering:
  - `stream = true` → live, `[post_create]`-prefixed output
  - `on_failure = "abort"` → failing hook is fatal (gw exits non-zero)
  - default `on_failure = "warn"` → failing hook only warns, command proceeds

## Verification
- `just check` passes (tests, vet, fmt-check, gocyclo, staticcheck)
- `just e2e` passes — **121/121**, including the 3 new hook-metadata assertions

## Notes
- No production logic changed — docs, tests, and e2e only.
- `AGENTS.md` is intentionally **not** included: it's an untracked file containing pre-existing find/replace corruption (e.g. "Codex" substituted for "Claude", a bogus `gw-Codex` plugin). It should be regenerated/cleaned separately rather than committed as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)