### PR TITLE
fix: correct Homebrew upgrade command

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -158,5 +158,5 @@ func (c *Checker) FormatNotice(current string) string {
 	if newer == "" {
 		return ""
 	}
-	return fmt.Sprintf("A newer version of gw is available: %s → %s. Update with: brew upgrade gw", current, newer)
+	return fmt.Sprintf("A newer version of gw is available: %s → %s. Update with: brew update && brew upgrade grove", current, newer)
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -189,3 +189,21 @@ func TestFetchAndCacheWritesToDisk(t *testing.T) {
 		t.Errorf("last_check: got %d, want %d", cache.LastCheck, fixed.Unix())
 	}
 }
+
+func TestFormatNoticeUsesHomebrewFormulaName(t *testing.T) {
+	c := testChecker(t)
+	cache := CacheData{LastCheck: time.Now().Unix(), Latest: "1.2.0"}
+	data, err := json.Marshal(cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(c.CachePath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := c.FormatNotice("1.1.0")
+	want := "A newer version of gw is available: 1.1.0 → 1.2.0. Update with: brew update && brew upgrade grove"
+	if got != want {
+		t.Errorf("FormatNotice() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- recommend the full Homebrew refresh and upgrade command in update notices
- use the `grove` formula name instead of the `gw` executable name
- add regression coverage for the exact user-facing notice

## Verification

- `go test ./internal/update -run TestFormatNoticeUsesHomebrewFormulaName -count=1 -v`
- `PATH="$(go env GOPATH)/bin:$PATH" just check`
- `just build`

Fixes #51