### PR TITLE
fix status branch reporting

### DIFF
--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -681,6 +681,13 @@ func collectRepoStatus(r models.RepoWorktree) repoStatusResult {
 		Repo:   r.RepoName,
 		Branch: r.Branch,
 	}
+	if branch, err := gitops.CurrentBranch(r.WorktreePath); err == nil {
+		if branch == "" {
+			rs.Branch = "(detached)"
+		} else {
+			rs.Branch = branch
+		}
+	}
 	status, err := gitops.RepoStatus(r.WorktreePath)
 	if err != nil {
 		rs.Status = "error: " + err.Error()

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -837,6 +837,42 @@ func TestStatusSuccess(t *testing.T) {
 	}
 }
 
+func TestCollectRepoStatusReportsCurrentBranch(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	env.svc.Create("status-ws", "feat/status", []string{"api"}, env.repoMap, env.cfg)
+
+	ws, err := env.svc.State.GetWorkspace("status-ws")
+	if err != nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+	repo := ws.Repos[0]
+	env.run(repo.WorktreePath, "git", "switch", "-q", "-c", "feat/actual")
+
+	result := collectRepoStatus(repo)
+	if result.Branch != "feat/actual" {
+		t.Errorf("branch: got %q, want %q", result.Branch, "feat/actual")
+	}
+}
+
+func TestCollectRepoStatusReportsDetachedHead(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	env.svc.Create("status-ws", "feat/status", []string{"api"}, env.repoMap, env.cfg)
+
+	ws, err := env.svc.State.GetWorkspace("status-ws")
+	if err != nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+	repo := ws.Repos[0]
+	env.run(repo.WorktreePath, "git", "switch", "-q", "--detach")
+
+	result := collectRepoStatus(repo)
+	if result.Branch != "(detached)" {
+		t.Errorf("branch: got %q, want %q", result.Branch, "(detached)")
+	}
+}
+
 func TestStatusJSON(t *testing.T) {
 	env := setupTestEnv(t)
 	env.createRepo("api")


### PR DESCRIPTION
`gw status` will show the workspace branch, instead of the branch that's actually checked:

```
~/.grove/workspaces/feature-xyz
❯ gw status
Workspace: cp-pin  (/Users/igor/.grove/workspaces/feature-xyz)

REPO                      BRANCH   ↑↓      STATUS
infra-platform            feature-xyz   5↑ 0↓   clean
infra-modules             feature-xyz   0↑ 0↓   clean

~/.grove/workspaces/feature-xyz
❯ cd infra-platform

~/.g/w/f/infra-platform
❯ git branch
  feature-xyz
* im-actually-on-different-branch
```

this fixes it