### PR TITLE
feat: add strict Recipe v1 validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist/
 
 # Generated per-workspace by gw create
 .mcp.json
+
+# Local-only private validation fixtures
+.private/

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Full documentation lives in the [OpenWiki](openwiki/quickstart.md) — start wit
 
 - [Hooks](docs/hooks.md) — global hooks (terminal integration) & per-repo hooks (`.grove.toml`, `gw run`)
 - [Plugins](docs/plugins.md) — extend gw with external commands
+- [Recipe v1](docs/recipe-v1.md) — strict workspace Recipe schema and validation
 - [AI coding tools](docs/ai-tools.md) — Claude Code workflows, MCP server
 
 ## Requirements

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/nicksenap/grove/internal/recipe"
+	"github.com/spf13/cobra"
+)
+
+const offlineCommandAnnotation = "grove.offline"
+
+var errRecipeInvalid = errors.New("recipe is invalid")
+
+var recipeValidateJSON bool
+
+var recipeCmd = &cobra.Command{
+	Use:   "recipe",
+	Short: "Inspect and validate workspace Recipes",
+}
+
+var recipeValidateCmd = &cobra.Command{
+	Use:   "validate FILE",
+	Short: "Validate a Recipe without executing it",
+	Args:  cobra.ExactArgs(1),
+	Annotations: map[string]string{
+		offlineCommandAnnotation: "true",
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runRecipeValidate(args[0], recipeValidateJSON, cmd.OutOrStdout())
+	},
+}
+
+type recipeValidationOutput struct {
+	Valid        bool                     `json:"valid"`
+	Name         string                   `json:"name,omitempty"`
+	Version      *int                     `json:"version,omitempty"`
+	Repositories *int                     `json:"repositories,omitempty"`
+	Jobs         *int                     `json:"jobs,omitempty"`
+	Errors       []recipe.ValidationError `json:"errors"`
+}
+
+func runRecipeValidate(path string, jsonOutput bool, stdout io.Writer) error {
+	data, readErr := readRecipeFile(path)
+	if readErr != nil {
+		result := recipe.Result{Errors: []recipe.ValidationError{{
+			Code:    "read_file",
+			Path:    path,
+			Message: readErr.Error(),
+		}}}
+		return writeRecipeValidation(result, jsonOutput, stdout)
+	}
+	return writeRecipeValidation(recipe.Parse(data), jsonOutput, stdout)
+}
+
+func readRecipeFile(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("recipe path is not a regular file")
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	if openedInfo, err := file.Stat(); err != nil {
+		return nil, err
+	} else if !openedInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("recipe path is not a regular file")
+	}
+
+	data, err := io.ReadAll(io.LimitReader(file, recipe.MaxRecipeBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func writeRecipeValidation(result recipe.Result, jsonOutput bool, stdout io.Writer) error {
+	output := recipeValidationOutput{Valid: result.Recipe != nil && len(result.Errors) == 0, Errors: result.Errors}
+	if output.Valid {
+		output.Name = result.Recipe.Name
+		output.Version = intPointer(result.Recipe.Version)
+		output.Repositories = intPointer(len(result.Recipe.Repositories))
+		output.Jobs = intPointer(len(result.Recipe.Jobs))
+	}
+	if output.Errors == nil {
+		output.Errors = []recipe.ValidationError{}
+	}
+
+	if jsonOutput {
+		if err := json.NewEncoder(stdout).Encode(output); err != nil {
+			return err
+		}
+	} else if output.Valid {
+		name := ""
+		if output.Name != "" {
+			name = ": " + terminalSafe(output.Name)
+		}
+		repositories := *output.Repositories
+		jobs := *output.Jobs
+		fmt.Fprintf(stdout, "Recipe valid%s (%d %s, %d %s)\n",
+			name,
+			repositories, pluralize(repositories, "repository", "repositories"),
+			jobs, pluralize(jobs, "job", "jobs"))
+	}
+
+	if output.Valid {
+		return nil
+	}
+	if jsonOutput {
+		return errRecipeInvalid
+	}
+	return fmt.Errorf("%w:\n%s", errRecipeInvalid, formatRecipeErrors(output.Errors))
+}
+
+func formatRecipeErrors(validationErrors []recipe.ValidationError) string {
+	lines := make([]string, 0, len(validationErrors))
+	for _, validationErr := range validationErrors {
+		location := validationErr.Path
+		if location == "" {
+			location = "recipe"
+		}
+		if validationErr.Line > 0 {
+			location = fmt.Sprintf("%s:%d:%d", location, validationErr.Line, validationErr.Column)
+		}
+		lines = append(lines, fmt.Sprintf("  %s [%s] %s", terminalSafe(location), validationErr.Code, terminalSafe(validationErr.Message)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func terminalSafe(value string) string {
+	var result strings.Builder
+	for _, char := range value {
+		if char < 0x20 || char == 0x7f {
+			fmt.Fprintf(&result, "\\x%02x", char)
+			continue
+		}
+		result.WriteRune(char)
+	}
+	return result.String()
+}
+
+func intPointer(value int) *int {
+	return &value
+}
+
+func pluralize(count int, singular, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}
+
+func init() {
+	recipeValidateCmd.Flags().BoolVarP(&recipeValidateJSON, "json", "j", false, "Output validation result as JSON")
+	recipeCmd.AddCommand(recipeValidateCmd)
+}

--- a/cmd/recipe_test.go
+++ b/cmd/recipe_test.go
@@ -1,0 +1,181 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestRunRecipeValidateHuman(t *testing.T) {
+	path := writeRecipeFixture(t, validRecipeFixture)
+	var stdout bytes.Buffer
+
+	if err := runRecipeValidate(path, false, &stdout); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if got := stdout.String(); got != "Recipe valid: example-stack (1 repository, 1 job)\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestRunRecipeValidateRepositoryOnly(t *testing.T) {
+	path := writeRecipeFixture(t, `version: 1
+repositories:
+  app:
+    url: https://github.com/acme/example-app.git
+    ref: main
+`)
+	var stdout bytes.Buffer
+
+	if err := runRecipeValidate(path, false, &stdout); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if got := stdout.String(); got != "Recipe valid (1 repository, 0 jobs)\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestRunRecipeValidateJSON(t *testing.T) {
+	path := writeRecipeFixture(t, validRecipeFixture)
+	var stdout bytes.Buffer
+
+	if err := runRecipeValidate(path, true, &stdout); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	var output recipeValidationOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if !output.Valid || output.Name != "example-stack" || output.Repositories == nil || *output.Repositories != 1 || output.Jobs == nil || *output.Jobs != 1 || len(output.Errors) != 0 {
+		t.Fatalf("unexpected output: %+v", output)
+	}
+}
+
+func TestRunRecipeValidateRepositoryOnlyJSONIncludesZeroJobs(t *testing.T) {
+	path := writeRecipeFixture(t, `version: 1
+repositories:
+  app:
+    url: https://github.com/acme/example-app.git
+    ref: main
+`)
+	var stdout bytes.Buffer
+	if err := runRecipeValidate(path, true, &stdout); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	var output map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatal(err)
+	}
+	if jobs, ok := output["jobs"]; !ok || jobs != float64(0) {
+		t.Fatalf("expected jobs: 0, got %v", output)
+	}
+}
+
+func TestHumanOutputEscapesTerminalControls(t *testing.T) {
+	input := strings.Replace(validRecipeFixture, "needs: []", `needs: ["missing\u001b[31m"]`, 1)
+	var stdout bytes.Buffer
+	err := runRecipeValidate(writeRecipeFixture(t, input), false, &stdout)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if strings.ContainsRune(err.Error(), '\x1b') || !strings.Contains(err.Error(), `\x1b`) {
+		t.Fatalf("terminal control was not escaped: %q", err.Error())
+	}
+}
+
+func TestRunRecipeValidateInvalidHuman(t *testing.T) {
+	path := writeRecipeFixture(t, strings.Replace(validRecipeFixture, "needs: []", "needs: [missing]", 1))
+	var stdout bytes.Buffer
+
+	err := runRecipeValidate(path, false, &stdout)
+	if !errors.Is(err, errRecipeInvalid) {
+		t.Fatalf("error = %v, want errRecipeInvalid", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("unexpected stdout: %q", stdout.String())
+	}
+	message := err.Error()
+	if !strings.Contains(message, "jobs.setup.needs[0]") || !strings.Contains(message, "[unknown_job]") {
+		t.Fatalf("error is not actionable: %s", message)
+	}
+}
+
+func TestRunRecipeValidateInvalidJSON(t *testing.T) {
+	path := writeRecipeFixture(t, strings.Replace(validRecipeFixture, "needs: []", "needs: [missing]", 1))
+	var stdout bytes.Buffer
+
+	err := runRecipeValidate(path, true, &stdout)
+	if !errors.Is(err, errRecipeInvalid) {
+		t.Fatalf("error = %v, want errRecipeInvalid", err)
+	}
+	var output recipeValidationOutput
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &output); decodeErr != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", decodeErr, stdout.String())
+	}
+	if output.Valid || len(output.Errors) == 0 || output.Errors[0].Code != "unknown_job" {
+		t.Fatalf("unexpected output: %+v", output)
+	}
+}
+
+func TestRunRecipeValidateRejectsNonRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "recipe.yaml")
+	if err := unix.Mkfifo(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	err := runRecipeValidate(path, true, &stdout)
+	if !errors.Is(err, errRecipeInvalid) {
+		t.Fatalf("error = %v, want errRecipeInvalid", err)
+	}
+	var output recipeValidationOutput
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &output); decodeErr != nil {
+		t.Fatal(decodeErr)
+	}
+	if len(output.Errors) != 1 || output.Errors[0].Code != "read_file" {
+		t.Fatalf("unexpected output: %+v", output)
+	}
+}
+
+func TestRunRecipeValidateUnreadableJSON(t *testing.T) {
+	var stdout bytes.Buffer
+	err := runRecipeValidate(filepath.Join(t.TempDir(), "missing.yaml"), true, &stdout)
+	if !errors.Is(err, errRecipeInvalid) {
+		t.Fatalf("error = %v, want errRecipeInvalid", err)
+	}
+	var output recipeValidationOutput
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &output); decodeErr != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", decodeErr, stdout.String())
+	}
+	if output.Valid || len(output.Errors) != 1 || output.Errors[0].Code != "read_file" {
+		t.Fatalf("unexpected output: %+v", output)
+	}
+}
+
+func writeRecipeFixture(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "recipe.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+const validRecipeFixture = `version: 1
+name: example-stack
+repositories:
+  app:
+    url: https://github.com/acme/example-app.git
+    ref: main
+jobs:
+  setup:
+    repository: app
+    needs: []
+    steps:
+      - run: make setup
+`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,12 @@ var rootCmd = &cobra.Command{
 	Short: "Grove — Git Worktree Workspace Orchestrator",
 	Long:  "Manages multi-repo worktree-based workspaces",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if cmd.Annotations[offlineCommandAnnotation] == "true" {
+			return
+		}
+		if notice := update.NewChecker(config.GroveDir).FormatNotice(Version); notice != "" {
+			fmt.Fprintf(os.Stderr, "\033[2m%s\033[0m\n", notice)
+		}
 		logging.Setup(verbose)
 		logging.Info("gw %s", cmd.Name())
 	},
@@ -62,6 +68,7 @@ func init() {
 		statsCmd,
 		shellInitCmd,
 		presetCmd,
+		recipeCmd,
 		addDirCmd,
 		removeDirCmd,
 		runCmd,
@@ -74,11 +81,6 @@ func init() {
 }
 
 func Execute() {
-	// Non-blocking version check
-	if notice := update.NewChecker(config.GroveDir).FormatNotice(Version); notice != "" {
-		fmt.Fprintf(os.Stderr, "\033[2m%s\033[0m\n", notice)
-	}
-
 	if err := rootCmd.Execute(); err != nil {
 		// If cobra says "unknown command", try to find a matching plugin
 		if isUnknownCommandErr(err) {
@@ -107,7 +109,7 @@ func Execute() {
 
 // isUnknownCommandErr checks if the error is cobra's "unknown command" error.
 func isUnknownCommandErr(err error) bool {
-	return strings.Contains(err.Error(), "unknown command")
+	return strings.HasPrefix(err.Error(), "unknown command ")
 }
 
 // extractUnknownCommand pulls the command name from cobra's error message.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -14,7 +14,8 @@ func TestIsUnknownCommandErr(t *testing.T) {
 	}{
 		{"unknown command", errors.New(`unknown command "foo" for "gw"`), true},
 		{"unrelated error", errors.New("some other failure"), false},
-		{"contains word in context", errors.New("the unknown command handler fired"), true}, // substring match is deliberate
+		{"contains word in context", errors.New("the unknown command handler fired"), false},
+		{"validation message", errors.New("recipe is invalid: unknown command \"../../bin/sh\""), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/recipe-v1.md
+++ b/docs/recipe-v1.md
@@ -1,0 +1,127 @@
+# Recipe v1 specification
+
+## Objective
+
+Define a strict YAML description of repositories and local preparation jobs. This first slice only parses and validates Recipes; it does not execute them or change existing workspace creation.
+
+Recipe uses GitHub Actions-inspired vocabulary (`jobs`, `needs`, `steps`, `name`, and `run`) to reduce the learning curve. It is a Grove-specific schema and is not syntactically, semantically, or tooling-compatible with GitHub Actions.
+
+## Command
+
+```bash
+gw recipe validate <file>
+gw recipe validate <file> --json
+```
+
+Validation is offline: it does not load Grove config, contact the network, write logs, or mutate state.
+
+## Schema
+
+```yaml
+version: 1
+name: example-stack
+
+repositories:
+  api:
+    url: https://github.com/acme/example-api.git
+    ref: main
+  web:
+    url: https://github.com/acme/example-web.git
+    ref: main
+
+jobs:
+  setup-api:
+    repository: api
+    steps:
+      - name: Install API dependencies
+        run: make setup
+      - name: Build API
+        run: make build
+
+  setup-web:
+    repository: web
+    steps:
+      - name: Install web dependencies
+        run: make setup
+
+  verify:
+    repository: api
+    needs: [setup-api, setup-web]
+    steps:
+      - run: make check
+```
+
+See [`examples/recipes/example-stack.yaml`](../examples/recipes/example-stack.yaml) for the complete generic example.
+
+### Fields
+
+- `version` — required integer; v1 accepts only `1`.
+- `name` — optional non-empty display name, maximum 128 characters when present.
+- `repositories` — required non-empty map of repository IDs to:
+  - `url` — required Git URL using HTTP(S), SSH, `git://`, `file://`, or SCP syntax.
+  - `ref` — required branch, tag, or commit name.
+- `jobs` — optional map of job IDs; an omitted or empty map creates a repository-only Recipe. Each job contains:
+  - `repository` — required repository ID.
+  - `working-directory` — optional relative path inside the repository; defaults to its root.
+  - `needs` — optional list of job IDs that must complete first.
+  - `steps` — required non-empty ordered list of steps.
+- Step fields:
+  - `name` — optional display name.
+  - `run` — required non-empty shell command.
+
+Repository and job IDs must match `^[a-z][a-z0-9_-]{0,63}$`. Job map order has no execution meaning. `needs` defines ordering between jobs, while steps within one job are ordered sequentially.
+
+`run` is a literal shell script. Recipe does not interpret GitHub Actions expressions such as `${{ ... }}` and does not support `on`, `runs-on`, `uses`, contexts, outputs, or marketplace actions. Validation never executes commands; future execution must treat Recipes as trusted code with normal host access.
+
+## Strictness and limits
+
+- Read only regular local files and accept one YAML document using YAML 1.2-compatible scalar behavior.
+- Reject unknown fields, duplicate mapping keys, aliases, anchors, custom tags, additional documents, explicit nulls, and values with the wrong YAML type.
+- Reject missing job/repository references, self-dependencies, duplicate `needs`, and DAG cycles.
+- `working-directory` must be relative, clean, and may not escape with `..`.
+- Maximum file size: 1 MiB.
+- Maximum YAML nesting depth: 32; maximum parsed nodes: 100,000.
+- Maximum repositories: 64.
+- Maximum jobs: 256.
+- Maximum steps per job: 64.
+- Maximum dependencies per job: 64.
+
+## Output contract
+
+Human success:
+
+```text
+Recipe valid: example-stack (2 repositories, 3 jobs)
+```
+
+JSON success:
+
+```json
+{"valid":true,"name":"example-stack","version":1,"repositories":2,"jobs":3,"errors":[]}
+```
+
+JSON failure exits non-zero and writes only JSON to stdout:
+
+```json
+{"valid":false,"errors":[{"code":"unknown_job","path":"jobs.verify.needs[0]","line":28,"column":13,"message":"unknown job: build"}]}
+```
+
+Validation errors use stable `code`, `path`, `line`, `column`, and `message` fields. Unreadable files and malformed YAML use the same envelope.
+
+## Compatibility
+
+- Existing `gw create`, `-r/--repos`, `-p/--preset`, interactive presets, and `.grove.toml` remain unchanged.
+- Presets and Recipes coexist in v1; there is no migration or deprecation.
+- Familiar field names do not make Recipe files executable by GitHub Actions or vice versa.
+- Future Recipe versions require an explicit parser branch. Unknown versions fail closed.
+
+## Testing
+
+- Table-driven parser and semantic validation tests.
+- CLI tests for human output, JSON-only stdout, and exit behavior.
+- A committed generic public example validated by the test suite.
+- `just check` and `just e2e` remain green.
+
+## Non-goals
+
+Execution, `gw create --recipe`, Oven, TOML, includes, templates, expressions, triggers, runners, actions, variables, environment maps, cache declarations, conditions, matrices, retries, services, containers, remote files, or credential-provider machinery.

--- a/examples/recipes/example-stack.yaml
+++ b/examples/recipes/example-stack.yaml
@@ -1,0 +1,30 @@
+version: 1
+name: example-stack
+
+repositories:
+  api:
+    url: https://github.com/acme/example-api.git
+    ref: main
+  web:
+    url: https://github.com/acme/example-web.git
+    ref: main
+
+jobs:
+  setup-api:
+    repository: api
+    steps:
+      - name: Install API dependencies
+        run: make setup
+
+  setup-web:
+    repository: web
+    steps:
+      - name: Install web dependencies
+        run: make setup
+
+  verify-api:
+    repository: api
+    needs: [setup-api, setup-web]
+    steps:
+      - name: Verify API
+        run: make check

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/spf13/cobra v1.10.2
+	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	modernc.org/sqlite v1.56.0

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -138,12 +138,12 @@ func TestWorkspaceSourceRoundtrip(t *testing.T) {
 	ws := Workspace{
 		Name:   "pr-feature",
 		Path:   "/ws/pr-feature",
-		Branch: "feat/data-status",
+		Branch: "feat/example",
 		Source: &WorkspaceSource{
 			Provider: "github",
-			URL:      "https://github.com/funnel-io/conversational-analytics/pull/1172",
+			URL:      "https://github.com/acme/example-app/pull/1172",
 			Ref:      "1172",
-			Title:    "Surface data source status",
+			Title:    "Example pull request",
 		},
 	}
 

--- a/internal/plugin/install.go
+++ b/internal/plugin/install.go
@@ -39,6 +39,9 @@ func Install(repo string) error {
 
 	// Plugin name is the repo name (e.g. "gw-dash" → command name "dash")
 	pluginCmd := strings.TrimPrefix(name, "gw-")
+	if err := validatePluginName(pluginCmd); err != nil {
+		return err
+	}
 
 	// Fetch latest release
 	release, err := fetchRelease(owner, name)
@@ -114,6 +117,9 @@ func loadMeta(pluginCmd string) (*pluginMeta, error) {
 
 // Upgrade re-fetches the latest release for an installed plugin.
 func Upgrade(name string) error {
+	if err := validatePluginName(name); err != nil {
+		return err
+	}
 	meta, err := loadMeta(name)
 	if err != nil {
 		return fmt.Errorf("plugin %q has no install metadata — reinstall with: gw plugin install <repo>", name)

--- a/internal/plugin/install_test.go
+++ b/internal/plugin/install_test.go
@@ -11,8 +11,23 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestInstallRejectsUnsafePluginName(t *testing.T) {
+	err := Install("owner/gw-../../bin/sh")
+	if err == nil || !strings.Contains(err.Error(), "invalid plugin name") {
+		t.Fatalf("error = %v, want invalid plugin name", err)
+	}
+}
+
+func TestUpgradeRejectsUnsafePluginName(t *testing.T) {
+	err := Upgrade("../../bin/sh")
+	if err == nil || !strings.Contains(err.Error(), "invalid plugin name") {
+		t.Fatalf("error = %v, want invalid plugin name", err)
+	}
+}
 
 func TestParseRepo(t *testing.T) {
 	tests := []struct {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -25,6 +25,9 @@ func Dir() string {
 // Find locates a plugin binary by name. Checks ~/.grove/plugins/ first, then $PATH.
 // Returns the absolute path to the binary, or error if not found.
 func Find(name string) (string, error) {
+	if err := validatePluginName(name); err != nil {
+		return "", err
+	}
 	bin := "gw-" + name
 
 	// Check plugins dir first
@@ -139,6 +142,9 @@ func List() ([]InstalledPlugin, error) {
 
 // Remove deletes a plugin and its metadata from the plugins directory.
 func Remove(name string) error {
+	if err := validatePluginName(name); err != nil {
+		return err
+	}
 	bin := "gw-" + name
 	pluginPath := filepath.Join(Dir(), bin)
 
@@ -153,6 +159,24 @@ func Remove(name string) error {
 	os.Remove(metaPath(name))
 
 	return os.Remove(pluginPath)
+}
+
+func validatePluginName(name string) error {
+	if len(name) == 0 || len(name) > 64 || !isPluginNameAlphanumeric(name[0]) {
+		return fmt.Errorf("invalid plugin name %q", name)
+	}
+	for i := 1; i < len(name); i++ {
+		char := name[i]
+		if isPluginNameAlphanumeric(char) || char == '-' || char == '_' || char == '.' {
+			continue
+		}
+		return fmt.Errorf("invalid plugin name %q", name)
+	}
+	return nil
+}
+
+func isPluginNameAlphanumeric(char byte) bool {
+	return char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' || char >= '0' && char <= '9'
 }
 
 // InstalledPlugin describes a plugin found in the plugins directory.

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/nicksenap/grove/internal/config"
@@ -54,6 +55,17 @@ func TestFindNotFound(t *testing.T) {
 	_, err := Find("nonexistent")
 	if err == nil {
 		t.Fatal("expected error for missing plugin")
+	}
+}
+
+func TestFindRejectsUnsafeNames(t *testing.T) {
+	setupPluginDir(t)
+	for _, name := range []string{"", "../bin/sh", "foo/bar", `foo\\bar`, ".hidden"} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Find(name); err == nil || !strings.Contains(err.Error(), "invalid plugin name") {
+				t.Fatalf("Find(%q) error = %v, want invalid plugin name", name, err)
+			}
+		})
 	}
 }
 
@@ -129,6 +141,13 @@ func TestRemoveNotInstalled(t *testing.T) {
 	err := Remove("nothere")
 	if err == nil {
 		t.Fatal("expected error removing non-existent plugin")
+	}
+}
+
+func TestRemoveRejectsUnsafeName(t *testing.T) {
+	setupPluginDir(t)
+	if err := Remove("../../target"); err == nil || !strings.Contains(err.Error(), "invalid plugin name") {
+		t.Fatalf("error = %v, want invalid plugin name", err)
 	}
 }
 

--- a/internal/recipe/model.go
+++ b/internal/recipe/model.go
@@ -1,0 +1,56 @@
+// Package recipe parses and validates versioned Grove Recipe files.
+package recipe
+
+const (
+	MaxRecipeBytes        = 1 << 20
+	maxYAMLDepth          = 32
+	maxYAMLNodes          = 100_000
+	maxNameLength         = 128
+	maxRepositories       = 64
+	maxJobs               = 256
+	maxStepsPerJob        = 64
+	maxDependenciesPerJob = 64
+)
+
+// Recipe is the versioned description of a prepared workspace.
+type Recipe struct {
+	Version      int                   `yaml:"version" json:"version"`
+	Name         string                `yaml:"name" json:"name"`
+	Repositories map[string]Repository `yaml:"repositories" json:"repositories"`
+	Jobs         map[string]Job        `yaml:"jobs" json:"jobs"`
+}
+
+// Repository identifies one Git repository and the base ref to prepare.
+type Repository struct {
+	URL string `yaml:"url" json:"url"`
+	Ref string `yaml:"ref" json:"ref"`
+}
+
+// Job is one node in the preparation DAG. Steps run sequentially within a job.
+type Job struct {
+	Repository       string   `yaml:"repository" json:"repository"`
+	WorkingDirectory string   `yaml:"working-directory,omitempty" json:"working_directory,omitempty"`
+	Needs            []string `yaml:"needs,omitempty" json:"needs,omitempty"`
+	Steps            []Step   `yaml:"steps" json:"steps"`
+}
+
+// Step is one shell command in a job.
+type Step struct {
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+	Run  string `yaml:"run" json:"run"`
+}
+
+// ValidationError is a stable, machine-readable Recipe diagnostic.
+type ValidationError struct {
+	Code    string `json:"code"`
+	Path    string `json:"path"`
+	Line    int    `json:"line"`
+	Column  int    `json:"column"`
+	Message string `json:"message"`
+}
+
+// Result contains either a valid Recipe or validation errors.
+type Result struct {
+	Recipe *Recipe           `json:"-"`
+	Errors []ValidationError `json:"errors"`
+}

--- a/internal/recipe/parse.go
+++ b/internal/recipe/parse.go
@@ -1,0 +1,368 @@
+package recipe
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+func Parse(data []byte) Result {
+	if len(data) > MaxRecipeBytes {
+		return failure("file_too_large", "", 0, 0, fmt.Sprintf("Recipe exceeds %d bytes", MaxRecipeBytes))
+	}
+
+	doc, result := parseDocument(data)
+	if len(result.Errors) > 0 {
+		return result
+	}
+
+	if err := validateYAMLComplexity(doc, 0, new(int)); err != nil {
+		return Result{Errors: []ValidationError{*err}}
+	}
+
+	root := documentRoot(doc)
+	locations := make(map[string]location)
+	collectLocations(root, "", locations)
+
+	if err := rejectUnsupportedYAML(root, ""); err != nil {
+		return Result{Errors: []ValidationError{*err}}
+	}
+	if errors := validateDuplicateKeys(root, ""); len(errors) > 0 {
+		return Result{Errors: errors}
+	}
+	if errors := validateKnownFields(root, locations); len(errors) > 0 {
+		return Result{Errors: errors}
+	}
+	if errors := validateSchemaTypes(root); len(errors) > 0 {
+		return Result{Errors: errors}
+	}
+
+	var parsed Recipe
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&parsed); err != nil {
+		code := "invalid_yaml"
+		if isDuplicateKeyError(err) {
+			code = "duplicate_key"
+		}
+		line, column := yamlErrorLocation(err)
+		return failure(code, pathAtLine(locations, line), line, column, err.Error())
+	}
+
+	errors := validateRecipe(&parsed, locations)
+	if len(errors) > 0 {
+		return Result{Errors: errors}
+	}
+	return Result{Recipe: &parsed, Errors: []ValidationError{}}
+}
+
+func parseDocument(data []byte) (*yaml.Node, Result) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	var doc yaml.Node
+	if err := decoder.Decode(&doc); err != nil {
+		if err == io.EOF {
+			return nil, failure("invalid_yaml", "", 0, 0, "Recipe is empty")
+		}
+		code := "invalid_yaml"
+		if isDuplicateKeyError(err) {
+			code = "duplicate_key"
+		}
+		line, column := yamlErrorLocation(err)
+		return nil, failure(code, "", line, column, err.Error())
+	}
+
+	var extra yaml.Node
+	if err := decoder.Decode(&extra); err == nil {
+		return nil, failure("multiple_documents", "", extra.Line, extra.Column, "Recipe must contain exactly one YAML document")
+	} else if err != io.EOF {
+		line, column := yamlErrorLocation(err)
+		return nil, failure("invalid_yaml", "", line, column, err.Error())
+	}
+	return &doc, Result{}
+}
+
+func isDuplicateKeyError(err error) bool {
+	message := err.Error()
+	return strings.Contains(message, "mapping key") && strings.Contains(message, "already defined")
+}
+
+func yamlErrorLocation(err error) (int, int) {
+	message := err.Error()
+	marker := "line "
+	index := strings.Index(message, marker)
+	if index < 0 {
+		return 0, 0
+	}
+	start := index + len(marker)
+	end := start
+	for end < len(message) && message[end] >= '0' && message[end] <= '9' {
+		end++
+	}
+	line, parseErr := strconv.Atoi(message[start:end])
+	if parseErr != nil {
+		return 0, 0
+	}
+	return line, 1
+}
+
+func validateYAMLComplexity(node *yaml.Node, depth int, count *int) *ValidationError {
+	if node == nil {
+		return nil
+	}
+	*count++
+	if depth > maxYAMLDepth || *count > maxYAMLNodes {
+		return &ValidationError{Code: "yaml_too_complex", Line: node.Line, Column: node.Column, Message: "YAML structure exceeds Recipe complexity limits"}
+	}
+	for _, child := range node.Content {
+		if err := validateYAMLComplexity(child, depth+1, count); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectUnsupportedYAML(node *yaml.Node, nodePath string) *ValidationError {
+	if node == nil {
+		return nil
+	}
+	if node.Anchor != "" || node.Kind == yaml.AliasNode {
+		return &ValidationError{Code: "unsupported_yaml", Path: nodePath, Line: node.Line, Column: node.Column, Message: "YAML anchors and aliases are not supported"}
+	}
+	if !allowedYAMLTag(node.Tag) {
+		return &ValidationError{Code: "unsupported_yaml", Path: nodePath, Line: node.Line, Column: node.Column, Message: "custom YAML tags are not supported"}
+	}
+	switch node.Kind {
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key, value := node.Content[i], node.Content[i+1]
+			childPath := joinPath(nodePath, key.Value)
+			if err := rejectUnsupportedYAML(key, childPath); err != nil {
+				return err
+			}
+			if err := rejectUnsupportedYAML(value, childPath); err != nil {
+				return err
+			}
+		}
+	case yaml.SequenceNode:
+		for index, child := range node.Content {
+			if err := rejectUnsupportedYAML(child, fmt.Sprintf("%s[%d]", nodePath, index)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func allowedYAMLTag(tag string) bool {
+	switch tag {
+	case "", "!!map", "!!seq", "!!str", "!!int", "!!bool", "!!null", "!!float":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateDuplicateKeys(node *yaml.Node, nodePath string) []ValidationError {
+	if node == nil {
+		return nil
+	}
+	var errors []ValidationError
+	if node.Kind == yaml.MappingNode {
+		seen := make(map[string]struct{}, len(node.Content)/2)
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key, value := node.Content[i], node.Content[i+1]
+			childPath := joinPath(nodePath, key.Value)
+			if key.Kind == yaml.ScalarNode {
+				if _, duplicate := seen[key.Value]; duplicate {
+					errors = append(errors, ValidationError{Code: "duplicate_key", Path: childPath, Line: key.Line, Column: key.Column, Message: "duplicate mapping key: " + key.Value})
+				}
+				seen[key.Value] = struct{}{}
+			}
+			errors = append(errors, validateDuplicateKeys(value, childPath)...)
+		}
+	} else if node.Kind == yaml.SequenceNode {
+		for index, child := range node.Content {
+			errors = append(errors, validateDuplicateKeys(child, fmt.Sprintf("%s[%d]", nodePath, index))...)
+		}
+	}
+	return errors
+}
+
+func validateSchemaTypes(root *yaml.Node) []ValidationError {
+	var errors []ValidationError
+	if !requireNodeType(root, "", yaml.MappingNode, "mapping", &errors) {
+		return errors
+	}
+
+	validateScalarField(root, "version", "", "!!int", "integer", &errors)
+	validateScalarField(root, "name", "", "!!str", "string", &errors)
+
+	repositories := mappingValue(root, "repositories")
+	if repositories != nil && requireNodeType(repositories, "repositories", yaml.MappingNode, "mapping", &errors) {
+		for i := 0; i+1 < len(repositories.Content); i += 2 {
+			id, repository := repositories.Content[i], repositories.Content[i+1]
+			basePath := "repositories." + id.Value
+			requireStringKey(id, basePath, &errors)
+			if requireNodeType(repository, basePath, yaml.MappingNode, "mapping", &errors) {
+				validateScalarField(repository, "url", basePath, "!!str", "string", &errors)
+				validateScalarField(repository, "ref", basePath, "!!str", "string", &errors)
+			}
+		}
+	}
+
+	jobs := mappingValue(root, "jobs")
+	if jobs != nil && requireNodeType(jobs, "jobs", yaml.MappingNode, "mapping", &errors) {
+		for i := 0; i+1 < len(jobs.Content); i += 2 {
+			id, job := jobs.Content[i], jobs.Content[i+1]
+			basePath := "jobs." + id.Value
+			requireStringKey(id, basePath, &errors)
+			validateJobTypes(job, basePath, &errors)
+		}
+	}
+	return errors
+}
+
+func validateJobTypes(job *yaml.Node, basePath string, errors *[]ValidationError) {
+	if !requireNodeType(job, basePath, yaml.MappingNode, "mapping", errors) {
+		return
+	}
+	validateScalarField(job, "repository", basePath, "!!str", "string", errors)
+	validateScalarField(job, "working-directory", basePath, "!!str", "string", errors)
+
+	needs := mappingValue(job, "needs")
+	if needs != nil && requireNodeType(needs, basePath+".needs", yaml.SequenceNode, "sequence", errors) {
+		for index, dependency := range needs.Content {
+			requireScalarTag(dependency, fmt.Sprintf("%s.needs[%d]", basePath, index), "!!str", "string", errors)
+		}
+	}
+	steps := mappingValue(job, "steps")
+	if steps != nil && requireNodeType(steps, basePath+".steps", yaml.SequenceNode, "sequence", errors) {
+		for index, step := range steps.Content {
+			stepPath := fmt.Sprintf("%s.steps[%d]", basePath, index)
+			if requireNodeType(step, stepPath, yaml.MappingNode, "mapping", errors) {
+				validateScalarField(step, "name", stepPath, "!!str", "string", errors)
+				validateScalarField(step, "run", stepPath, "!!str", "string", errors)
+			}
+		}
+	}
+}
+
+func validateScalarField(mapping *yaml.Node, field, parentPath, tag, description string, errors *[]ValidationError) {
+	if node := mappingValue(mapping, field); node != nil {
+		requireScalarTag(node, joinPath(parentPath, field), tag, description, errors)
+	}
+}
+
+func requireStringKey(node *yaml.Node, valuePath string, errors *[]ValidationError) {
+	requireScalarTag(node, valuePath, "!!str", "string key", errors)
+}
+
+func requireScalarTag(node *yaml.Node, valuePath, tag, description string, errors *[]ValidationError) bool {
+	if !requireNodeType(node, valuePath, yaml.ScalarNode, description, errors) {
+		return false
+	}
+	if node.Tag != tag {
+		*errors = append(*errors, typeError(node, valuePath, description))
+		return false
+	}
+	return true
+}
+
+func requireNodeType(node *yaml.Node, valuePath string, kind yaml.Kind, description string, errors *[]ValidationError) bool {
+	if node != nil && node.Kind == kind && node.Tag != "!!null" {
+		return true
+	}
+	*errors = append(*errors, typeError(node, valuePath, description))
+	return false
+}
+
+func typeError(node *yaml.Node, valuePath, expected string) ValidationError {
+	err := ValidationError{Code: "invalid_type", Path: valuePath, Message: "expected " + expected}
+	if node != nil {
+		err.Line = node.Line
+		err.Column = node.Column
+	}
+	return err
+}
+
+func validateKnownFields(root *yaml.Node, locations map[string]location) []ValidationError {
+	var errors []ValidationError
+	checkAllowedFields(root, "", set("version", "name", "repositories", "jobs"), &errors)
+
+	if repositories := mappingValue(root, "repositories"); repositories != nil && repositories.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(repositories.Content); i += 2 {
+			id := repositories.Content[i].Value
+			checkAllowedFields(repositories.Content[i+1], "repositories."+id, set("url", "ref"), &errors)
+		}
+	}
+	if jobs := mappingValue(root, "jobs"); jobs != nil && jobs.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(jobs.Content); i += 2 {
+			id := jobs.Content[i].Value
+			jobPath := "jobs." + id
+			jobNode := jobs.Content[i+1]
+			checkAllowedFields(jobNode, jobPath, set("repository", "working-directory", "needs", "steps"), &errors)
+			if steps := mappingValue(jobNode, "steps"); steps != nil && steps.Kind == yaml.SequenceNode {
+				for index, step := range steps.Content {
+					checkAllowedFields(step, fmt.Sprintf("%s.steps[%d]", jobPath, index), set("name", "run"), &errors)
+				}
+			}
+		}
+	}
+	return errors
+}
+
+func checkAllowedFields(node *yaml.Node, nodePath string, allowed map[string]struct{}, errors *[]ValidationError) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		if _, ok := allowed[key.Value]; ok {
+			continue
+		}
+		fieldPath := joinPath(nodePath, key.Value)
+		*errors = append(*errors, ValidationError{Code: "unknown_field", Path: fieldPath, Line: key.Line, Column: key.Column, Message: "unknown field: " + key.Value})
+	}
+}
+
+func documentRoot(doc *yaml.Node) *yaml.Node {
+	if doc != nil && doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		return doc.Content[0]
+	}
+	return doc
+}
+
+func mappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func set(values ...string) map[string]struct{} {
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+func joinPath(parent, child string) string {
+	if parent == "" {
+		return child
+	}
+	return parent + "." + child
+}
+
+func failure(code, valuePath string, line, column int, message string) Result {
+	return Result{Errors: []ValidationError{{Code: code, Path: valuePath, Line: line, Column: column, Message: message}}}
+}

--- a/internal/recipe/recipe_test.go
+++ b/internal/recipe/recipe_test.go
@@ -1,0 +1,205 @@
+package recipe
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+const validRecipe = `version: 1
+name: example-stack
+repositories:
+  app:
+    url: https://github.com/acme/example-app.git
+    ref: main
+jobs:
+  setup-api:
+    repository: app
+    working-directory: services/api
+    steps:
+      - name: Install
+        run: make setup
+  verify:
+    repository: app
+    needs: [setup-api]
+    steps:
+      - run: make check
+`
+
+func TestParseValidRecipe(t *testing.T) {
+	result := Parse([]byte(validRecipe))
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected errors: %+v", result.Errors)
+	}
+	if result.Recipe == nil {
+		t.Fatal("expected recipe")
+	}
+	if result.Recipe.Version != 1 || result.Recipe.Name != "example-stack" {
+		t.Fatalf("unexpected recipe: %+v", result.Recipe)
+	}
+	if len(result.Recipe.Repositories) != 1 || len(result.Recipe.Jobs) != 2 {
+		t.Fatalf("unexpected counts: repos=%d jobs=%d", len(result.Recipe.Repositories), len(result.Recipe.Jobs))
+	}
+	if got := result.Recipe.Jobs["verify"].Needs; len(got) != 1 || got[0] != "setup-api" {
+		t.Fatalf("unexpected needs: %v", got)
+	}
+}
+
+func TestGenericExample(t *testing.T) {
+	data, err := os.ReadFile("../../examples/recipes/example-stack.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := Parse(data)
+	if len(result.Errors) != 0 {
+		t.Fatalf("example is invalid: %+v", result.Errors)
+	}
+}
+
+func TestParseRepositoryOnlyRecipe(t *testing.T) {
+	result := Parse([]byte(`version: 1
+repositories:
+  app:
+    url: https://github.com/acme/example-app.git
+    ref: main
+`))
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected errors: %+v", result.Errors)
+	}
+	if result.Recipe == nil || result.Recipe.Name != "" || len(result.Recipe.Jobs) != 0 {
+		t.Fatalf("unexpected recipe: %+v", result.Recipe)
+	}
+}
+
+func TestParseRejectsMalformedAndNonStrictYAML(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		code string
+	}{
+		{"malformed", "version: [", "invalid_yaml"},
+		{"unknown field", validRecipe + "extra: true\n", "unknown_field"},
+		{"duplicate key", strings.Replace(validRecipe, "name: example-stack", "name: example-stack\nname: duplicate", 1), "duplicate_key"},
+		{"anchor", strings.Replace(validRecipe, "name: example-stack", "name: &recipe_name example-stack", 1), "unsupported_yaml"},
+		{"alias", strings.Replace(validRecipe, "name: example-stack", "name: &recipe_name example-stack\nother: *recipe_name", 1), "unsupported_yaml"},
+		{"custom tag", strings.Replace(validRecipe, "name: example-stack", "name: !custom example-stack", 1), "unsupported_yaml"},
+		{"expanded custom tag", strings.Replace(validRecipe, "name: example-stack", "name: !<tag:example.com,2024:display> example-stack", 1), "unsupported_yaml"},
+		{"multiple documents", validRecipe + "---\nversion: 1\n", "multiple_documents"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Parse([]byte(tt.yaml))
+			assertErrorCode(t, result, tt.code)
+		})
+	}
+}
+
+func TestParseRejectsIncorrectSchemaTypes(t *testing.T) {
+	tests := []string{
+		strings.Replace(validRecipe, "version: 1", "version: 1.0", 1),
+		strings.Replace(validRecipe, "name: example-stack", "name: true", 1),
+		strings.Replace(validRecipe, "url: https://github.com/acme/example-app.git", "url: true", 1),
+		strings.Replace(validRecipe, "ref: main", "ref: null", 1),
+		strings.Replace(validRecipe, "needs: [setup-api]", "needs: setup-api", 1),
+		strings.Replace(validRecipe, "run: make check", "run: 123", 1),
+		strings.SplitN(validRecipe, "jobs:", 2)[0] + "jobs: null\n",
+	}
+	for index, input := range tests {
+		t.Run(fmt.Sprintf("case-%d", index), func(t *testing.T) {
+			assertErrorCode(t, Parse([]byte(input)), "invalid_type")
+		})
+	}
+}
+
+func TestParseValidatesGitURLs(t *testing.T) {
+	validSSH := strings.Replace(validRecipe, "https://github.com/acme/example-app.git", "ssh://git@example.com/acme/example-app.git", 1)
+	if result := Parse([]byte(validSSH)); len(result.Errors) != 0 {
+		t.Fatalf("valid SSH URL rejected: %+v", result.Errors)
+	}
+	for _, invalidURL := range []string{"https://", "http:// bad", "ext::sh -c id"} {
+		t.Run(invalidURL, func(t *testing.T) {
+			input := strings.Replace(validRecipe, "https://github.com/acme/example-app.git", invalidURL, 1)
+			assertErrorCode(t, Parse([]byte(input)), "invalid_git_url")
+		})
+	}
+}
+
+func TestParseRejectsExcessiveYAMLDepth(t *testing.T) {
+	input := validRecipe + "extra: " + strings.Repeat("[", maxYAMLDepth+1) + "value" + strings.Repeat("]", maxYAMLDepth+1) + "\n"
+	assertErrorCode(t, Parse([]byte(input)), "yaml_too_complex")
+}
+
+func TestParseRejectsInvalidRecipeSemantics(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		code string
+	}{
+		{"missing version", strings.Replace(validRecipe, "version: 1\n", "", 1), "required"},
+		{"unsupported version", strings.Replace(validRecipe, "version: 1", "version: 2", 1), "unsupported_version"},
+		{"empty name", strings.Replace(validRecipe, "name: example-stack", "name: '  '", 1), "required"},
+		{"invalid repository id", strings.Replace(validRecipe, "  app:", "  APP:", 1), "invalid_id"},
+		{"invalid job id", strings.Replace(validRecipe, "  setup-api:", "  Setup.API:", 1), "invalid_id"},
+		{"invalid git url", strings.Replace(validRecipe, "https://github.com/acme/example-app.git", "not-a-url", 1), "invalid_git_url"},
+		{"unknown repository", strings.Replace(validRecipe, "repository: app", "repository: missing", 1), "unknown_repository"},
+		{"unknown dependency", strings.Replace(validRecipe, "needs: [setup-api]", "needs: [missing]", 1), "unknown_job"},
+		{"duplicate dependency", strings.Replace(validRecipe, "needs: [setup-api]", "needs: [setup-api, setup-api]", 1), "duplicate_dependency"},
+		{"escaping working directory", strings.Replace(validRecipe, "services/api", "../../outside", 1), "invalid_path"},
+		{"unclean working directory", strings.Replace(validRecipe, "services/api", "services/../api", 1), "invalid_path"},
+		{"empty steps", strings.Replace(validRecipe, "steps:\n      - name: Install\n        run: make setup", "steps: []", 1), "required"},
+		{"empty command", strings.Replace(validRecipe, "run: make check", "run: '  '", 1), "required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Parse([]byte(tt.yaml))
+			assertErrorCode(t, result, tt.code)
+		})
+	}
+}
+
+func TestParseLocatesMalformedYAML(t *testing.T) {
+	result := Parse([]byte("version: 1\nrepositories: ["))
+	err := findError(result, "invalid_yaml")
+	if err == nil {
+		t.Fatalf("expected invalid_yaml, got %+v", result.Errors)
+	}
+	if err.Line != 2 || err.Column == 0 {
+		t.Fatalf("expected line 2 location, got %+v", err)
+	}
+}
+
+func TestParseRejectsDependencyCycle(t *testing.T) {
+	yaml := strings.Replace(validRecipe, "repository: app\n    working-directory", "repository: app\n    needs: [verify]\n    working-directory", 1)
+	result := Parse([]byte(yaml))
+	err := findError(result, "dependency_cycle")
+	if err == nil {
+		t.Fatalf("expected dependency_cycle, got %+v", result.Errors)
+	}
+	if err.Line == 0 || err.Column == 0 || err.Path == "" {
+		t.Fatalf("expected located error, got %+v", err)
+	}
+}
+
+func TestParseRejectsOversizedRecipe(t *testing.T) {
+	result := Parse([]byte(strings.Repeat("x", MaxRecipeBytes+1)))
+	assertErrorCode(t, result, "file_too_large")
+}
+
+func assertErrorCode(t *testing.T, result Result, code string) {
+	t.Helper()
+	if err := findError(result, code); err == nil {
+		t.Fatalf("expected %q, got %+v", code, result.Errors)
+	}
+}
+
+func findError(result Result, code string) *ValidationError {
+	for i := range result.Errors {
+		if result.Errors[i].Code == code {
+			return &result.Errors[i]
+		}
+	}
+	return nil
+}

--- a/internal/recipe/validate.go
+++ b/internal/recipe/validate.go
@@ -1,0 +1,275 @@
+package recipe
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"go.yaml.in/yaml/v3"
+)
+
+func validateRecipe(recipe *Recipe, locations map[string]location) []ValidationError {
+	validator := validator{locations: locations}
+	validateMetadata(recipe, locations, &validator)
+	validateRepositories(recipe.Repositories, &validator)
+	validateJobs(recipe, &validator)
+	validateCycles(recipe.Jobs, &validator)
+	return validator.errors
+}
+
+func validateMetadata(recipe *Recipe, locations map[string]location, validator *validator) {
+	if _, present := locations["version"]; !present {
+		validator.add("required", "version", "version is required")
+	} else if recipe.Version != 1 {
+		validator.add("unsupported_version", "version", fmt.Sprintf("unsupported Recipe version: %d", recipe.Version))
+	}
+	if _, present := locations["name"]; present && strings.TrimSpace(recipe.Name) == "" {
+		validator.add("required", "name", "name must not be empty when provided")
+	} else if utf8.RuneCountInString(recipe.Name) > maxNameLength {
+		validator.add("too_long", "name", fmt.Sprintf("name exceeds %d characters", maxNameLength))
+	}
+	if len(recipe.Repositories) == 0 {
+		validator.add("required", "repositories", "at least one repository is required")
+	}
+	if len(recipe.Repositories) > maxRepositories {
+		validator.add("too_many_repositories", "repositories", fmt.Sprintf("at most %d repositories are allowed", maxRepositories))
+	}
+	if len(recipe.Jobs) > maxJobs {
+		validator.add("too_many_jobs", "jobs", fmt.Sprintf("at most %d jobs are allowed", maxJobs))
+	}
+}
+
+func validateRepositories(repositories map[string]Repository, validator *validator) {
+	for _, id := range sortedKeys(repositories) {
+		repository := repositories[id]
+		basePath := "repositories." + id
+		if !validID(id) {
+			validator.add("invalid_id", basePath, "repository ID must match ^[a-z][a-z0-9_-]{0,63}$")
+		}
+		if strings.TrimSpace(repository.URL) == "" {
+			validator.add("required", basePath+".url", "repository URL is required")
+		} else if !validGitURL(repository.URL) {
+			validator.add("invalid_git_url", basePath+".url", "repository URL must use HTTP(S), SSH, git, file://, or SCP syntax")
+		}
+		if strings.TrimSpace(repository.Ref) == "" {
+			validator.add("required", basePath+".ref", "repository ref is required")
+		}
+	}
+}
+
+func validateJobs(recipe *Recipe, validator *validator) {
+	for _, id := range sortedKeys(recipe.Jobs) {
+		validateJob(id, recipe.Jobs[id], recipe, validator)
+	}
+}
+
+func validateJob(id string, job Job, recipe *Recipe, validator *validator) {
+	basePath := "jobs." + id
+	if !validID(id) {
+		validator.add("invalid_id", basePath, "job ID must match ^[a-z][a-z0-9_-]{0,63}$")
+	}
+	if _, ok := recipe.Repositories[job.Repository]; !ok {
+		if strings.TrimSpace(job.Repository) == "" {
+			validator.add("required", basePath+".repository", "job repository is required")
+		} else {
+			validator.add("unknown_repository", basePath+".repository", "unknown repository: "+job.Repository)
+		}
+	}
+	if !validWorkingDirectory(job.WorkingDirectory) {
+		validator.add("invalid_path", basePath+".working-directory", "working-directory must be a relative path inside the repository")
+	}
+	validateSteps(job.Steps, basePath, validator)
+	validateDependencies(id, job.Needs, recipe.Jobs, basePath, validator)
+}
+
+func validateSteps(steps []Step, basePath string, validator *validator) {
+	if len(steps) == 0 {
+		validator.add("required", basePath+".steps", "at least one step is required")
+	}
+	if len(steps) > maxStepsPerJob {
+		validator.add("too_many_steps", basePath+".steps", fmt.Sprintf("at most %d steps are allowed", maxStepsPerJob))
+	}
+	for index, step := range steps {
+		if strings.TrimSpace(step.Run) == "" {
+			validator.add("required", fmt.Sprintf("%s.steps[%d].run", basePath, index), "step run command is required")
+		}
+	}
+}
+
+func validateDependencies(id string, dependencies []string, jobs map[string]Job, basePath string, validator *validator) {
+	if len(dependencies) > maxDependenciesPerJob {
+		validator.add("too_many_dependencies", basePath+".needs", fmt.Sprintf("at most %d dependencies are allowed", maxDependenciesPerJob))
+	}
+	seen := make(map[string]struct{}, len(dependencies))
+	for index, dependency := range dependencies {
+		dependencyPath := fmt.Sprintf("%s.needs[%d]", basePath, index)
+		if _, duplicate := seen[dependency]; duplicate {
+			validator.add("duplicate_dependency", dependencyPath, "duplicate dependency: "+dependency)
+		}
+		seen[dependency] = struct{}{}
+		if dependency == id {
+			validator.add("self_dependency", dependencyPath, "job cannot depend on itself")
+		} else if _, ok := jobs[dependency]; !ok {
+			validator.add("unknown_job", dependencyPath, "unknown job: "+dependency)
+		}
+	}
+}
+
+func validateCycles(jobs map[string]Job, validator *validator) {
+	const (
+		unvisited = iota
+		visiting
+		visited
+	)
+	state := make(map[string]int, len(jobs))
+	var visit func(string)
+	visit = func(id string) {
+		state[id] = visiting
+		for index, dependency := range jobs[id].Needs {
+			if dependency == id {
+				continue
+			}
+			if _, ok := jobs[dependency]; !ok {
+				continue
+			}
+			switch state[dependency] {
+			case unvisited:
+				visit(dependency)
+			case visiting:
+				validator.add("dependency_cycle", fmt.Sprintf("jobs.%s.needs[%d]", id, index), fmt.Sprintf("dependency cycle between %s and %s", id, dependency))
+			}
+		}
+		state[id] = visited
+	}
+	for _, id := range sortedKeys(jobs) {
+		if state[id] == unvisited {
+			visit(id)
+		}
+	}
+}
+
+func validGitURL(value string) bool {
+	if value == "" || strings.ContainsAny(value, " \t\r\n") {
+		return false
+	}
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return false
+	}
+	if parsed.Scheme != "" {
+		switch parsed.Scheme {
+		case "http", "https", "ssh", "git":
+			return parsed.Host != "" && strings.Trim(parsed.Path, "/") != ""
+		case "file":
+			return parsed.Path != ""
+		default:
+			return false
+		}
+	}
+
+	at := strings.IndexByte(value, '@')
+	colon := strings.IndexByte(value, ':')
+	return at > 0 && colon > at+1 && colon < len(value)-1
+}
+
+func validID(id string) bool {
+	if len(id) == 0 || len(id) > 64 || id[0] < 'a' || id[0] > 'z' {
+		return false
+	}
+	for _, char := range id[1:] {
+		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') || char == '_' || char == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validWorkingDirectory(value string) bool {
+	if value == "" || value == "." {
+		return true
+	}
+	normalized := strings.ReplaceAll(value, "\\", "/")
+	if strings.HasPrefix(normalized, "/") || len(normalized) >= 2 && normalized[1] == ':' {
+		return false
+	}
+	cleaned := path.Clean(normalized)
+	return cleaned == normalized && cleaned != ".." && !strings.HasPrefix(cleaned, "../")
+}
+
+type location struct{ line, column int }
+
+type validator struct {
+	locations map[string]location
+	errors    []ValidationError
+}
+
+func (v *validator) add(code, valuePath, message string) {
+	loc := nearestLocation(valuePath, v.locations)
+	v.errors = append(v.errors, ValidationError{Code: code, Path: valuePath, Line: loc.line, Column: loc.column, Message: message})
+}
+
+func pathAtLine(locations map[string]location, line int) string {
+	if line == 0 {
+		return ""
+	}
+	paths := make([]string, 0)
+	for valuePath, loc := range locations {
+		if loc.line == line {
+			paths = append(paths, valuePath)
+		}
+	}
+	if len(paths) == 0 {
+		return ""
+	}
+	sort.Strings(paths)
+	return paths[0]
+}
+
+func nearestLocation(valuePath string, locations map[string]location) location {
+	candidate := valuePath
+	for {
+		if loc, ok := locations[candidate]; ok {
+			return loc
+		}
+		if index := strings.LastIndexAny(candidate, ".["); index >= 0 {
+			candidate = candidate[:index]
+			continue
+		}
+		return location{}
+	}
+}
+
+func collectLocations(node *yaml.Node, nodePath string, locations map[string]location) {
+	if node == nil {
+		return
+	}
+	if nodePath != "" {
+		locations[nodePath] = location{line: node.Line, column: node.Column}
+	}
+	switch node.Kind {
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key, value := node.Content[i], node.Content[i+1]
+			childPath := joinPath(nodePath, key.Value)
+			locations[childPath] = location{line: key.Line, column: key.Column}
+			collectLocations(value, childPath, locations)
+		}
+	case yaml.SequenceNode:
+		for index, child := range node.Content {
+			collectLocations(child, fmt.Sprintf("%s[%d]", nodePath, index), locations)
+		}
+	}
+}
+
+func sortedKeys[T any](values map[string]T) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -405,9 +405,9 @@ func TestCreateWithOptsPersistsSource(t *testing.T) {
 
 	src := &models.WorkspaceSource{
 		Provider: "github",
-		URL:      "https://github.com/funnel-io/conversational-analytics/pull/1172",
+		URL:      "https://github.com/acme/example-app/pull/1172",
 		Ref:      "1172",
-		Title:    "Surface data source status",
+		Title:    "Example pull request",
 	}
 	err := env.svc.CreateWithOpts("src-ws", CreateOpts{
 		Branch:  "feat/src",


### PR DESCRIPTION
## Summary

- define a strict, versioned YAML Recipe model using familiar `jobs` / `needs` / `steps` / `run` vocabulary
- add offline, side-effect-free `gw recipe validate <file> [--json]` with stable path-aware diagnostics
- reject unknown fields, duplicate keys, wrong YAML types, custom tags, unsafe Git URLs, invalid references, and DAG cycles
- document Recipe v1 and include a generic multi-repository example
- harden plugin fallback against unsafe command names discovered during validation review
- replace tracked private-repository examples with generic values and keep local private fixtures under ignored `.private/`

Recipe validation does not execute commands or change existing create/preset behavior.

## Verification

- `PATH="$(go env GOPATH)/bin:$PATH" just check`
- `go test -race ./internal/recipe ./cmd ./internal/plugin`
- `just e2e` — 121/121 passed
- public and ignored private Recipe fixtures validated with an empty temporary `HOME`; no files or logs were created
- independent code review: PASS

Closes #75
