### PR TITLE
Make workspace mutations fail safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ gw status my-feature   # git status across every repo
 gw sync my-feature     # rebase all repos onto their base branch
 gw run my-feature      # run dev processes (TUI)
 
-# Clean up when done
-gw delete my-feature   # removes worktrees + branches
+# Clean up when done (refuses dirty worktrees unless --force is used)
+gw delete my-feature   # removes worktrees + safely deletes merged branches
 ```
 
 Interactive menus support **type-to-search** filtering, arrow-key navigation (single-select), or arrow + tab (multi-select) with an `(all)` shortcut.

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -82,16 +82,16 @@ func doDelete(args []string, force bool) {
 			}
 		}
 
-		if err := workspace.NewService().Delete(name); err != nil {
+		if err := workspace.NewService().DeleteWithOptions(name, workspace.RemoveOptions{Force: force}); err != nil {
 			exitError(err.Error())
 		}
 	}
 }
 
 func init() {
-	deleteCmd.Flags().BoolVarP(&deleteCmdForce, "force", "f", false, "Skip confirmation")
+	deleteCmd.Flags().BoolVarP(&deleteCmdForce, "force", "f", false, "Skip worktree safety checks and confirmation")
 	deleteCmd.ValidArgsFunction = completeWorkspaceNames
 
-	wsDeleteCmd.Flags().BoolVarP(&wsDeleteCmdForce, "force", "f", false, "Skip confirmation")
+	wsDeleteCmd.Flags().BoolVarP(&wsDeleteCmdForce, "force", "f", false, "Skip worktree safety checks and confirmation")
 	wsDeleteCmd.ValidArgsFunction = completeWorkspaceNames
 }

--- a/cmd/removerepo.go
+++ b/cmd/removerepo.go
@@ -75,7 +75,7 @@ var removeRepoCmd = &cobra.Command{
 			}
 		}
 
-		if err := workspace.NewService().RemoveRepos(wsName, repoNames); err != nil {
+		if err := workspace.NewService().RemoveReposWithOptions(wsName, repoNames, workspace.RemoveOptions{Force: removeRepoForce}); err != nil {
 			exitError(err.Error())
 		}
 	},
@@ -83,7 +83,7 @@ var removeRepoCmd = &cobra.Command{
 
 func init() {
 	removeRepoCmd.Flags().StringVarP(&removeRepoRepos, "repos", "r", "", "Comma-separated repo names")
-	removeRepoCmd.Flags().BoolVarP(&removeRepoForce, "force", "f", false, "Skip confirmation")
+	removeRepoCmd.Flags().BoolVarP(&removeRepoForce, "force", "f", false, "Skip worktree safety checks and confirmation")
 	removeRepoCmd.RegisterFlagCompletionFunc("repos", completeRepoNames)
 	removeRepoCmd.ValidArgsFunction = completeWorkspaceNames
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	modernc.org/sqlite v1.56.0
 )
@@ -17,7 +18,6 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	modernc.org/libc v1.74.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/internal/gitops/gitops.go
+++ b/internal/gitops/gitops.go
@@ -178,9 +178,13 @@ func RemoteBranchExists(repo, branch string) bool {
 	return err == nil
 }
 
-// WorktreeRemove removes a worktree.
-func WorktreeRemove(repo, path string) error {
-	_, err := runGit(repo, "worktree", "remove", path, "--force")
+// WorktreeRemove removes a worktree. Force allows removal of a dirty worktree.
+func WorktreeRemove(repo, path string, force bool) error {
+	args := []string{"worktree", "remove", path}
+	if force {
+		args = append(args, "--force")
+	}
+	_, err := runGit(repo, args...)
 	return err
 }
 

--- a/internal/gitops/gitops_test.go
+++ b/internal/gitops/gitops_test.go
@@ -151,7 +151,7 @@ func TestWorktreeAddAndRemove(t *testing.T) {
 	}
 
 	// Remove
-	if err := WorktreeRemove(repo, wtPath); err != nil {
+	if err := WorktreeRemove(repo, wtPath, true); err != nil {
 		t.Fatalf("remove: %v", err)
 	}
 }
@@ -209,7 +209,7 @@ func TestWorktreeAddTracking(t *testing.T) {
 		t.Errorf("expected upstream origin/feat/pr-head, got %q", upstream)
 	}
 
-	WorktreeRemove(repo, wtPath)
+	WorktreeRemove(repo, wtPath, true)
 }
 
 func TestWorktreeHasBranch(t *testing.T) {
@@ -236,7 +236,7 @@ func TestWorktreeHasBranch(t *testing.T) {
 	}
 
 	// Cleanup
-	WorktreeRemove(repo, wtPath)
+	WorktreeRemove(repo, wtPath, true)
 }
 
 func TestWorktreeListParsing(t *testing.T) {
@@ -336,7 +336,7 @@ func TestRebaseOnto(t *testing.T) {
 	}
 
 	// Cleanup
-	WorktreeRemove(repo, wtPath)
+	WorktreeRemove(repo, wtPath, true)
 }
 
 func TestCommitsAheadBehind(t *testing.T) {
@@ -368,7 +368,7 @@ func TestCommitsAheadBehind(t *testing.T) {
 	}
 
 	// Cleanup
-	WorktreeRemove(repo, wtPath)
+	WorktreeRemove(repo, wtPath, true)
 }
 
 func TestRemoteURL(t *testing.T) {
@@ -495,7 +495,7 @@ func TestWorktreeRepair(t *testing.T) {
 		t.Fatalf("repair: %v", err)
 	}
 
-	WorktreeRemove(repo, wtPath)
+	WorktreeRemove(repo, wtPath, true)
 }
 
 func TestDeleteBranchForce(t *testing.T) {

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -128,7 +128,7 @@ func Run(hookName string, vars Vars) error {
 	if hook.Stream {
 		// Stream live to stderr, prefixed, so progress is visible. stderr keeps
 		// gw's stdout clean for shell integration (e.g. `cd "$(gw go ...)"`).
-		w := &streamio.PrefixWriter{Prefix: prefix, W: os.Stderr}
+		w := streamio.New(prefix, os.Stderr)
 		cmd.Stdout = w
 		cmd.Stderr = w
 		runErr := cmd.Run()
@@ -166,7 +166,7 @@ func wrap(hookName string, hook models.Hook, runErr error, ctx context.Context) 
 // echoCaptured prints captured hook output to stderr, prefixing each line so it
 // reads the same as streamed output.
 func echoCaptured(prefix string, out []byte) {
-	w := &streamio.PrefixWriter{Prefix: prefix, W: os.Stderr}
+	w := streamio.New(prefix, os.Stderr)
 	w.Write(out)
 	w.Flush()
 }

--- a/internal/state/lock.go
+++ b/internal/state/lock.go
@@ -1,0 +1,31 @@
+package state
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// WithLock serializes a state-changing operation across Grove processes.
+// The separate lock file is stable while state.json is atomically replaced.
+func (s *Store) WithLock(fn func() error) error {
+	if err := os.MkdirAll(filepath.Dir(s.Path), 0o755); err != nil {
+		return fmt.Errorf("creating state directory: %w", err)
+	}
+
+	path := filepath.Join(filepath.Dir(s.Path), "state.lock")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("opening state lock: %w", err)
+	}
+	defer file.Close()
+
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		return fmt.Errorf("locking state: %w", err)
+	}
+	defer unix.Flock(int(file.Fd()), unix.LOCK_UN) //nolint:errcheck -- close also releases the lock
+
+	return fn()
+}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,9 +1,13 @@
 package state
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/nicksenap/grove/internal/models"
 )
@@ -279,5 +283,126 @@ func TestAtomicWrite(t *testing.T) {
 	tmpPath := s.Path + ".tmp"
 	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
 		t.Error("temp file should be cleaned up")
+	}
+}
+
+func TestWithLockHelperProcess(t *testing.T) {
+	if os.Getenv("GROVE_LOCK_HELPER") != "1" {
+		return
+	}
+
+	store := &Store{Path: os.Getenv("GROVE_LOCK_STATE")}
+	err := store.WithLock(func() error {
+		if err := os.WriteFile(os.Getenv("GROVE_LOCK_MARKER"), []byte("locked"), 0o600); err != nil {
+			return err
+		}
+		if os.Getenv("GROVE_LOCK_HOLD") == "1" {
+			time.Sleep(300 * time.Millisecond)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWithLockSerializesProcesses(t *testing.T) {
+	store := testStore(t)
+	firstMarker := filepath.Join(t.TempDir(), "first.locked")
+	secondMarker := filepath.Join(t.TempDir(), "second.locked")
+
+	first := exec.Command(os.Args[0], "-test.run=^TestWithLockHelperProcess$")
+	first.Env = append(os.Environ(),
+		"GROVE_LOCK_HELPER=1",
+		"GROVE_LOCK_HOLD=1",
+		"GROVE_LOCK_STATE="+store.Path,
+		"GROVE_LOCK_MARKER="+firstMarker,
+	)
+	if err := first.Start(); err != nil {
+		t.Fatalf("start first process: %v", err)
+	}
+	t.Cleanup(func() { _ = first.Process.Kill() })
+	waitForFile(t, firstMarker)
+
+	second := exec.Command(os.Args[0], "-test.run=^TestWithLockHelperProcess$")
+	second.Env = append(os.Environ(),
+		"GROVE_LOCK_HELPER=1",
+		"GROVE_LOCK_STATE="+store.Path,
+		"GROVE_LOCK_MARKER="+secondMarker,
+	)
+	if err := second.Start(); err != nil {
+		t.Fatalf("start second process: %v", err)
+	}
+	t.Cleanup(func() { _ = second.Process.Kill() })
+
+	time.Sleep(75 * time.Millisecond)
+	if _, err := os.Stat(secondMarker); !os.IsNotExist(err) {
+		t.Fatal("second process acquired the lock while the first held it")
+	}
+	if err := first.Wait(); err != nil {
+		t.Fatalf("first process: %v", err)
+	}
+	if err := second.Wait(); err != nil {
+		t.Fatalf("second process: %v", err)
+	}
+	if _, err := os.Stat(secondMarker); err != nil {
+		t.Fatalf("second process never acquired the released lock: %v", err)
+	}
+}
+
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}
+
+func TestWithLockPreventsLostUpdates(t *testing.T) {
+	s := testStore(t)
+	const workers = 12
+
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			store := &Store{Path: s.Path}
+			errs <- store.WithLock(func() error {
+				workspaces, err := store.Load()
+				if err != nil {
+					return err
+				}
+				workspaces = append(workspaces, models.NewWorkspace(
+					fmt.Sprintf("ws-%d", i),
+					fmt.Sprintf("/tmp/ws-%d", i),
+					"main",
+				))
+				return store.Save(workspaces)
+			})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("locked update: %v", err)
+		}
+	}
+
+	workspaces, err := s.Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(workspaces) != workers {
+		t.Fatalf("expected %d workspaces, got %d", workers, len(workspaces))
 	}
 }

--- a/internal/streamio/prefix.go
+++ b/internal/streamio/prefix.go
@@ -35,9 +35,19 @@ type PrefixWriter struct {
 	midLine bool
 }
 
+// New returns a PrefixWriter that prepends prefix to every complete line it
+// forwards to w.
+func New(prefix string, w io.Writer) *PrefixWriter {
+	return &PrefixWriter{Prefix: prefix, W: w}
+}
+
 // Write implements io.Writer. It forwards each complete line prefixed with
 // Prefix and buffers any trailing partial line.
 func (pw *PrefixWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
 	pw.mu.Lock()
 	defer pw.mu.Unlock()
 
@@ -47,21 +57,21 @@ func (pw *PrefixWriter) Write(p []byte) (int, error) {
 		if idx < 0 {
 			break
 		}
-		pw.emit(pw.buf[:idx], true)
+		pw.emitLine(pw.buf[:idx], true)
 		pw.buf = pw.buf[idx+1:]
 	}
 	// Prevent unbounded growth: flush the oversized partial line without a
 	// newline and remember we're mid-line so the continuation isn't prefixed.
 	if len(pw.buf) > maxLineBuffer {
-		pw.emit(pw.buf, false)
+		pw.emitLine(pw.buf, false)
 		pw.buf = pw.buf[:0]
 	}
 	return len(p), nil
 }
 
-// emit writes one (possibly partial) line to W. It adds Prefix only at the
+// emitLine writes one (possibly partial) line to W. It adds Prefix only at the
 // start of a fresh line and a trailing newline only when newline is true.
-func (pw *PrefixWriter) emit(line []byte, newline bool) {
+func (pw *PrefixWriter) emitLine(line []byte, newline bool) {
 	if !pw.midLine {
 		fmt.Fprint(pw.W, pw.Prefix)
 	}
@@ -82,7 +92,7 @@ func (pw *PrefixWriter) Flush() {
 	defer pw.mu.Unlock()
 
 	if len(pw.buf) > 0 {
-		pw.emit(pw.buf, true)
+		pw.emitLine(pw.buf, true)
 		pw.buf = pw.buf[:0]
 	}
 }

--- a/internal/workspace/run.go
+++ b/internal/workspace/run.go
@@ -83,8 +83,9 @@ func Run(wsName string) error {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 		// Prefix output with repo name
-		outW := &streamio.PrefixWriter{Prefix: fmt.Sprintf("[%s] ", r.RepoName), W: os.Stdout}
-		errW := &streamio.PrefixWriter{Prefix: fmt.Sprintf("[%s] ", r.RepoName), W: os.Stderr}
+		prefix := fmt.Sprintf("[%s] ", r.RepoName)
+		outW := streamio.New(prefix, os.Stdout)
+		errW := streamio.New(prefix, os.Stderr)
 		cmd.Stdout = outW
 		cmd.Stderr = errW
 

--- a/internal/workspace/service.go
+++ b/internal/workspace/service.go
@@ -11,10 +11,11 @@ import (
 
 // Service orchestrates workspace operations with injectable dependencies.
 type Service struct {
-	State        *state.Store
-	Stats        *stats.Tracker
-	RunCmd       func(dir, cmd string) error
-	RunCmdSilent func(dir, cmd string) error
+	State          *state.Store
+	Stats          *stats.Tracker
+	RunCmd         func(dir, cmd string) error
+	RunCmdSilent   func(dir, cmd string) error
+	RemoveWorktree func(repo, path string, force bool) error // optional test seam
 }
 
 // NewService creates a Service with production dependencies.

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -68,25 +69,55 @@ func (s *Service) Create(name, branch string, repoNames []string, repoMap map[st
 // implementation behind Create, additionally supporting per-repo branch tracking
 // (BranchMode/TrackBranchRepo) and a persisted Source link.
 func (s *Service) CreateWithOpts(name string, opts CreateOpts) error {
+	var ws models.Workspace
+	if err := s.State.WithLock(func() error {
+		var err error
+		ws, err = s.createWithOptsLocked(name, opts)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	// Setup commands are user-owned and may invoke gw, so run them after the
+	// workspace is committed and the cross-process mutation lock is released.
+	if hasSetupHooks(ws) {
+		console.Infof("running setup hooks...")
+	}
+	s.runSetupHooks(ws)
+
+	s.Stats.RecordCreated(ws)
+	logging.Info("workspace %q created at %s", name, ws.Path)
+	console.Successf("Workspace %s created at %s", name, ws.Path)
+
+	if cdFile := os.Getenv("GROVE_CD_FILE"); cdFile != "" {
+		os.WriteFile(cdFile, []byte(ws.Path), 0o644)
+	}
+
+	return nil
+}
+
+func (s *Service) createWithOptsLocked(name string, opts CreateOpts) (models.Workspace, error) {
 	branch := opts.Branch
 	repoNames := opts.Repos
 	repoMap := opts.RepoMap
 	cfg := opts.Cfg
 
-	// Check duplicate
 	existing, err := s.State.GetWorkspace(name)
 	if err != nil {
-		return err
+		return models.Workspace{}, err
 	}
 	if existing != nil {
-		return fmt.Errorf("workspace %s already exists", name)
+		return models.Workspace{}, fmt.Errorf("workspace %s already exists", name)
 	}
 
 	logging.Info("creating workspace %q (branch=%s, repos=%v)", name, branch, repoNames)
 
+	if err := os.MkdirAll(cfg.WorkspaceDir, 0o755); err != nil {
+		return models.Workspace{}, fmt.Errorf("creating workspace parent: %w", err)
+	}
 	wsPath := filepath.Join(cfg.WorkspaceDir, name)
-	if err := os.MkdirAll(wsPath, 0o755); err != nil {
-		return fmt.Errorf("creating workspace dir: %w", err)
+	if err := os.Mkdir(wsPath, 0o755); err != nil {
+		return models.Workspace{}, fmt.Errorf("creating workspace dir: %w", err)
 	}
 
 	ws := models.NewWorkspace(name, wsPath, branch)
@@ -97,8 +128,10 @@ func (s *Service) CreateWithOpts(name string, opts CreateOpts) error {
 	for i, repoName := range repoNames {
 		sourcePath, ok := repoMap[repoName]
 		if !ok {
-			os.RemoveAll(wsPath)
-			return fmt.Errorf("repo %s not found", repoName)
+			return models.Workspace{}, errors.Join(
+				fmt.Errorf("repo %s not found", repoName),
+				removeEmptyDir(wsPath),
+			)
 		}
 		sourcePaths[i] = sourcePath
 	}
@@ -118,94 +151,79 @@ func (s *Service) CreateWithOpts(name string, opts CreateOpts) error {
 	fetchWg.Wait()
 
 	// Phase 2: sequential worktree creation (for rollback safety)
-	var created []models.RepoWorktree
+	var created []provisionedRepo
 	for i, repoName := range repoNames {
 		console.Infof("[%d/%d] %s", i+1, len(repoNames), repoName)
-		// Resolve the per-repo mode. With no TrackBranchRepo set, opts.BranchMode
-		// applies to every repo; otherwise only the named repo uses it.
 		mode := opts.BranchMode
 		if opts.TrackBranchRepo != "" && repoName != opts.TrackBranchRepo {
 			mode = BranchModeCreate
 		}
-		rw, err := provisionWorktreeNoFetch(sourcePaths[i], repoName, wsPath, branch, mode)
+		provisioned, err := provisionWorktreeNoFetch(sourcePaths[i], repoName, wsPath, branch, mode)
 		if err != nil {
-			logging.Error("workspace creation failed for %q — rolled back", name)
-			rollback(created)
-			os.RemoveAll(wsPath)
-			return fmt.Errorf("provisioning %s: %w", repoName, err)
+			logging.Error("workspace creation failed for %q — rolling back", name)
+			return models.Workspace{}, errors.Join(
+				fmt.Errorf("provisioning %s: %w", repoName, err),
+				s.rollback(created),
+				removeEmptyDir(wsPath),
+			)
 		}
-		created = append(created, *rw)
+		created = append(created, *provisioned)
+		ws.Repos = append(ws.Repos, provisioned.worktree)
 	}
 
-	ws.Repos = created
-
-	// Run setup hooks (parallel)
-	if hasSetupHooks(ws) {
-		console.Infof("running setup hooks...")
-	}
-	s.runSetupHooks(ws)
-
-	// Save state
 	if err := s.State.AddWorkspace(ws); err != nil {
-		rollback(created)
-		os.RemoveAll(wsPath)
-		return err
+		return models.Workspace{}, errors.Join(err, s.rollback(created), removeEmptyDir(wsPath))
 	}
 
-	// Record stats
-	s.Stats.RecordCreated(ws)
-
-	// Write .mcp.json
 	writeMCPConfig(ws)
-
-	logging.Info("workspace %q created at %s", name, wsPath)
-	console.Successf("Workspace %s created at %s", name, wsPath)
-
-	// Write GROVE_CD_FILE if set
-	if cdFile := os.Getenv("GROVE_CD_FILE"); cdFile != "" {
-		os.WriteFile(cdFile, []byte(wsPath), 0o644)
-	}
-
-	return nil
+	return ws, nil
 }
 
-func provisionWorktree(sourcePath, repoName, wsPath, branch string) (*models.RepoWorktree, error) {
+type provisionedRepo struct {
+	worktree      models.RepoWorktree
+	branchCreated bool
+}
+
+func provisionWorktree(sourcePath, repoName, wsPath, branch string) (*provisionedRepo, error) {
 	_ = gitops.Fetch(sourcePath)
 	return provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch, BranchModeCreate)
 }
 
-func provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch string, mode BranchMode) (*models.RepoWorktree, error) {
+func provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch string, mode BranchMode) (*provisionedRepo, error) {
 	wtPath := filepath.Join(wsPath, repoName)
 
-	// Check if branch already has a worktree
 	hasWT, _ := gitops.WorktreeHasBranch(sourcePath, branch)
 	if hasWT {
 		return nil, fmt.Errorf("branch %s already has a worktree in %s", branch, repoName)
 	}
 
-	// Track mode: check out an existing remote branch (e.g. a PR head) rather
-	// than creating a new branch. Only meaningful when the branch does not
-	// already exist locally; otherwise fall through to the normal add below.
+	// Tracking creates the local branch as part of git worktree add.
 	if mode == BranchModeTrack && !gitops.BranchExists(sourcePath, branch) {
 		if gitops.RemoteBranchExists(sourcePath, branch) {
 			logging.Info("tracking existing remote branch %q in %s", branch, repoName)
 			if err := gitops.WorktreeAddTracking(sourcePath, wtPath, branch); err != nil {
-				return nil, fmt.Errorf("adding tracking worktree: %w", err)
+				var cleanupErr error
+				if gitops.BranchExists(sourcePath, branch) {
+					if err := gitops.DeleteBranch(sourcePath, branch, true); err != nil {
+						cleanupErr = fmt.Errorf("rolling back branch: %w", err)
+					}
+				}
+				return nil, errors.Join(fmt.Errorf("adding tracking worktree: %w", err), cleanupErr)
 			}
-			return &models.RepoWorktree{
-				RepoName:     repoName,
-				SourceRepo:   sourcePath,
-				WorktreePath: wtPath,
-				Branch:       branch,
+			return &provisionedRepo{
+				worktree: models.RepoWorktree{
+					RepoName:     repoName,
+					SourceRepo:   sourcePath,
+					WorktreePath: wtPath,
+					Branch:       branch,
+				},
+				branchCreated: true,
 			}, nil
 		}
-		// Remote branch missing (deleted, force-pushed, or a fork PR whose head
-		// lives on another remote). Fall back to create-mode with a warning
-		// rather than failing mid-creation.
 		console.Warningf("%s: remote branch %s not found — creating a new branch from base instead", repoName, branch)
 	}
 
-	// Create branch if needed
+	branchCreated := false
 	if !gitops.BranchExists(sourcePath, branch) {
 		base, err := gitops.ResolveBaseBranch(sourcePath)
 		if err != nil {
@@ -220,25 +238,52 @@ func provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch string, mode 
 				}
 			}
 		}
+		branchCreated = true
 	}
 
-	// Add worktree
 	if err := gitops.WorktreeAdd(sourcePath, wtPath, branch); err != nil {
-		return nil, fmt.Errorf("adding worktree: %w", err)
+		var cleanupErr error
+		if branchCreated {
+			if err := gitops.DeleteBranch(sourcePath, branch, true); err != nil {
+				cleanupErr = fmt.Errorf("rolling back branch: %w", err)
+			}
+		}
+		return nil, errors.Join(fmt.Errorf("adding worktree: %w", err), cleanupErr)
 	}
 
-	return &models.RepoWorktree{
-		RepoName:     repoName,
-		SourceRepo:   sourcePath,
-		WorktreePath: wtPath,
-		Branch:       branch,
+	return &provisionedRepo{
+		worktree: models.RepoWorktree{
+			RepoName:     repoName,
+			SourceRepo:   sourcePath,
+			WorktreePath: wtPath,
+			Branch:       branch,
+		},
+		branchCreated: branchCreated,
 	}, nil
 }
 
-func rollback(repos []models.RepoWorktree) {
-	for _, r := range repos {
-		gitops.WorktreeRemove(r.SourceRepo, r.WorktreePath)
+func (s *Service) rollback(repos []provisionedRepo) error {
+	var errs []error
+	for i := len(repos) - 1; i >= 0; i-- {
+		repo := repos[i]
+		if err := s.removeWorktree(repo.worktree.SourceRepo, repo.worktree.WorktreePath, true); err != nil {
+			errs = append(errs, fmt.Errorf("%s: rolling back worktree: %w", repo.worktree.RepoName, err))
+			continue
+		}
+		if repo.branchCreated {
+			if err := gitops.DeleteBranch(repo.worktree.SourceRepo, repo.worktree.Branch, true); err != nil {
+				errs = append(errs, fmt.Errorf("%s: rolling back branch: %w", repo.worktree.RepoName, err))
+			}
+		}
 	}
+	return errors.Join(errs...)
+}
+
+func removeEmptyDir(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing empty workspace root %s: %w", path, err)
+	}
+	return nil
 }
 
 func hasSetupHooks(ws models.Workspace) bool {
@@ -346,8 +391,18 @@ func removeMCPConfig(ws models.Workspace) {
 	}
 }
 
-// Delete removes a workspace and its worktrees.
+// RemoveOptions controls destructive worktree cleanup.
+type RemoveOptions struct {
+	Force bool
+}
+
+// Delete removes a workspace using safe defaults.
 func (s *Service) Delete(name string) error {
+	return s.DeleteWithOptions(name, RemoveOptions{})
+}
+
+// DeleteWithOptions removes a workspace and its worktrees.
+func (s *Service) DeleteWithOptions(name string, opts RemoveOptions) error {
 	ws, err := s.State.GetWorkspace(name)
 	if err != nil {
 		return err
@@ -356,69 +411,176 @@ func (s *Service) Delete(name string) error {
 		return fmt.Errorf("workspace %s not found", name)
 	}
 
-	logging.Info("deleting workspace %q", name)
-	removeMCPConfig(*ws)
-
-	// Parallel teardown+remove for all repos
-	succeeded := make([]bool, len(ws.Repos))
-	var wg sync.WaitGroup
-	for i, r := range ws.Repos {
-		wg.Add(1)
-		go func(idx int, repo models.RepoWorktree) {
-			defer wg.Done()
-			groveCfg, _ := gitops.ReadGroveConfig(repo.SourceRepo)
-			if groveCfg != nil && groveCfg.Teardown != "" {
-				s.RunCmdSilent(repo.WorktreePath, groveCfg.Teardown)
-			}
-
-			if err := gitops.WorktreeRemove(repo.SourceRepo, repo.WorktreePath); err != nil {
-				if err := os.RemoveAll(repo.WorktreePath); err != nil {
-					logging.Warn("failed to remove worktree for %s: %s", repo.RepoName, err)
-					console.Warningf("%s: failed to remove worktree: %s", repo.RepoName, err)
-					return
-				}
-			}
-
-			if err := gitops.DeleteBranch(repo.SourceRepo, repo.Branch, true); err != nil {
-				logging.Warn("failed to delete branch %q in %s: %s", repo.Branch, repo.RepoName, err)
-				console.Warningf("%s: failed to delete branch %s: %s", repo.RepoName, repo.Branch, err)
-			} else {
-				logging.Info("deleted branch %q in %s", repo.Branch, repo.RepoName)
-			}
-
-			succeeded[idx] = true
-		}(i, r)
-	}
-	wg.Wait()
-
-	failCount := 0
-	for _, ok := range succeeded {
-		if !ok {
-			failCount++
-		}
-	}
-	if failCount > 0 {
-		logging.Warn("workspace %q: %d worktree(s) failed to remove", name, failCount)
+	if err := preflightRemovals(ws.Repos, opts.Force); err != nil {
+		return err
 	}
 
-	os.RemoveAll(ws.Path)
+	// Teardown commands are user-owned and may invoke gw. Run them before the
+	// mutation lock, then reload and preflight state again while locked.
+	s.runTeardownHooks(ws.Repos)
 
-	s.Stats.RecordDeleted(*ws)
-
-	_, dirErr := os.Stat(ws.Path)
-	if failCount == 0 || os.IsNotExist(dirErr) {
-		if err := s.State.RemoveWorkspace(name); err != nil {
-			return err
-		}
+	var deleted *models.Workspace
+	if err := s.State.WithLock(func() error {
+		var err error
+		deleted, err = s.deleteLocked(name, opts)
+		return err
+	}); err != nil {
+		return err
 	}
 
+	s.Stats.RecordDeleted(*deleted)
 	logging.Info("workspace %q deleted", name)
 	console.Successf("Workspace %s deleted", name)
 	return nil
 }
 
+func (s *Service) deleteLocked(name string, opts RemoveOptions) (*models.Workspace, error) {
+	ws, err := s.State.GetWorkspace(name)
+	if err != nil {
+		return nil, err
+	}
+	if ws == nil {
+		return nil, fmt.Errorf("workspace %s not found", name)
+	}
+	if err := preflightRemovals(ws.Repos, opts.Force); err != nil {
+		return nil, err
+	}
+
+	logging.Info("deleting workspace %q", name)
+	original := *ws
+	remaining := make([]models.RepoWorktree, 0, len(ws.Repos))
+	var cleanupErrs []error
+
+	for _, repo := range ws.Repos {
+		if err := s.removeWorktree(repo.SourceRepo, repo.WorktreePath, opts.Force); err != nil {
+			remaining = append(remaining, repo)
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("%s: removing worktree: %w", repo.RepoName, err))
+			continue
+		}
+		s.deleteBranch(repo, opts.Force)
+	}
+
+	if len(remaining) > 0 {
+		ws.Repos = remaining
+		if err := s.State.UpdateWorkspace(*ws); err != nil {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("updating state: %w", err))
+		}
+		return nil, errors.Join(cleanupErrs...)
+	}
+
+	removeMCPConfig(*ws)
+	if err := os.Remove(ws.Path); err != nil && !os.IsNotExist(err) {
+		ws.Repos = nil
+		cleanupErrs = append(cleanupErrs, fmt.Errorf("removing workspace root %s: %w", ws.Path, err))
+		if stateErr := s.State.UpdateWorkspace(*ws); stateErr != nil {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("updating state: %w", stateErr))
+		}
+		return nil, errors.Join(cleanupErrs...)
+	}
+
+	if err := s.State.RemoveWorkspace(name); err != nil {
+		return nil, err
+	}
+	return &original, nil
+}
+
+func (s *Service) runTeardownHooks(repos []models.RepoWorktree) {
+	for _, repo := range repos {
+		groveCfg, _ := gitops.ReadGroveConfig(repo.SourceRepo)
+		if groveCfg != nil && groveCfg.Teardown != "" {
+			s.RunCmdSilent(repo.WorktreePath, groveCfg.Teardown)
+		}
+	}
+}
+
+func (s *Service) removeWorktree(repo, path string, force bool) error {
+	if s.RemoveWorktree != nil {
+		return s.RemoveWorktree(repo, path, force)
+	}
+	return gitops.WorktreeRemove(repo, path, force)
+}
+
+func (s *Service) deleteBranch(repo models.RepoWorktree, force bool) {
+	if err := gitops.DeleteBranch(repo.SourceRepo, repo.Branch, force); err != nil {
+		logging.Warn("failed to delete branch %q in %s: %s", repo.Branch, repo.RepoName, err)
+		console.Warningf("%s: failed to delete branch %s: %s", repo.RepoName, repo.Branch, err)
+		return
+	}
+	logging.Info("deleted branch %q in %s", repo.Branch, repo.RepoName)
+}
+
+func preflightRemovals(repos []models.RepoWorktree, force bool) error {
+	if force {
+		return nil
+	}
+	var errs []error
+	for _, repo := range repos {
+		if err := preflightRemoval(repo); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", repo.RepoName, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func preflightRemoval(repo models.RepoWorktree) error {
+	entries, err := gitops.WorktreeList(repo.SourceRepo)
+	if err != nil {
+		return fmt.Errorf("reading worktree registration: %w", err)
+	}
+
+	expectedPath := canonicalPath(repo.WorktreePath)
+	registered := false
+	for _, entry := range entries {
+		if canonicalPath(entry.Path) != expectedPath {
+			continue
+		}
+		registered = true
+		if entry.Branch != repo.Branch {
+			return fmt.Errorf("unexpected branch %q at %s (expected %q)", entry.Branch, repo.WorktreePath, repo.Branch)
+		}
+		break
+	}
+	if !registered {
+		return fmt.Errorf("worktree path is not registered: %s", repo.WorktreePath)
+	}
+
+	branch, err := gitops.CurrentBranch(repo.WorktreePath)
+	if err != nil {
+		return fmt.Errorf("reading current branch: %w", err)
+	}
+	if branch != repo.Branch {
+		return fmt.Errorf("unexpected current branch %q (expected %q)", branch, repo.Branch)
+	}
+
+	status, err := gitops.RepoStatus(repo.WorktreePath)
+	if err != nil {
+		return fmt.Errorf("reading worktree status: %w", err)
+	}
+	if status != "" {
+		return fmt.Errorf("dirty worktree; commit, stash, or use --force")
+	}
+	return nil
+}
+
+func canonicalPath(path string) string {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		absolute = path
+	}
+	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(absolute)
+}
+
 // Rename renames a workspace using a state-first pattern with rollback.
 func (s *Service) Rename(oldName, newName string) error {
+	return s.State.WithLock(func() error {
+		return s.renameLocked(oldName, newName)
+	})
+}
+
+func (s *Service) renameLocked(oldName, newName string) error {
 	ws, err := s.State.GetWorkspace(oldName)
 	if err != nil {
 		return err
@@ -480,12 +642,33 @@ func (s *Service) Rename(oldName, newName string) error {
 
 // AddRepos adds repos to an existing workspace.
 func (s *Service) AddRepos(wsName string, repoNames []string, repoMap map[string]string) error {
-	ws, err := s.State.GetWorkspace(wsName)
-	if err != nil {
+	var added []models.RepoWorktree
+	if err := s.State.WithLock(func() error {
+		var err error
+		added, err = s.addReposLocked(wsName, repoNames, repoMap)
+		return err
+	}); err != nil {
 		return err
 	}
+
+	if len(added) == 0 {
+		return nil
+	}
+
+	// As with create, setup runs after the state mutation lock is released.
+	s.runSetupHooks(models.Workspace{Repos: added})
+	logging.Info("added %d repo(s) to workspace %q", len(added), wsName)
+	console.Successf("Added %d repo(s) to %s", len(added), wsName)
+	return nil
+}
+
+func (s *Service) addReposLocked(wsName string, repoNames []string, repoMap map[string]string) ([]models.RepoWorktree, error) {
+	ws, err := s.State.GetWorkspace(wsName)
+	if err != nil {
+		return nil, err
+	}
 	if ws == nil {
-		return fmt.Errorf("workspace %s not found", wsName)
+		return nil, fmt.Errorf("workspace %s not found", wsName)
 	}
 
 	existing := make(map[string]bool)
@@ -502,38 +685,46 @@ func (s *Service) AddRepos(wsName string, repoNames []string, repoMap map[string
 
 	if len(toAdd) == 0 {
 		console.Info("All repos already in workspace")
-		return nil
+		return nil, nil
 	}
 
-	beforeLen := len(ws.Repos)
-	for _, repoName := range toAdd {
+	sourcePaths := make([]string, len(toAdd))
+	for i, repoName := range toAdd {
 		sourcePath, ok := repoMap[repoName]
 		if !ok {
-			return fmt.Errorf("repo %s not found", repoName)
+			return nil, fmt.Errorf("repo %s not found", repoName)
 		}
-
-		rw, err := provisionWorktree(sourcePath, repoName, ws.Path, ws.Branch)
-		if err != nil {
-			return fmt.Errorf("adding %s: %w", repoName, err)
-		}
-
-		ws.Repos = append(ws.Repos, *rw)
+		sourcePaths[i] = sourcePath
 	}
 
-	newWS := models.Workspace{Repos: ws.Repos[beforeLen:]}
-	s.runSetupHooks(newWS)
+	created := make([]provisionedRepo, 0, len(toAdd))
+	for i, repoName := range toAdd {
+		provisioned, err := provisionWorktree(sourcePaths[i], repoName, ws.Path, ws.Branch)
+		if err != nil {
+			return nil, errors.Join(fmt.Errorf("adding %s: %w", repoName, err), s.rollback(created))
+		}
+		created = append(created, *provisioned)
+		ws.Repos = append(ws.Repos, provisioned.worktree)
+	}
 
 	if err := s.State.UpdateWorkspace(*ws); err != nil {
-		return err
+		return nil, errors.Join(err, s.rollback(created))
 	}
 
-	logging.Info("added %d repo(s) to workspace %q", len(toAdd), wsName)
-	console.Successf("Added %d repo(s) to %s", len(toAdd), wsName)
-	return nil
+	added := make([]models.RepoWorktree, 0, len(created))
+	for _, repo := range created {
+		added = append(added, repo.worktree)
+	}
+	return added, nil
 }
 
-// RemoveRepos removes repos from a workspace.
+// RemoveRepos removes repos from a workspace using safe defaults.
 func (s *Service) RemoveRepos(wsName string, repoNames []string) error {
+	return s.RemoveReposWithOptions(wsName, repoNames, RemoveOptions{})
+}
+
+// RemoveReposWithOptions removes selected repos from a workspace.
+func (s *Service) RemoveReposWithOptions(wsName string, repoNames []string, opts RemoveOptions) error {
 	ws, err := s.State.GetWorkspace(wsName)
 	if err != nil {
 		return err
@@ -542,52 +733,71 @@ func (s *Service) RemoveRepos(wsName string, repoNames []string) error {
 		return fmt.Errorf("workspace %s not found", wsName)
 	}
 
-	type removeItem struct {
-		name string
-		repo *models.RepoWorktree
-	}
-	var items []removeItem
-	for _, repoName := range repoNames {
-		r := ws.FindRepo(repoName)
-		if r != nil {
-			items = append(items, removeItem{name: repoName, repo: r})
-		}
-	}
-
-	succeeded := make([]bool, len(items))
-	var wg sync.WaitGroup
-	for i, item := range items {
-		wg.Add(1)
-		go func(idx int, r models.RepoWorktree) {
-			defer wg.Done()
-			groveCfg, _ := gitops.ReadGroveConfig(r.SourceRepo)
-			if groveCfg != nil && groveCfg.Teardown != "" {
-				s.RunCmdSilent(r.WorktreePath, groveCfg.Teardown)
-			}
-
-			if err := gitops.WorktreeRemove(r.SourceRepo, r.WorktreePath); err != nil {
-				os.RemoveAll(r.WorktreePath)
-			}
-
-			gitops.DeleteBranch(r.SourceRepo, r.Branch, false)
-			succeeded[idx] = true
-		}(i, *item.repo)
-	}
-	wg.Wait()
-
-	for i, item := range items {
-		if succeeded[i] {
-			ws.RemoveRepo(item.name)
-		}
-	}
-
-	if err := s.State.UpdateWorkspace(*ws); err != nil {
+	selected := selectRepos(ws, repoNames)
+	if err := preflightRemovals(selected, opts.Force); err != nil {
 		return err
 	}
+	s.runTeardownHooks(selected)
 
-	logging.Info("removed %d repo(s) from workspace %q", len(repoNames), wsName)
-	console.Successf("Removed %d repo(s) from %s", len(repoNames), wsName)
+	var removed int
+	if err := s.State.WithLock(func() error {
+		var err error
+		removed, err = s.removeReposLocked(wsName, repoNames, opts)
+		return err
+	}); err != nil {
+		return err
+	}
+	if removed == 0 {
+		return nil
+	}
+
+	logging.Info("removed %d repo(s) from workspace %q", removed, wsName)
+	console.Successf("Removed %d repo(s) from %s", removed, wsName)
 	return nil
+}
+
+func (s *Service) removeReposLocked(wsName string, repoNames []string, opts RemoveOptions) (int, error) {
+	ws, err := s.State.GetWorkspace(wsName)
+	if err != nil {
+		return 0, err
+	}
+	if ws == nil {
+		return 0, fmt.Errorf("workspace %s not found", wsName)
+	}
+
+	items := selectRepos(ws, repoNames)
+	if err := preflightRemovals(items, opts.Force); err != nil {
+		return 0, err
+	}
+
+	removed := 0
+	var cleanupErrs []error
+	for _, repo := range items {
+		if err := s.removeWorktree(repo.SourceRepo, repo.WorktreePath, opts.Force); err != nil {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("%s: removing worktree: %w", repo.RepoName, err))
+			continue
+		}
+		s.deleteBranch(repo, opts.Force)
+		ws.RemoveRepo(repo.RepoName)
+		removed++
+	}
+
+	if removed > 0 {
+		if err := s.State.UpdateWorkspace(*ws); err != nil {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("updating state: %w", err))
+		}
+	}
+	return removed, errors.Join(cleanupErrs...)
+}
+
+func selectRepos(ws *models.Workspace, names []string) []models.RepoWorktree {
+	selected := make([]models.RepoWorktree, 0, len(names))
+	for _, name := range names {
+		if repo := ws.FindRepo(name); repo != nil {
+			selected = append(selected, *repo)
+		}
+	}
+	return selected
 }
 
 // syncOneRepo syncs a single repo.
@@ -953,6 +1163,21 @@ func (s *Service) AllWorkspacesSummary() ([]WorkspaceSummary, error) {
 
 // Doctor checks workspace health and returns issues.
 func (s *Service) Doctor(fix bool) ([]models.DoctorIssue, int, error) {
+	if !fix {
+		return s.doctor(false)
+	}
+
+	var issues []models.DoctorIssue
+	var fixed int
+	err := s.State.WithLock(func() error {
+		var err error
+		issues, fixed, err = s.doctor(true)
+		return err
+	})
+	return issues, fixed, err
+}
+
+func (s *Service) doctor(fix bool) ([]models.DoctorIssue, int, error) {
 	workspaces, err := s.State.Load()
 	if err != nil {
 		return nil, 0, err

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -203,6 +204,81 @@ func TestCreateRollbackOnFailure(t *testing.T) {
 	ws, _ := env.svc.State.GetWorkspace("rollback-ws")
 	if ws != nil {
 		t.Error("workspace should not be in state after rollback")
+	}
+}
+
+func TestCreateFailurePreservesPreexistingWorkspaceRoot(t *testing.T) {
+	env := setupTestEnv(t)
+	path := filepath.Join(env.wsDir, "preexisting-root")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("create pre-existing root: %v", err)
+	}
+
+	err := env.svc.Create("preexisting-root", "feat/preexisting-root", []string{"missing"}, env.repoMap, env.cfg)
+	if err == nil {
+		t.Fatal("expected missing repo error")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("pre-existing workspace root should remain: %v", err)
+	}
+}
+
+func TestCreateRollbackRemovesBranchesCreatedByInvocation(t *testing.T) {
+	env := setupTestEnv(t)
+	api := env.createRepo("api")
+	web := env.createRepo("web")
+
+	conflictPath := filepath.Join(env.dir, "web-conflict")
+	env.run(web, "git", "worktree", "add", "-q", "-b", "feat/create-rollback", conflictPath)
+
+	err := env.svc.Create("create-rollback", "feat/create-rollback", []string{"api", "web"}, env.repoMap, env.cfg)
+	if err == nil || !strings.Contains(err.Error(), "web") {
+		t.Fatalf("expected web conflict, got %v", err)
+	}
+	if gitops.BranchExists(api, "feat/create-rollback") {
+		t.Error("rollback should remove the api branch created by this invocation")
+	}
+	if _, err := os.Stat(filepath.Join(env.wsDir, "create-rollback")); !os.IsNotExist(err) {
+		t.Error("empty workspace root should be removed after rollback")
+	}
+}
+
+func TestConcurrentCreatesPreserveBothStateEntries(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	env.createRepo("web")
+
+	svcA := *env.svc
+	svcA.State = state.NewStore(env.groveDir)
+	svcA.Stats = &stats.Tracker{StatsPath: filepath.Join(env.groveDir, "stats-a.json"), NowFn: time.Now}
+	svcB := *env.svc
+	svcB.State = state.NewStore(env.groveDir)
+	svcB.Stats = &stats.Tracker{StatsPath: filepath.Join(env.groveDir, "stats-b.json"), NowFn: time.Now}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	go func() {
+		<-start
+		errs <- svcA.Create("ws-a", "feat/a", []string{"api"}, env.repoMap, env.cfg)
+	}()
+	go func() {
+		<-start
+		errs <- svcB.Create("ws-b", "feat/b", []string{"web"}, env.repoMap, env.cfg)
+	}()
+	close(start)
+
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatalf("concurrent create: %v", err)
+		}
+	}
+
+	workspaces, err := env.svc.State.Load()
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if len(workspaces) != 2 {
+		t.Fatalf("expected both workspaces in state, got %d", len(workspaces))
 	}
 }
 
@@ -508,6 +584,102 @@ func TestDeleteCleansBranch(t *testing.T) {
 	}
 }
 
+func TestDeleteRejectsDirtyWorktreeByDefault(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	if err := env.svc.Create("dirty-delete", "feat/dirty-delete", []string{"api"}, env.repoMap, env.cfg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	ws, _ := env.svc.State.GetWorkspace("dirty-delete")
+	dirtyFile := filepath.Join(ws.Repos[0].WorktreePath, "dirty.txt")
+	if err := os.WriteFile(dirtyFile, []byte("keep me"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	err := env.svc.DeleteWithOptions("dirty-delete", RemoveOptions{})
+	if err == nil || !strings.Contains(err.Error(), "api") || !strings.Contains(err.Error(), "dirty") {
+		t.Fatalf("expected repo-named dirty error, got %v", err)
+	}
+	if _, err := os.Stat(dirtyFile); err != nil {
+		t.Fatalf("dirty file should remain: %v", err)
+	}
+	if saved, _ := env.svc.State.GetWorkspace("dirty-delete"); saved == nil {
+		t.Fatal("workspace state should remain")
+	}
+}
+
+func TestDeleteForceRemovesDirtyWorktree(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	if err := env.svc.Create("force-delete", "feat/force-delete", []string{"api"}, env.repoMap, env.cfg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	ws, _ := env.svc.State.GetWorkspace("force-delete")
+	if err := os.WriteFile(filepath.Join(ws.Repos[0].WorktreePath, "dirty.txt"), []byte("remove me"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	if err := env.svc.DeleteWithOptions("force-delete", RemoveOptions{Force: true}); err != nil {
+		t.Fatalf("force delete: %v", err)
+	}
+	if saved, _ := env.svc.State.GetWorkspace("force-delete"); saved != nil {
+		t.Fatal("workspace state should be removed")
+	}
+}
+
+func TestDeleteRemovalFailurePreservesPathAndState(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	if err := env.svc.Create("failed-delete", "feat/failed-delete", []string{"api"}, env.repoMap, env.cfg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	ws, _ := env.svc.State.GetWorkspace("failed-delete")
+	env.svc.RemoveWorktree = func(repo, path string, force bool) error {
+		return fmt.Errorf("simulated git failure")
+	}
+
+	err := env.svc.Delete("failed-delete")
+	if err == nil || !strings.Contains(err.Error(), "api") {
+		t.Fatalf("expected repo-named removal error, got %v", err)
+	}
+	if _, err := os.Stat(ws.Repos[0].WorktreePath); err != nil {
+		t.Fatalf("worktree path should remain: %v", err)
+	}
+	if saved, _ := env.svc.State.GetWorkspace("failed-delete"); saved == nil || len(saved.Repos) != 1 {
+		t.Fatal("failed repo should remain in state")
+	}
+	if _, err := os.Stat(filepath.Join(ws.Path, ".mcp.json")); err != nil {
+		t.Fatalf("failed delete should preserve workspace MCP config: %v", err)
+	}
+}
+
+func TestDeletePreflightsEveryRepoBeforeRemovingAny(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	env.createRepo("web")
+	if err := env.svc.Create("preflight-delete", "feat/preflight-delete", []string{"api", "web"}, env.repoMap, env.cfg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	ws, _ := env.svc.State.GetWorkspace("preflight-delete")
+	apiPath := ws.Repos[0].WorktreePath
+	ws.Repos[1].WorktreePath = filepath.Join(ws.Path, "unexpected-web")
+	if err := env.svc.State.UpdateWorkspace(*ws); err != nil {
+		t.Fatalf("corrupt state fixture: %v", err)
+	}
+
+	err := env.svc.Delete("preflight-delete")
+	if err == nil || !strings.Contains(err.Error(), "web") {
+		t.Fatalf("expected web preflight error, got %v", err)
+	}
+	if _, err := os.Stat(apiPath); err != nil {
+		t.Fatalf("api should not be removed before all preflights pass: %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Rename tests
 // ---------------------------------------------------------------------------
@@ -720,6 +892,86 @@ func TestAddReposNotFound(t *testing.T) {
 	}
 }
 
+func TestAddReposRollsBackEarlierAdditions(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	env.createRepo("web")
+	worker := env.createRepo("worker")
+	if err := env.svc.Create("add-rollback", "feat/add-rollback", []string{"api"}, env.repoMap, env.cfg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	conflictPath := filepath.Join(env.dir, "worker-conflict")
+	env.run(worker, "git", "worktree", "add", "-q", "-b", "feat/add-rollback", conflictPath)
+
+	err := env.svc.AddRepos("add-rollback", []string{"web", "worker"}, env.repoMap)
+	if err == nil || !strings.Contains(err.Error(), "worker") {
+		t.Fatalf("expected worker conflict, got %v", err)
+	}
+
+	ws, _ := env.svc.State.GetWorkspace("add-rollback")
+	if ws.FindRepo("web") != nil {
+		t.Fatal("rolled-back web repo should not be saved")
+	}
+	if _, err := os.Stat(filepath.Join(ws.Path, "web")); !os.IsNotExist(err) {
+		t.Error("rolled-back web worktree should be removed")
+	}
+	if gitops.BranchExists(env.repoMap["web"], "feat/add-rollback") {
+		t.Error("branch created for rolled-back web repo should be removed")
+	}
+}
+
+func TestAddReposRollbackPreservesPreexistingBranch(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	web := env.createRepo("web")
+	worker := env.createRepo("worker")
+	if err := env.svc.Create("add-preserve", "feat/add-preserve", []string{"api"}, env.repoMap, env.cfg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	env.run(web, "git", "branch", "feat/add-preserve")
+	conflictPath := filepath.Join(env.dir, "worker-preserve-conflict")
+	env.run(worker, "git", "worktree", "add", "-q", "-b", "feat/add-preserve", conflictPath)
+
+	err := env.svc.AddRepos("add-preserve", []string{"web", "worker"}, env.repoMap)
+	if err == nil {
+		t.Fatal("expected worker conflict")
+	}
+	if _, err := os.Stat(filepath.Join(env.wsDir, "add-preserve", "web")); !os.IsNotExist(err) {
+		t.Error("rolled-back web worktree should be removed")
+	}
+	if !gitops.BranchExists(web, "feat/add-preserve") {
+		t.Error("rollback should preserve a branch it did not create")
+	}
+}
+
+func TestAddReposCleansBranchWhenWorktreeAddFails(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	web := env.createRepo("web")
+	if err := env.svc.Create("add-provision-fail", "feat/add-provision-fail", []string{"api"}, env.repoMap, env.cfg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	blockedPath := filepath.Join(env.wsDir, "add-provision-fail", "web")
+	if err := os.MkdirAll(blockedPath, 0o755); err != nil {
+		t.Fatalf("create blocked path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blockedPath, "keep.txt"), []byte("occupied"), 0o644); err != nil {
+		t.Fatalf("write blocked path: %v", err)
+	}
+
+	if err := env.svc.AddRepos("add-provision-fail", []string{"web"}, env.repoMap); err == nil {
+		t.Fatal("expected worktree add failure")
+	}
+	if gitops.BranchExists(web, "feat/add-provision-fail") {
+		t.Error("branch created before failed worktree add should be cleaned up")
+	}
+	if _, err := os.Stat(filepath.Join(blockedPath, "keep.txt")); err != nil {
+		t.Fatal("pre-existing blocked path should remain untouched")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // RemoveRepos tests
 // ---------------------------------------------------------------------------
@@ -787,6 +1039,65 @@ func TestRemoveReposNonexistent(t *testing.T) {
 	err := env.svc.RemoveRepos("rm-ne", []string{"nonexistent"})
 	if err != nil {
 		t.Fatalf("remove nonexistent: %v", err)
+	}
+}
+
+func TestRemoveReposRejectsDirtyWorktreeByDefault(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	env.createRepo("web")
+	if err := env.svc.Create("dirty-remove", "feat/dirty-remove", []string{"api", "web"}, env.repoMap, env.cfg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	ws, _ := env.svc.State.GetWorkspace("dirty-remove")
+	web := ws.FindRepo("web")
+	if err := os.WriteFile(filepath.Join(web.WorktreePath, "dirty.txt"), []byte("keep me"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	err := env.svc.RemoveRepos("dirty-remove", []string{"web"})
+	if err == nil || !strings.Contains(err.Error(), "web") || !strings.Contains(err.Error(), "dirty") {
+		t.Fatalf("expected repo-named dirty error, got %v", err)
+	}
+	if saved, _ := env.svc.State.GetWorkspace("dirty-remove"); saved == nil || saved.FindRepo("web") == nil {
+		t.Fatal("dirty repo should remain in state")
+	}
+}
+
+func TestRemoveReposRetainsOnlyFailedEntries(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	env.createRepo("web")
+	env.createRepo("worker")
+	if err := env.svc.Create("partial-remove", "feat/partial-remove", []string{"api", "web", "worker"}, env.repoMap, env.cfg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	ws, _ := env.svc.State.GetWorkspace("partial-remove")
+	apiPath := ws.FindRepo("api").WorktreePath
+	webPath := ws.FindRepo("web").WorktreePath
+	env.svc.RemoveWorktree = func(repo, path string, force bool) error {
+		if path == webPath {
+			return fmt.Errorf("simulated git failure")
+		}
+		return gitops.WorktreeRemove(repo, path, force)
+	}
+
+	err := env.svc.RemoveRepos("partial-remove", []string{"api", "web"})
+	if err == nil || !strings.Contains(err.Error(), "web") {
+		t.Fatalf("expected web removal error, got %v", err)
+	}
+	if _, err := os.Stat(apiPath); !os.IsNotExist(err) {
+		t.Error("successfully removed api worktree should be gone")
+	}
+	if _, err := os.Stat(webPath); err != nil {
+		t.Fatalf("failed web worktree should remain: %v", err)
+	}
+
+	saved, _ := env.svc.State.GetWorkspace("partial-remove")
+	if saved == nil || saved.FindRepo("api") != nil || saved.FindRepo("web") == nil || saved.FindRepo("worker") == nil {
+		t.Fatalf("state should retain failed and untouched repos: %+v", saved)
 	}
 }
 
@@ -1691,29 +2002,45 @@ func TestLoggingRename(t *testing.T) {
 	}
 }
 
-func TestDeleteForceDeletesUnmergedBranch(t *testing.T) {
+func TestDeletePreservesUnmergedBranchWithoutForce(t *testing.T) {
 	readLog := setupLogging(t)
 	env := setupTestEnv(t)
 	env.createRepo("api")
 
 	env.svc.Create("unmerged-ws", "feat/unmerged", []string{"api"}, env.repoMap, env.cfg)
 
-	// Add an unmerged commit to the worktree branch
 	wt := filepath.Join(env.wsDir, "unmerged-ws", "api")
 	os.WriteFile(filepath.Join(wt, "new.txt"), []byte("unmerged work"), 0o644)
 	env.run(wt, "git", "add", ".")
 	env.run(wt, "git", "commit", "-q", "-m", "unmerged commit")
 
 	sourceRepo := env.repoMap["api"]
-	env.svc.Delete("unmerged-ws")
-
-	log := readLog()
-	if !strings.Contains(log, "deleted branch") {
-		t.Errorf("log should confirm branch deletion, got:\n%s", log)
+	if err := env.svc.Delete("unmerged-ws"); err != nil {
+		t.Fatalf("delete: %v", err)
 	}
 
-	// Verify the branch is actually gone from the source repo
-	if gitops.BranchExists(sourceRepo, "feat/unmerged") {
-		t.Error("branch feat/unmerged should have been force-deleted from source repo")
+	if !gitops.BranchExists(sourceRepo, "feat/unmerged") {
+		t.Error("safe delete should preserve an unmerged branch")
+	}
+	if log := readLog(); !strings.Contains(log, "failed to delete branch") {
+		t.Errorf("log should explain preserved branch, got:\n%s", log)
+	}
+}
+
+func TestDeleteForceDeletesUnmergedBranch(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+
+	env.svc.Create("force-unmerged-ws", "feat/force-unmerged", []string{"api"}, env.repoMap, env.cfg)
+	wt := filepath.Join(env.wsDir, "force-unmerged-ws", "api")
+	os.WriteFile(filepath.Join(wt, "new.txt"), []byte("unmerged work"), 0o644)
+	env.run(wt, "git", "add", ".")
+	env.run(wt, "git", "commit", "-q", "-m", "unmerged commit")
+
+	if err := env.svc.DeleteWithOptions("force-unmerged-ws", RemoveOptions{Force: true}); err != nil {
+		t.Fatalf("force delete: %v", err)
+	}
+	if gitops.BranchExists(env.repoMap["api"], "feat/force-unmerged") {
+		t.Error("force delete should remove an unmerged branch")
 	}
 }


### PR DESCRIPTION
## Summary

- serialize workspace mutations across processes with a stable advisory state lock
- preflight dirty and unexpected worktrees before delete/remove
- remove unsafe filesystem cleanup fallbacks and retain failed repo entries
- roll back only worktrees and branches created by the current create/add operation
- preserve user-owned workspace roots, MCP configuration, and pre-existing branches on failure
- centralize `PrefixWriter` construction in a separate preparatory commit

## Compatibility

Clean create/add/remove/delete workflows are unchanged. The intentional safety change is that dirty or unexpected worktrees now require `--force`; safe deletion also preserves unmerged branches unless forced. State and config formats are unchanged.

## Verification

- `go test -race ./internal/state ./internal/workspace`
- `just check`
- `just e2e` — 121 passed, 0 failed
- independent correctness and simplification reviews: pass

Closes #59
