### PR TITLE
feat: create workspaces from Recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Full documentation lives in the [OpenWiki](openwiki/quickstart.md) — start wit
 
 - [Hooks](docs/hooks.md) — global hooks (terminal integration) & per-repo hooks (`.grove.toml`, `gw run`)
 - [Plugins](docs/plugins.md) — extend gw with external commands
-- [Recipe v1](docs/recipe-v1.md) — strict workspace Recipe schema and validation
+- [Recipes](docs/recipe-v1.md) — strict schema, validation, and [workspace creation](docs/recipe-execution.md)
 - [AI coding tools](docs/ai-tools.md) — Claude Code workflows, MCP server
 
 ## Requirements

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -26,6 +26,8 @@ var (
 	createReplace       bool
 	createForce         bool
 	createTrack         bool
+	createRecipe        string
+	createJSON          bool
 	createSourceURL     string
 	createSourceProvide string
 	createSourceRef     string
@@ -37,6 +39,16 @@ var createCmd = &cobra.Command{
 	Short: "Create a new workspace",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		if createRecipe != "" {
+			if err := runRecipeCreate(cmd, args); err != nil {
+				exitError(terminalSafe(err.Error()))
+			}
+			return
+		}
+		if createJSON {
+			exitError("--json requires --recipe")
+		}
+
 		cfg := config.RequireConfig()
 		repos := discover.FindAllRepos(cfg.RepoDirs)
 		repoMap := discover.RepoMap(repos)
@@ -259,6 +271,8 @@ func init() {
 	createCmd.Flags().BoolVar(&createReplace, "replace", false, "Delete the current workspace (detected from cwd) before creating the new one")
 	createCmd.Flags().BoolVarP(&createForce, "force", "f", false, "Skip --replace confirmation prompt")
 	createCmd.Flags().BoolVar(&createTrack, "track", false, "Check out an existing remote branch (e.g. a PR head) instead of creating a new one")
+	createCmd.Flags().StringVar(&createRecipe, "recipe", "", "Create from a Recipe YAML file")
+	createCmd.Flags().BoolVarP(&createJSON, "json", "j", false, "Output Recipe creation result as JSON")
 	createCmd.Flags().StringVar(&createSourceURL, "source-url", "", "Record the source URL this workspace was seeded from")
 	createCmd.Flags().StringVar(&createSourceProvide, "source-provider", "", "Source provider label (e.g. github, notion, slack)")
 	createCmd.Flags().StringVar(&createSourceRef, "source-ref", "", "Source ref (PR number, page id, message ts)")

--- a/cmd/create_recipe.go
+++ b/cmd/create_recipe.go
@@ -1,0 +1,380 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/nicksenap/grove/internal/config"
+	"github.com/nicksenap/grove/internal/console"
+	"github.com/nicksenap/grove/internal/discover"
+	"github.com/nicksenap/grove/internal/gitops"
+	"github.com/nicksenap/grove/internal/lifecycle"
+	"github.com/nicksenap/grove/internal/models"
+	"github.com/nicksenap/grove/internal/recipe"
+	"github.com/nicksenap/grove/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+const (
+	createErrorRecipeInvalid    = "recipe_invalid"
+	createErrorResolutionFailed = "repository_resolution_failed"
+	createErrorProvisionFailed  = "workspace_provision_failed"
+	createErrorPostCreateFailed = "post_create_failed"
+)
+
+type recipeCreateOutput struct {
+	Created bool                     `json:"created"`
+	Name    string                   `json:"name"`
+	Path    string                   `json:"path,omitempty"`
+	Recipe  string                   `json:"recipe,omitempty"`
+	Jobs    *[]recipe.JobResult      `json:"jobs,omitempty"`
+	Error   *recipeCreateErrorOutput `json:"error,omitempty"`
+}
+
+type recipeCreateErrorOutput struct {
+	Code         string `json:"code"`
+	Job          string `json:"job,omitempty"`
+	Step         int    `json:"step,omitempty"`
+	StepName     string `json:"step_name,omitempty"`
+	Message      string `json:"message"`
+	CleanupError string `json:"cleanup_error,omitempty"`
+}
+
+type recipeCreateRunError struct {
+	output recipeCreateErrorOutput
+	cause  error
+}
+
+func (e *recipeCreateRunError) Error() string {
+	if e.output.Job == "" {
+		return e.output.Message
+	}
+	step := ""
+	if e.output.Step > 0 {
+		step = fmt.Sprintf(" step %d", e.output.Step)
+		if e.output.StepName != "" {
+			step += " (" + e.output.StepName + ")"
+		}
+	}
+	return fmt.Sprintf("Recipe job %s%s: %s", e.output.Job, step, e.output.Message)
+}
+func (e *recipeCreateRunError) Unwrap() error { return e.cause }
+
+func runRecipeCreate(cmd *cobra.Command, args []string) error {
+	options := recipeCreateOptions{
+		Recipe: createRecipe, Repos: createRepos, Preset: createPreset,
+		All: createAll, Replace: createReplace, Track: createTrack, Force: createForce,
+	}
+	if err := validateRecipeCreateOptions(options); err != nil {
+		return writeRecipeCreateFailure(cmd, "", "", false, recipeCreateErrorOutput{Code: createErrorRecipeInvalid, Message: err.Error()}, err)
+	}
+
+	name, branch, err := recipeCreateIdentity(args)
+	if err != nil {
+		return writeRecipeCreateFailure(cmd, name, "", false, recipeCreateErrorOutput{Code: createErrorRecipeInvalid, Message: err.Error()}, err)
+	}
+	data, err := readRecipeFile(createRecipe)
+	if err != nil {
+		return writeRecipeCreateFailure(cmd, name, "", false, recipeCreateErrorOutput{Code: createErrorRecipeInvalid, Message: err.Error()}, err)
+	}
+	parsed := recipe.Parse(data)
+	if parsed.Recipe == nil || len(parsed.Errors) > 0 {
+		err := errors.New(strings.TrimSpace(formatRecipeErrors(parsed.Errors)))
+		return writeRecipeCreateFailure(cmd, name, "", false, recipeCreateErrorOutput{Code: createErrorRecipeInvalid, Message: err.Error()}, err)
+	}
+
+	cfg := config.RequireConfig()
+	resolved, err := resolveRecipeRepositories(parsed.Recipe, cfg)
+	if err != nil {
+		return writeRecipeCreateFailure(cmd, name, parsed.Recipe.Name, false, recipeCreateErrorOutput{Code: createErrorResolutionFailed, Message: err.Error()}, err)
+	}
+
+	var source *models.WorkspaceSource
+	if createSourceURL != "" || createSourceProvide != "" {
+		source = &models.WorkspaceSource{Provider: createSourceProvide, URL: createSourceURL, Ref: createSourceRef, Title: createSourceTitle}
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	var report recipe.Report
+	svc := workspace.NewService()
+	err = svc.CreateWithPreparation(name, workspace.PreparationOpts{
+		CreateOpts: workspace.CreateOpts{
+			Branch: branch, Repos: resolved.Names, RepoMap: resolved.RepoMap, Cfg: cfg, Source: source,
+		},
+		BaseCommits: resolved.BaseCommits,
+	}, func(ws models.Workspace) error {
+		worktrees := make(map[string]string, len(ws.Repos))
+		for _, repoWorktree := range ws.Repos {
+			worktrees[repoWorktree.RepoName] = repoWorktree.WorktreePath
+		}
+		var executeErr error
+		report, executeErr = (recipe.Executor{Output: cmd.ErrOrStderr()}).Execute(ctx, parsed.Recipe, worktrees)
+		return executeErr
+	})
+	wsPath := filepath.Join(cfg.WorkspaceDir, name)
+	if err != nil {
+		failure := recipeCreateFailureFromError(err)
+		return writeRecipeCreateFailure(cmd, name, parsed.Recipe.Name, false, failure, err)
+	}
+
+	vars := lifecycle.Vars{Name: name, Path: wsPath, Branch: branch}
+	if source != nil {
+		vars.SourceURL, vars.SourceRef, vars.SourceTitle = source.URL, source.Ref, source.Title
+	}
+	if hookErr := lifecycle.Run("post_create", vars); hookErr != nil && !errors.Is(hookErr, lifecycle.ErrNoHook) {
+		if lifecycle.ShouldAbort(hookErr) {
+			failure := recipeCreateErrorOutput{Code: createErrorPostCreateFailed, Message: hookErr.Error()}
+			if createJSON {
+				if err := json.NewEncoder(cmd.OutOrStdout()).Encode(recipeCreateOutput{
+					Created: true, Name: name, Path: wsPath, Recipe: parsed.Recipe.Name, Jobs: &report.Jobs, Error: &failure,
+				}); err != nil {
+					return err
+				}
+			}
+			return &recipeCreateRunError{output: failure, cause: hookErr}
+		}
+		console.Warning(hookErr.Error())
+	}
+
+	if createJSON {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(recipeCreateOutput{
+			Created: true, Name: name, Path: wsPath, Recipe: parsed.Recipe.Name, Jobs: &report.Jobs,
+		})
+	}
+	return nil
+}
+
+func recipeCreateIdentity(args []string) (string, string, error) {
+	name := ""
+	if len(args) > 0 {
+		name = args[0]
+	}
+	branch := createBranch
+	if branch == "" && console.IsTerminal(os.Stdin) {
+		branch = console.PromptDefault("Branch name", name)
+	}
+	if branch == "" {
+		return name, "", errors.New("branch is required: --branch / -b")
+	}
+	if name == "" {
+		name = deriveName(branch)
+	}
+	return name, branch, nil
+}
+
+func recipeCreateFailureFromError(err error) recipeCreateErrorOutput {
+	failure := recipeCreateErrorOutput{Code: createErrorProvisionFailed, Message: err.Error()}
+	var preparationErr *workspace.PreparationError
+	if !errors.As(err, &preparationErr) {
+		return failure
+	}
+	failure.Message = preparationErr.Cause.Error()
+	if preparationErr.CleanupErr != nil {
+		failure.CleanupError = preparationErr.CleanupErr.Error()
+	}
+	var executionErr *recipe.ExecutionError
+	if errors.As(preparationErr.Cause, &executionErr) {
+		failure.Code = executionErr.Code
+		failure.Job = executionErr.Job
+		failure.Step = executionErr.Step
+		failure.StepName = executionErr.StepName
+		failure.Message = executionErr.Err.Error()
+	}
+	return failure
+}
+
+func writeRecipeCreateFailure(cmd *cobra.Command, name, recipeName string, created bool, failure recipeCreateErrorOutput, cause error) error {
+	if createJSON {
+		if err := json.NewEncoder(cmd.OutOrStdout()).Encode(recipeCreateOutput{
+			Created: created, Name: name, Recipe: recipeName, Error: &failure,
+		}); err != nil {
+			return err
+		}
+	}
+	return &recipeCreateRunError{output: failure, cause: cause}
+}
+
+type recipeCreateOptions struct {
+	Recipe  string
+	Repos   string
+	Preset  string
+	All     bool
+	Replace bool
+	Track   bool
+	Force   bool
+}
+
+func validateRecipeCreateOptions(options recipeCreateOptions) error {
+	if options.Recipe == "" {
+		return nil
+	}
+	var conflicts []string
+	if options.Repos != "" {
+		conflicts = append(conflicts, "--repos")
+	}
+	if options.Preset != "" {
+		conflicts = append(conflicts, "--preset")
+	}
+	if options.All {
+		conflicts = append(conflicts, "--all")
+	}
+	if options.Replace {
+		conflicts = append(conflicts, "--replace")
+	}
+	if options.Track {
+		conflicts = append(conflicts, "--track")
+	}
+	if options.Force {
+		conflicts = append(conflicts, "--force")
+	}
+	if len(conflicts) > 0 {
+		return fmt.Errorf("--recipe cannot be combined with %s", strings.Join(conflicts, ", "))
+	}
+	return nil
+}
+
+type recipeRepositoryCandidate struct {
+	Path   string
+	Remote string
+}
+
+type resolvedRecipeRepositories struct {
+	Names       []string
+	RepoMap     map[string]string
+	BaseCommits map[string]string
+}
+
+func resolveRecipeRepositories(model *recipe.Recipe, cfg *models.Config) (resolvedRecipeRepositories, error) {
+	result := resolvedRecipeRepositories{
+		Names:       sortedRecipeRepositoryIDs(model.Repositories),
+		RepoMap:     make(map[string]string, len(model.Repositories)),
+		BaseCommits: make(map[string]string, len(model.Repositories)),
+	}
+	candidates := findRecipeRepositoryCandidates(cfg.RepoDirs)
+	seenIdentities := make(map[string]string, len(model.Repositories))
+
+	for _, id := range result.Names {
+		repository := model.Repositories[id]
+		identity, err := gitops.CanonicalRemoteIdentity(repository.URL)
+		if err != nil {
+			return resolvedRecipeRepositories{}, fmt.Errorf("repository %s: %w", id, err)
+		}
+		if existingID, duplicate := seenIdentities[identity]; duplicate {
+			return resolvedRecipeRepositories{}, fmt.Errorf("repositories %s and %s resolve to the same remote", existingID, id)
+		}
+		seenIdentities[identity] = id
+
+		path, found, err := selectLocalRecipeRepository(repository.URL, candidates)
+		if err != nil {
+			return resolvedRecipeRepositories{}, fmt.Errorf("repository %s: %w", id, err)
+		}
+		if !found {
+			if len(cfg.RepoDirs) == 0 {
+				return resolvedRecipeRepositories{}, fmt.Errorf("repository %s is not local and no repo_dirs are configured", id)
+			}
+			console.Infof("Cloning %s ...", terminalSafe(repository.URL))
+			clonedPath, _, err := gitops.Clone(repository.URL, cfg.RepoDirs[0])
+			if err != nil {
+				return resolvedRecipeRepositories{}, fmt.Errorf("repository %s: %w", id, err)
+			}
+			path = clonedPath
+		}
+		resolvedRemote := gitops.RemoteURL(path, "origin")
+		resolvedIdentity, remoteErr := gitops.CanonicalRemoteIdentity(resolvedRemote)
+		if remoteErr != nil || resolvedIdentity != identity {
+			return resolvedRecipeRepositories{}, fmt.Errorf("repository %s: local clone at %s does not have the expected origin", id, path)
+		}
+		result.RepoMap[id] = path
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, len(result.Names))
+	var mu sync.Mutex
+	for index, id := range result.Names {
+		wg.Add(1)
+		go func(index int, id string) {
+			defer wg.Done()
+			path := result.RepoMap[id]
+			if err := gitops.Fetch(path); err != nil {
+				errs[index] = fmt.Errorf("repository %s: fetch failed: %w", id, err)
+				return
+			}
+			sha, err := gitops.ResolveCommit(path, model.Repositories[id].Ref)
+			if err != nil {
+				errs[index] = fmt.Errorf("repository %s: %w", id, err)
+				return
+			}
+			mu.Lock()
+			result.BaseCommits[id] = sha
+			mu.Unlock()
+		}(index, id)
+	}
+	wg.Wait()
+	if err := errors.Join(errs...); err != nil {
+		return resolvedRecipeRepositories{}, err
+	}
+	return result, nil
+}
+
+func findRecipeRepositoryCandidates(repoDirs []string) []recipeRepositoryCandidate {
+	var candidates []recipeRepositoryCandidate
+	seenPaths := make(map[string]bool)
+	for _, root := range repoDirs {
+		discover.WalkRepos([]string{root}, 3, func(path, _ string, _ int, _ bool) bool {
+			canonicalPath := path
+			if resolved, err := filepath.EvalSymlinks(path); err == nil {
+				canonicalPath = resolved
+			}
+			if absolute, err := filepath.Abs(canonicalPath); err == nil {
+				canonicalPath = absolute
+			}
+			if !seenPaths[canonicalPath] {
+				seenPaths[canonicalPath] = true
+				candidates = append(candidates, recipeRepositoryCandidate{Path: canonicalPath, Remote: gitops.RemoteURL(canonicalPath, "origin")})
+			}
+			return true
+		})
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].Path < candidates[j].Path })
+	return candidates
+}
+
+func selectLocalRecipeRepository(remote string, candidates []recipeRepositoryCandidate) (string, bool, error) {
+	identity, err := gitops.CanonicalRemoteIdentity(remote)
+	if err != nil {
+		return "", false, err
+	}
+	var matches []string
+	for _, candidate := range candidates {
+		candidateIdentity, err := gitops.CanonicalRemoteIdentity(candidate.Remote)
+		if err == nil && candidateIdentity == identity {
+			matches = append(matches, candidate.Path)
+		}
+	}
+	if len(matches) > 1 {
+		sort.Strings(matches)
+		return "", false, fmt.Errorf("multiple local repositories match %s: %s", remote, strings.Join(matches, ", "))
+	}
+	if len(matches) == 1 {
+		return matches[0], true, nil
+	}
+	return "", false, nil
+}
+
+func sortedRecipeRepositoryIDs(repositories map[string]recipe.Repository) []string {
+	ids := make([]string, 0, len(repositories))
+	for id := range repositories {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/cmd/create_recipe_test.go
+++ b/cmd/create_recipe_test.go
@@ -1,0 +1,354 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/nicksenap/grove/internal/config"
+	"github.com/nicksenap/grove/internal/gitops"
+	"github.com/nicksenap/grove/internal/models"
+	"github.com/nicksenap/grove/internal/recipe"
+	"github.com/nicksenap/grove/internal/state"
+	"github.com/nicksenap/grove/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+func TestRunRecipeCreateSuccessJSON(t *testing.T) {
+	env := setupRecipeCreateCommand(t, "printf ready > ready.txt")
+	var stdout, stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := runRecipeCreate(cmd, []string{"cake"}); err != nil {
+		t.Fatalf("runRecipeCreate: %v\nstderr: %s", err, stderr.String())
+	}
+	var output recipeCreateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+	if !output.Created || output.Name != "cake" || output.Jobs == nil || len(*output.Jobs) != 1 {
+		t.Fatalf("unexpected output: %+v", output)
+	}
+	if _, err := os.Stat(filepath.Join(env.workspaceDir, "cake", "api", "ready.txt")); err != nil {
+		t.Fatalf("Recipe step output missing: %v", err)
+	}
+	store := state.NewStore(env.groveDir)
+	if ws, _ := store.GetWorkspace("cake"); ws == nil {
+		t.Fatal("workspace not registered")
+	}
+}
+
+func TestRunRecipeCreatePostCreateAbortReportsCreatedWorkspace(t *testing.T) {
+	env := setupRecipeCreateCommand(t, "true")
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Hooks = map[string]models.Hook{"post_create": {Command: "exit 9", OnFailure: "abort"}}
+	if err := config.Save(cfg); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err = runRecipeCreate(cmd, []string{"hook-cake"})
+	if err == nil {
+		t.Fatal("expected post_create failure")
+	}
+	var output recipeCreateOutput
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &output); decodeErr != nil {
+		t.Fatal(decodeErr)
+	}
+	if !output.Created || output.Path == "" || output.Error == nil || output.Error.Code != "post_create_failed" {
+		t.Fatalf("unexpected output: %+v", output)
+	}
+	if ws, _ := state.NewStore(env.groveDir).GetWorkspace("hook-cake"); ws == nil {
+		t.Fatal("post_create abort incorrectly removed completed workspace")
+	}
+}
+
+func TestRunRecipeCreateFailureHumanIdentifiesJobAndStep(t *testing.T) {
+	setupRecipeCreateCommand(t, "exit 4")
+	createJSON = false
+	var stdout, stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := runRecipeCreate(cmd, []string{"failed-human"})
+	if err == nil || !strings.Contains(err.Error(), "Recipe job setup step 1 (Prepare)") {
+		t.Fatalf("error is not actionable: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("unexpected human stdout: %q", stdout.String())
+	}
+}
+
+func TestRunRecipeCreateFailureJSONRollsBack(t *testing.T) {
+	env := setupRecipeCreateCommand(t, "printf dirty > generated.txt; exit 7")
+	createBranch = "feat/failing-recipe"
+	var stdout, stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := runRecipeCreate(cmd, []string{"failed-cake"})
+	var runErr *recipeCreateRunError
+	if !errors.As(err, &runErr) {
+		t.Fatalf("error = %v, want recipeCreateRunError", err)
+	}
+	var output recipeCreateOutput
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &output); decodeErr != nil {
+		t.Fatalf("invalid JSON: %v\n%s", decodeErr, stdout.String())
+	}
+	if output.Created || output.Error == nil || output.Error.Code != recipe.ErrorStepFailed || output.Error.Job != "setup" || output.Error.Step != 1 {
+		t.Fatalf("unexpected output: %+v", output)
+	}
+	store := state.NewStore(env.groveDir)
+	if ws, _ := store.GetWorkspace("failed-cake"); ws != nil {
+		t.Fatalf("failed workspace remained registered: %+v", ws)
+	}
+	if _, err := os.Stat(filepath.Join(env.workspaceDir, "failed-cake")); !os.IsNotExist(err) {
+		t.Fatalf("failed workspace directory remained: %v", err)
+	}
+	if gitops.BranchExists(env.repoPath, createBranch) {
+		t.Fatal("owned branch remained after rollback")
+	}
+}
+
+func TestRecipeCreateFailurePreservesTimeoutAndCleanupDetails(t *testing.T) {
+	executionErr := &recipe.ExecutionError{Code: recipe.ErrorJobTimeout, Job: "slow", Step: 2, StepName: "Build", Err: errors.New("timed out")}
+	failure := recipeCreateFailureFromError(&workspace.PreparationError{Cause: executionErr, CleanupErr: errors.New("cleanup refused")})
+	if failure.Code != recipe.ErrorJobTimeout || failure.Job != "slow" || failure.Step != 2 || failure.CleanupError != "cleanup refused" {
+		t.Fatalf("unexpected failure: %+v", failure)
+	}
+}
+
+func TestValidateRecipeCreateOptions(t *testing.T) {
+	valid := recipeCreateOptions{Recipe: "recipe.yaml"}
+	if err := validateRecipeCreateOptions(valid); err != nil {
+		t.Fatalf("valid options: %v", err)
+	}
+	conflicts := []recipeCreateOptions{
+		{Recipe: "recipe.yaml", Repos: "api"},
+		{Recipe: "recipe.yaml", Preset: "stack"},
+		{Recipe: "recipe.yaml", All: true},
+		{Recipe: "recipe.yaml", Replace: true},
+		{Recipe: "recipe.yaml", Track: true},
+		{Recipe: "recipe.yaml", Force: true},
+	}
+	for _, options := range conflicts {
+		if err := validateRecipeCreateOptions(options); err == nil {
+			t.Fatalf("expected conflict for %+v", options)
+		}
+	}
+}
+
+func TestSelectLocalRecipeRepositoryMatchesCanonicalRemote(t *testing.T) {
+	candidates := []recipeRepositoryCandidate{
+		{Path: "/repos/example", Remote: "git@github.com:Acme/example.git"},
+	}
+	path, found, err := selectLocalRecipeRepository("https://github.com/Acme/example.git", candidates)
+	if err != nil || !found || path != "/repos/example" {
+		t.Fatalf("got path=%q found=%v err=%v", path, found, err)
+	}
+}
+
+func TestFindRecipeRepositoryCandidatesIncludesNestedRepositories(t *testing.T) {
+	root := t.TempDir()
+	outer := filepath.Join(root, "outer")
+	nested := filepath.Join(outer, "nested")
+	runRecipeGit(t, root, "init", outer)
+	runRecipeGit(t, outer, "init", nested)
+	runRecipeGit(t, nested, "remote", "add", "origin", "https://github.com/acme/nested.git")
+
+	candidates := findRecipeRepositoryCandidates([]string{root})
+	path, found, err := selectLocalRecipeRepository("git@github.com:acme/nested.git", candidates)
+	expectedPath, _ := filepath.EvalSymlinks(nested)
+	if err != nil || !found || path != expectedPath {
+		t.Fatalf("path=%q found=%v err=%v candidates=%+v", path, found, err, candidates)
+	}
+}
+
+func TestSelectLocalRecipeRepositoryRejectsAmbiguousMatch(t *testing.T) {
+	candidates := []recipeRepositoryCandidate{
+		{Path: "/repos/one", Remote: "https://github.com/acme/example.git"},
+		{Path: "/repos/two", Remote: "git@github.com:acme/example.git"},
+	}
+	if _, _, err := selectLocalRecipeRepository("https://github.com/acme/example", candidates); err == nil {
+		t.Fatal("expected ambiguous remote error")
+	}
+}
+
+func TestResolveRecipeRepositoriesUsesFetchedRemoteCommit(t *testing.T) {
+	dir := t.TempDir()
+	reposDir := filepath.Join(dir, "repos")
+	os.MkdirAll(reposDir, 0o755)
+	bare := filepath.Join(dir, "origin.git")
+	repoPath := filepath.Join(reposDir, "example")
+	runRecipeGit(t, dir, "init", "--bare", bare)
+	runRecipeGit(t, dir, "clone", bare, repoPath)
+	runRecipeGit(t, repoPath, "config", "user.email", "test@example.com")
+	runRecipeGit(t, repoPath, "config", "user.name", "Test")
+	os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("initial"), 0o644)
+	runRecipeGit(t, repoPath, "add", ".")
+	runRecipeGit(t, repoPath, "commit", "-m", "initial")
+	runRecipeGit(t, repoPath, "push", "origin", "HEAD")
+	branch := runRecipeGit(t, repoPath, "branch", "--show-current")
+	remoteSHA := runRecipeGit(t, repoPath, "rev-parse", "origin/"+branch)
+	runRecipeGit(t, repoPath, "remote", "set-url", "origin", "file://"+bare)
+
+	os.WriteFile(filepath.Join(repoPath, "local.txt"), []byte("local"), 0o644)
+	runRecipeGit(t, repoPath, "add", ".")
+	runRecipeGit(t, repoPath, "commit", "-m", "local only")
+
+	cfg := &models.Config{RepoDirs: []string{reposDir}, WorkspaceDir: filepath.Join(dir, "workspaces")}
+	model := &recipe.Recipe{Repositories: map[string]recipe.Repository{
+		"api": {URL: "file://" + bare, Ref: branch},
+	}}
+	resolved, err := resolveRecipeRepositories(model, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedPath, _ := filepath.EvalSymlinks(repoPath)
+	if resolved.RepoMap["api"] != expectedPath || resolved.BaseCommits["api"] != remoteSHA {
+		t.Fatalf("unexpected resolution: %+v", resolved)
+	}
+}
+
+func TestResolveRecipeRepositoriesRejectsExistingRepoWithoutExpectedOrigin(t *testing.T) {
+	dir := t.TempDir()
+	reposDir := filepath.Join(dir, "repos")
+	os.MkdirAll(reposDir, 0o755)
+	bare := filepath.Join(dir, "example.git")
+	runRecipeGit(t, dir, "init", "--bare", bare)
+	conflict := filepath.Join(reposDir, "example")
+	runRecipeGit(t, reposDir, "init", conflict)
+	runRecipeGit(t, conflict, "config", "user.email", "test@example.com")
+	runRecipeGit(t, conflict, "config", "user.name", "Test")
+	os.WriteFile(filepath.Join(conflict, "README.md"), []byte("unrelated"), 0o644)
+	runRecipeGit(t, conflict, "add", ".")
+	runRecipeGit(t, conflict, "commit", "-m", "unrelated")
+
+	cfg := &models.Config{RepoDirs: []string{reposDir}, WorkspaceDir: filepath.Join(dir, "workspaces")}
+	model := &recipe.Recipe{Repositories: map[string]recipe.Repository{
+		"api": {URL: "file://" + bare, Ref: "main"},
+	}}
+	if _, err := resolveRecipeRepositories(model, cfg); err == nil {
+		t.Fatal("expected existing repository without matching origin to be rejected")
+	}
+}
+
+func TestResolveRecipeRepositoriesClonesMissingRemote(t *testing.T) {
+	dir := t.TempDir()
+	reposDir := filepath.Join(dir, "repos")
+	os.MkdirAll(reposDir, 0o755)
+	bare := filepath.Join(dir, "example.git")
+	seed := filepath.Join(dir, "seed")
+	runRecipeGit(t, dir, "init", "--bare", bare)
+	runRecipeGit(t, dir, "clone", bare, seed)
+	runRecipeGit(t, seed, "config", "user.email", "test@example.com")
+	runRecipeGit(t, seed, "config", "user.name", "Test")
+	os.WriteFile(filepath.Join(seed, "README.md"), []byte("initial"), 0o644)
+	runRecipeGit(t, seed, "add", ".")
+	runRecipeGit(t, seed, "commit", "-m", "initial")
+	runRecipeGit(t, seed, "push", "origin", "HEAD")
+	branch := runRecipeGit(t, seed, "branch", "--show-current")
+
+	cfg := &models.Config{RepoDirs: []string{reposDir}, WorkspaceDir: filepath.Join(dir, "workspaces")}
+	model := &recipe.Recipe{Repositories: map[string]recipe.Repository{
+		"api": {URL: "file://" + bare, Ref: branch},
+	}}
+	resolved, err := resolveRecipeRepositories(model, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.RepoMap["api"] == "" || resolved.BaseCommits["api"] == "" {
+		t.Fatalf("missing cloned resolution: %+v", resolved)
+	}
+	if _, err := os.Stat(filepath.Join(resolved.RepoMap["api"], ".git")); err != nil {
+		t.Fatalf("clone missing: %v", err)
+	}
+}
+
+type recipeCreateCommandEnv struct {
+	groveDir     string
+	workspaceDir string
+	repoPath     string
+}
+
+func setupRecipeCreateCommand(t *testing.T, command string) recipeCreateCommandEnv {
+	t.Helper()
+	dir := t.TempDir()
+	groveDir := filepath.Join(dir, ".grove")
+	reposDir := filepath.Join(dir, "repos")
+	workspaceDir := filepath.Join(groveDir, "workspaces")
+	os.MkdirAll(reposDir, 0o755)
+	os.MkdirAll(workspaceDir, 0o755)
+	os.WriteFile(filepath.Join(groveDir, "state.json"), []byte("[]"), 0o644)
+
+	bare := filepath.Join(dir, "origin.git")
+	repoPath := filepath.Join(reposDir, "source-name")
+	runRecipeGit(t, dir, "init", "--bare", bare)
+	runRecipeGit(t, dir, "clone", bare, repoPath)
+	runRecipeGit(t, repoPath, "config", "user.email", "test@example.com")
+	runRecipeGit(t, repoPath, "config", "user.name", "Test")
+	os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("initial"), 0o644)
+	runRecipeGit(t, repoPath, "add", ".")
+	runRecipeGit(t, repoPath, "commit", "-m", "initial")
+	runRecipeGit(t, repoPath, "push", "origin", "HEAD")
+	branch := runRecipeGit(t, repoPath, "branch", "--show-current")
+	runRecipeGit(t, repoPath, "remote", "set-url", "origin", "file://"+bare)
+
+	recipePath := filepath.Join(dir, "recipe.yaml")
+	recipeData := "version: 1\nname: test-recipe\nrepositories:\n  api:\n    url: file://" + bare + "\n    ref: " + branch + "\njobs:\n  setup:\n    repository: api\n    steps:\n      - name: Prepare\n        run: " + strconv.Quote(command) + "\n"
+	os.WriteFile(recipePath, []byte(recipeData), 0o644)
+
+	oldGroveDir, oldConfigPath, oldWorkspaceDir := config.GroveDir, config.ConfigPath, config.DefaultWorkspaceDir
+	config.GroveDir = groveDir
+	config.ConfigPath = filepath.Join(groveDir, "config.toml")
+	config.DefaultWorkspaceDir = workspaceDir
+	if err := config.Save(&models.Config{RepoDirs: []string{reposDir}, WorkspaceDir: workspaceDir}); err != nil {
+		t.Fatal(err)
+	}
+	oldRecipe, oldBranch, oldJSON := createRecipe, createBranch, createJSON
+	oldRepos, oldPreset, oldAll := createRepos, createPreset, createAll
+	oldReplace, oldTrack, oldForce := createReplace, createTrack, createForce
+	createRecipe, createBranch, createJSON = recipePath, "feat/recipe", true
+	createRepos, createPreset, createAll = "", "", false
+	createReplace, createTrack, createForce = false, false, false
+	t.Cleanup(func() {
+		config.GroveDir, config.ConfigPath, config.DefaultWorkspaceDir = oldGroveDir, oldConfigPath, oldWorkspaceDir
+		createRecipe, createBranch, createJSON = oldRecipe, oldBranch, oldJSON
+		createRepos, createPreset, createAll = oldRepos, oldPreset, oldAll
+		createReplace, createTrack, createForce = oldReplace, oldTrack, oldForce
+	})
+	return recipeCreateCommandEnv{groveDir: groveDir, workspaceDir: workspaceDir, repoPath: repoPath}
+}
+
+func runRecipeGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -140,7 +140,7 @@ func formatRecipeErrors(validationErrors []recipe.ValidationError) string {
 func terminalSafe(value string) string {
 	var result strings.Builder
 	for _, char := range value {
-		if char < 0x20 || char == 0x7f {
+		if char < 0x20 || char == 0x7f || char >= 0x80 && char <= 0x9f {
 			fmt.Fprintf(&result, "\\x%02x", char)
 			continue
 		}

--- a/docs/recipe-execution.md
+++ b/docs/recipe-execution.md
@@ -1,0 +1,66 @@
+# Recipe workspace creation
+
+> **Security:** A Recipe is trusted executable code, equivalent to running its shell scripts directly. `--recipe` is the explicit acknowledgement to execute it. Working-directory checks are not a sandbox; commands inherit Grove's environment and normal host access. Review Recipes from the same trust boundary as source code before running them.
+
+## Command
+
+```bash
+gw create NAME --branch BRANCH --recipe recipe.yaml
+gw create NAME --branch BRANCH --recipe recipe.yaml --json
+```
+
+`--recipe` is mutually exclusive with `--repos`, `--preset`, `--all`, `--replace`, `--track`, and `--force`. Without `--recipe`, create and Preset behavior is unchanged.
+
+## Repository resolution
+
+- Match each Recipe URL to configured local repositories by canonical remote identity, independent of HTTPS versus SSH spelling.
+- Fail if multiple local repositories match one Recipe repository.
+- Clone an unmatched URL into the first configured `repo_dir` using Grove's existing clone path.
+- Use the Recipe repository ID as the workspace directory and state name.
+- If the requested workspace branch already exists at the resolved base SHA, reuse it but persist that it is pre-existing so normal workspace deletion preserves it. A branch at any other commit fails closed.
+- Before workspace mutation, require a successful fetch and resolve each Recipe `ref` to a commit SHA. Unqualified branches and `refs/heads/*` resolve only through fetched `origin` refs, tags resolve through exact tag refs, and hexadecimal object IDs are disambiguated as Git objects rather than ref names. Revision expressions and local-branch fallback are rejected.
+- Canonical identity includes lowercase host plus case-preserving repository path. Resolution inspects every configured candidate without basename deduplication.
+
+## Execution
+
+- Recipe creation skips per-repository `.grove.toml` setup commands because the Recipe owns the complete bake. Ordinary create still runs them.
+- Recipe jobs run after worktrees and state exist, outside Grove's mutation lock.
+- Up to four jobs run concurrently.
+- Independent jobs in different repositories may overlap. Only one job per repository runs at a time; when several are ready for one repository, lexical job ID wins.
+- `needs` controls readiness; job map order has no meaning.
+- Steps within a job run sequentially in separate `/bin/sh -c` processes.
+- A job's `working-directory` applies to every step and is relative to its worktree.
+- Commands inherit Grove's environment, receive no interactive stdin, and stream raw command output with sanitized job/step metadata prefixes.
+- Optional `timeout-minutes` follows the familiar GitHub Actions spelling. It accepts 1–360 and defaults to 360 minutes per job.
+- Global `post_create` runs only after every Recipe job succeeds.
+
+## Failure and cancellation
+
+- The first failed or timed-out step cancels queued work and kills ordinary running process groups. Deliberately detached/daemonized processes are outside v1's best-effort cancellation boundary.
+- Failure identifies the job, one-based step number, optional step name, and cause.
+- Grove retains the invocation's worktree and branch ownership metadata. On failure it reacquires the lock, verifies persisted workspace state still exactly matches the workspace it created, then removes only invocation-owned worktrees and branches.
+- If state changed concurrently, cleanup fails closed and leaves recoverable state rather than guessing ownership. Cleanup errors are reported separately from the original preparation failure.
+- SIGINT or SIGTERM cancels execution and uses the same rollback path.
+- Cold creation writes no persistent Recipe logs; prefixed live output is the v1 log surface.
+
+## JSON
+
+Progress and command output remain on stderr. `--json` writes one result object to stdout.
+
+Success:
+
+```json
+{"created":true,"name":"cake","path":"/workspaces/cake","recipe":"example-stack","jobs":[{"id":"setup-api","status":"succeeded","steps":2}]}
+```
+
+Failure exits non-zero after rollback:
+
+```json
+{"created":false,"name":"cake","error":{"code":"recipe_step_failed","job":"setup-api","step":2,"step_name":"Build API","message":"exit status 1"}}
+```
+
+Stable failure codes cover `recipe_invalid`, `repository_resolution_failed`, `workspace_provision_failed`, `recipe_step_failed`, `recipe_job_timeout`, `recipe_cancelled`, and `post_create_failed`. A cleanup failure adds `cleanup_error` while preserving the original job failure. An aborting global `post_create` failure reports `created: true` because the completed workspace remains present.
+
+## Non-goals
+
+Oven slots, remote execution, containers, services, matrices, retries, conditions, actions, expressions, output caching, persistent logs, or credential-provider machinery.

--- a/docs/recipe-v1.md
+++ b/docs/recipe-v1.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Define a strict YAML description of repositories and local preparation jobs. This first slice only parses and validates Recipes; it does not execute them or change existing workspace creation.
+Define a strict YAML description of repositories and local preparation jobs. Validation is independently available before [workspace creation and execution](recipe-execution.md).
 
 Recipe uses GitHub Actions-inspired vocabulary (`jobs`, `needs`, `steps`, `name`, and `run`) to reduce the learning curve. It is a Grove-specific schema and is not syntactically, semantically, or tooling-compatible with GitHub Actions.
 
@@ -63,6 +63,7 @@ See [`examples/recipes/example-stack.yaml`](../examples/recipes/example-stack.ya
 - `jobs` — optional map of job IDs; an omitted or empty map creates a repository-only Recipe. Each job contains:
   - `repository` — required repository ID.
   - `working-directory` — optional relative path inside the repository; defaults to its root.
+  - `timeout-minutes` — optional integer from 1–360; execution defaults to 360 minutes.
   - `needs` — optional list of job IDs that must complete first.
   - `steps` — required non-empty ordered list of steps.
 - Step fields:
@@ -124,4 +125,4 @@ Validation errors use stable `code`, `path`, `line`, `column`, and `message` fie
 
 ## Non-goals
 
-Execution, `gw create --recipe`, Oven, TOML, includes, templates, expressions, triggers, runners, actions, variables, environment maps, cache declarations, conditions, matrices, retries, services, containers, remote files, or credential-provider machinery.
+Oven, TOML, includes, templates, expressions, triggers, runners, actions, variables, environment maps, cache declarations, conditions, matrices, retries, services, containers, remote files, or credential-provider machinery.

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -922,6 +922,105 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test: Recipe workspace creation
+# ---------------------------------------------------------------------------
+section "Recipe create"
+
+RECIPE_AUTH_ORIGIN="${GROVE_HOME}/recipe-auth.git"
+RECIPE_API_ORIGIN="${GROVE_HOME}/recipe-api.git"
+git clone -q --bare "${REPOS_DIR}/svc-auth" "${RECIPE_AUTH_ORIGIN}"
+git clone -q --bare "${REPOS_DIR}/svc-api" "${RECIPE_API_ORIGIN}"
+git -C "${REPOS_DIR}/svc-auth" remote add origin "file://${RECIPE_AUTH_ORIGIN}"
+git -C "${REPOS_DIR}/svc-api" remote add origin "file://${RECIPE_API_ORIGIN}"
+git -C "${REPOS_DIR}/svc-auth" fetch -q origin
+git -C "${REPOS_DIR}/svc-api" fetch -q origin
+
+RECIPE_FILE="${GROVE_HOME}/recipe.yaml"
+cat > "${RECIPE_FILE}" <<EOF
+version: 1
+name: e2e-recipe
+repositories:
+  auth:
+    url: file://${RECIPE_AUTH_ORIGIN}
+    ref: main
+  api:
+    url: file://${RECIPE_API_ORIGIN}
+    ref: main
+jobs:
+  setup-auth:
+    repository: auth
+    steps:
+      - run: touch .recipe-ran
+  setup-api:
+    repository: api
+    steps:
+      - run: touch .recipe-ran
+  verify:
+    repository: auth
+    needs: [setup-auth, setup-api]
+    steps:
+      - run: test -f .recipe-ran && test -f ../api/.recipe-ran
+EOF
+
+recipe_json=$(gw create recipe-ws --branch feat/recipe-e2e --recipe "${RECIPE_FILE}" --json 2>/dev/null)
+if echo "${recipe_json}" | jq -e '.created == true and .name == "recipe-ws" and (.jobs | length) == 3' >/dev/null; then
+    pass "create --recipe returns successful JSON"
+else
+    fail "create --recipe JSON failed: ${recipe_json}"
+fi
+
+RECIPE_WS="${GROVE_HOME}/.grove/workspaces/recipe-ws"
+if [ -f "${RECIPE_WS}/auth/.recipe-ran" ] && [ -f "${RECIPE_WS}/api/.recipe-ran" ]; then
+    pass "Recipe jobs prepared aliased repository worktrees"
+else
+    fail "Recipe job outputs missing"
+fi
+if [ ! -f "${RECIPE_WS}/auth/.grove-setup-ran" ]; then
+    pass "Recipe create skipped legacy .grove.toml setup"
+else
+    fail "Recipe create unexpectedly ran legacy setup"
+fi
+
+gw delete recipe-ws --force >/dev/null 2>&1
+pass "Recipe workspace cleaned up normally"
+
+FAIL_RECIPE="${GROVE_HOME}/recipe-fail.yaml"
+cat > "${FAIL_RECIPE}" <<EOF
+version: 1
+repositories:
+  api:
+    url: file://${RECIPE_API_ORIGIN}
+    ref: main
+jobs:
+  fail:
+    repository: api
+    steps:
+      - name: Fail deliberately
+        run: touch generated.txt; exit 7
+EOF
+
+if failed_json=$(gw create failed-recipe --branch feat/recipe-fail --recipe "${FAIL_RECIPE}" --json 2>/dev/null); then
+    fail "failing Recipe unexpectedly succeeded"
+else
+    if echo "${failed_json}" | jq -e '.created == false and .error.code == "recipe_step_failed" and .error.job == "fail" and .error.step == 1' >/dev/null; then
+        pass "Recipe failure identifies job and step in JSON"
+    else
+        fail "Recipe failure JSON was not actionable: ${failed_json}"
+    fi
+fi
+if [ ! -d "${GROVE_HOME}/.grove/workspaces/failed-recipe" ] && ! git -C "${REPOS_DIR}/svc-api" show-ref --verify --quiet refs/heads/feat/recipe-fail; then
+    pass "failed Recipe rolled back workspace and owned branch"
+else
+    fail "failed Recipe rollback left workspace or branch"
+fi
+
+if gw create conflict-recipe --branch feat/conflict --recipe "${RECIPE_FILE}" --repos svc-api >/dev/null 2>&1; then
+    fail "--recipe accepted conflicting --repos"
+else
+    pass "--recipe rejects existing repository selectors"
+fi
+
+# ---------------------------------------------------------------------------
 # Test: stats
 # ---------------------------------------------------------------------------
 section "Stats"

--- a/examples/recipes/example-stack.yaml
+++ b/examples/recipes/example-stack.yaml
@@ -1,30 +1,34 @@
 version: 1
-name: example-stack
+name: grove-tools
 
 repositories:
-  api:
-    url: https://github.com/acme/example-api.git
-    ref: main
-  web:
-    url: https://github.com/acme/example-web.git
-    ref: main
+  grove:
+    url: https://github.com/nicksenap/grove.git
+    ref: master
+  zellij:
+    url: https://github.com/nicksenap/gw-zellij.git
+    ref: master
 
 jobs:
-  setup-api:
-    repository: api
+  test-grove:
+    repository: grove
+    timeout-minutes: 10
     steps:
-      - name: Install API dependencies
-        run: make setup
+      - name: Test Grove
+        run: go test ./...
 
-  setup-web:
-    repository: web
+  test-zellij:
+    repository: zellij
+    timeout-minutes: 10
     steps:
-      - name: Install web dependencies
-        run: make setup
+      - name: Test Zellij plugin
+        run: go test ./...
 
-  verify-api:
-    repository: api
-    needs: [setup-api, setup-web]
+  verify:
+    repository: grove
+    needs: [test-grove, test-zellij]
     steps:
-      - name: Verify API
-        run: make check
+      - name: Confirm clean worktrees
+        run: |
+          test -z "$(git status --short)"
+          test -z "$(git -C ../zellij status --short)"

--- a/internal/gitops/gitops.go
+++ b/internal/gitops/gitops.go
@@ -383,44 +383,70 @@ func Clone(url, destDir string) (string, string, error) {
 	dest := filepath.Join(destDir, name)
 
 	if _, err := os.Stat(dest); err == nil {
-		// Already exists — verify it's a git repo with a matching remote
-		if !IsGitRepo(dest) {
-			return "", "", fmt.Errorf("directory %s already exists but is not a git repo", dest)
-		}
-		existingRemote := RemoteURL(dest, "origin")
-		if existingRemote != "" && existingRemote != url {
-			return "", "", fmt.Errorf("directory %s already exists but points to %s, not %s", name, existingRemote, url)
+		if err := validateExistingClone(dest, name, url); err != nil {
+			return "", "", err
 		}
 		return dest, name, nil
 	}
 
 	const maxAttempts = 3
 	backoff := cloneBackoff
-
 	var lastErr error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		_, lastErr = runGit(destDir, "clone", url, name)
-		if lastErr == nil {
-			return dest, name, nil
+		tempDir, err := os.MkdirTemp(destDir, ".grove-clone-"+name+"-")
+		if err != nil {
+			return "", "", fmt.Errorf("creating temporary clone directory: %w", err)
 		}
+		_, lastErr = runGit(destDir, "clone", url, tempDir)
+		if lastErr == nil {
+			if err := os.Rename(tempDir, dest); err == nil {
+				return dest, name, nil
+			}
+			_ = os.RemoveAll(tempDir) // uniquely owned by this invocation
+			if err := validateExistingClone(dest, name, url); err == nil {
+				return dest, name, nil
+			} else {
+				return "", "", err
+			}
+		}
+		_ = os.RemoveAll(tempDir) // uniquely owned by this invocation
 
-		// Don't retry auth errors — they'll fail every time
+		// Don't retry auth errors — they'll fail every time.
 		var gitErr *GitError
 		if errors.As(lastErr, &gitErr) && isAuthError(gitErr.Stderr) {
 			break
 		}
-
 		if attempt < maxAttempts {
 			logging.Warn("clone %s failed (attempt %d/%d), retrying in %v: %s",
 				url, attempt, maxAttempts, backoff, lastErr)
 			time.Sleep(backoff)
 			backoff *= 2
 		}
-
-		// Clean up partial clone directory
-		os.RemoveAll(dest)
 	}
 	return "", "", fmt.Errorf("cloning %s: %w", url, lastErr)
+}
+
+func validateExistingClone(dest, name, expectedRemote string) error {
+	if !IsGitRepo(dest) {
+		return fmt.Errorf("directory %s already exists but is not a git repo", dest)
+	}
+	existingRemote := RemoteURL(dest, "origin")
+	if existingRemote == "" {
+		return fmt.Errorf("directory %s already exists but has no origin remote", name)
+	}
+	if !sameRemoteIdentity(existingRemote, expectedRemote) {
+		return fmt.Errorf("directory %s already exists but points to %s, not %s", name, existingRemote, expectedRemote)
+	}
+	return nil
+}
+
+func sameRemoteIdentity(left, right string) bool {
+	if left == right {
+		return true
+	}
+	leftIdentity, leftErr := CanonicalRemoteIdentity(left)
+	rightIdentity, rightErr := CanonicalRemoteIdentity(right)
+	return leftErr == nil && rightErr == nil && leftIdentity == rightIdentity
 }
 
 // RepoBaseBranch returns "origin/<base>" from .grove.toml, or "".

--- a/internal/gitops/gitops_test.go
+++ b/internal/gitops/gitops_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -371,6 +372,81 @@ func TestCommitsAheadBehind(t *testing.T) {
 	WorktreeRemove(repo, wtPath, true)
 }
 
+func TestCanonicalRemoteIdentity(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://GitHub.com/Acme/example.git", "github.com/Acme/example"},
+		{"git@github.com:Acme/example.git", "github.com/Acme/example"},
+		{"ssh://git@github.com/Acme/example.git", "github.com/Acme/example"},
+		{"git://github.com/Acme/example", "github.com/Acme/example"},
+	}
+	for _, tt := range tests {
+		got, err := CanonicalRemoteIdentity(tt.input)
+		if err != nil {
+			t.Fatalf("CanonicalRemoteIdentity(%q): %v", tt.input, err)
+		}
+		if got != tt.want {
+			t.Errorf("CanonicalRemoteIdentity(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestResolveCommitPrefersRemoteBranch(t *testing.T) {
+	repo := initTestRepo(t)
+	branch := currentBranch(t, repo)
+	remoteSHA := run(t, repo, "git", "rev-parse", "origin/"+branch)
+
+	os.WriteFile(filepath.Join(repo, "local.txt"), []byte("local"), 0o644)
+	run(t, repo, "git", "add", "local.txt")
+	run(t, repo, "git", "commit", "-m", "local only")
+	localSHA := run(t, repo, "git", "rev-parse", "HEAD")
+	if localSHA == remoteSHA {
+		t.Fatal("test setup did not create a local-only commit")
+	}
+
+	got, err := ResolveCommit(repo, branch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != remoteSHA {
+		t.Fatalf("ResolveCommit(%q) = %s, want remote SHA %s", branch, got, remoteSHA)
+	}
+}
+
+func TestResolveCommitRejectsUnknownRef(t *testing.T) {
+	repo := initTestRepo(t)
+	if _, err := ResolveCommit(repo, "missing-ref"); err == nil {
+		t.Fatal("expected unknown ref error")
+	}
+}
+
+func TestResolveCommitRejectsRevisionExpressionsAndLocalFallback(t *testing.T) {
+	repo := initTestRepo(t)
+	run(t, repo, "git", "branch", "local-only")
+	run(t, repo, "git", "branch", "deadbee")
+	for _, ref := range []string{"HEAD~1", "HEAD^", "HEAD@{1}", "local-only", "refs/heads/local-only", "deadbee"} {
+		t.Run(ref, func(t *testing.T) {
+			if _, err := ResolveCommit(repo, ref); err == nil {
+				t.Fatalf("ResolveCommit(%q) should fail", ref)
+			}
+		})
+	}
+}
+
+func TestResolveCommitAcceptsExactTagAndObjectID(t *testing.T) {
+	repo := initTestRepo(t)
+	sha := run(t, repo, "git", "rev-parse", "HEAD")
+	run(t, repo, "git", "tag", "v1.0.0")
+	for _, ref := range []string{"v1.0.0", sha} {
+		got, err := ResolveCommit(repo, ref)
+		if err != nil || got != sha {
+			t.Fatalf("ResolveCommit(%q) = %q, %v; want %s", ref, got, err, sha)
+		}
+	}
+}
+
 func TestRemoteURL(t *testing.T) {
 	repo := initTestRepo(t)
 
@@ -609,6 +685,61 @@ func TestClone(t *testing.T) {
 	}
 	if clonedPath != clonedPath2 {
 		t.Errorf("expected same path, got %q vs %q", clonedPath, clonedPath2)
+	}
+}
+
+func TestCloneConcurrentCallsShareCompletedClone(t *testing.T) {
+	dir := t.TempDir()
+	bare := filepath.Join(dir, "origin.git")
+	run(t, dir, "git", "init", "--bare", bare)
+	seed := filepath.Join(dir, "seed")
+	run(t, dir, "git", "clone", bare, seed)
+	run(t, seed, "git", "config", "user.email", "test@test.com")
+	run(t, seed, "git", "config", "user.name", "Test")
+	os.WriteFile(filepath.Join(seed, "README.md"), []byte("test"), 0o644)
+	run(t, seed, "git", "add", ".")
+	run(t, seed, "git", "commit", "-m", "initial")
+	run(t, seed, "git", "push", "origin", "HEAD")
+	destDir := filepath.Join(dir, "repos")
+	os.MkdirAll(destDir, 0o755)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	paths := make([]string, 2)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			paths[i], _, errs[i] = Clone(bare, destDir)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Clone[%d]: %v", i, err)
+		}
+	}
+	if paths[0] != paths[1] || !IsGitRepo(paths[0]) {
+		t.Fatalf("paths = %v, want one valid clone", paths)
+	}
+	matches, err := filepath.Glob(filepath.Join(destDir, ".grove-clone-*"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("temporary clones remained: %v, err=%v", matches, err)
+	}
+}
+
+func TestCloneExistingRepoWithoutOrigin(t *testing.T) {
+	dir := t.TempDir()
+	destDir := filepath.Join(dir, "repos")
+	os.MkdirAll(destDir, 0o755)
+	existing := filepath.Join(destDir, "example")
+	run(t, destDir, "git", "init", existing)
+
+	if _, _, err := Clone("https://github.com/acme/example.git", destDir); err == nil || !strings.Contains(err.Error(), "no origin") {
+		t.Fatalf("error = %v, want missing origin rejection", err)
 	}
 }
 

--- a/internal/gitops/remote.go
+++ b/internal/gitops/remote.go
@@ -1,0 +1,154 @@
+package gitops
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+// CanonicalRemoteIdentity normalizes a Git remote for identity comparison.
+// Network remotes use lowercase host plus a case-preserving repository path.
+func CanonicalRemoteIdentity(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.ContainsAny(value, "\r\n\t ") {
+		return "", fmt.Errorf("invalid Git remote %q", value)
+	}
+
+	if !strings.Contains(value, "://") {
+		if at := strings.IndexByte(value, '@'); at > 0 {
+			if colon := strings.IndexByte(value[at+1:], ':'); colon >= 0 {
+				colon += at + 1
+				return canonicalNetworkRemote(value[at+1:colon], value[colon+1:])
+			}
+		}
+	}
+
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", fmt.Errorf("parsing Git remote: %w", err)
+	}
+	switch parsed.Scheme {
+	case "http", "https", "ssh", "git":
+		host := parsed.Hostname()
+		if port := parsed.Port(); port != "" {
+			host += ":" + port
+		}
+		return canonicalNetworkRemote(host, parsed.Path)
+	case "file":
+		if parsed.Path == "" {
+			return "", fmt.Errorf("file Git remote has no path")
+		}
+		path, err := filepath.Abs(filepath.Clean(parsed.Path))
+		if err != nil {
+			return "", fmt.Errorf("resolving file Git remote: %w", err)
+		}
+		if resolved, err := filepath.EvalSymlinks(path); err == nil {
+			path = resolved
+		}
+		return "file:" + path, nil
+	default:
+		return "", fmt.Errorf("unsupported Git remote scheme %q", parsed.Scheme)
+	}
+}
+
+func canonicalNetworkRemote(host, repositoryPath string) (string, error) {
+	host = strings.ToLower(strings.TrimSpace(host))
+	repositoryPath = strings.Trim(strings.TrimSpace(repositoryPath), "/")
+	repositoryPath = strings.TrimSuffix(repositoryPath, ".git")
+	if host == "" || repositoryPath == "" {
+		return "", fmt.Errorf("git remote must include host and repository path")
+	}
+	return host + "/" + repositoryPath, nil
+}
+
+// ResolveCommit resolves a Recipe ref to an immutable commit SHA. Unqualified
+// refs prefer the fetched origin ref over a potentially stale local branch.
+func ResolveCommit(repoPath, ref string) (string, error) {
+	if isHexObjectID(ref) {
+		return resolveObjectID(repoPath, ref)
+	}
+	candidates, err := exactRefCandidates(repoPath, ref)
+	if err != nil {
+		return "", err
+	}
+	for _, candidate := range candidates {
+		sha, err := runGit(repoPath, "rev-parse", "--verify", "--end-of-options", candidate+"^{commit}")
+		if err == nil && sha != "" {
+			return sha, nil
+		}
+	}
+	return "", fmt.Errorf("git ref %q does not resolve to a fetched branch, exact tag, or commit", ref)
+}
+
+// LocalBranchCommit resolves an already-provisioned local branch. Recipe ref
+// resolution must not call this because local branches are not fetched inputs.
+func LocalBranchCommit(repoPath, branch string) (string, error) {
+	if _, err := runGit(repoPath, "check-ref-format", "--branch", branch); err != nil {
+		return "", fmt.Errorf("invalid local branch %q", branch)
+	}
+	sha, err := runGit(repoPath, "rev-parse", "--verify", "--end-of-options", "refs/heads/"+branch+"^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("resolving local branch %q: %w", branch, err)
+	}
+	return sha, nil
+}
+
+func resolveObjectID(repoPath, objectID string) (string, error) {
+	matches, err := runGit(repoPath, "rev-parse", "--disambiguate="+strings.ToLower(objectID))
+	if err != nil {
+		return "", fmt.Errorf("resolving commit object %q: %w", objectID, err)
+	}
+	var objects []string
+	for _, match := range strings.Split(matches, "\n") {
+		if match = strings.TrimSpace(match); match != "" {
+			objects = append(objects, match)
+		}
+	}
+	if len(objects) != 1 {
+		return "", fmt.Errorf("commit object %q is missing or ambiguous", objectID)
+	}
+	sha, err := runGit(repoPath, "rev-parse", "--verify", "--end-of-options", objects[0]+"^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("object %q is not a commit", objectID)
+	}
+	return sha, nil
+}
+
+func exactRefCandidates(repoPath, ref string) ([]string, error) {
+	if ref == "" || strings.HasPrefix(ref, "-") || strings.ContainsAny(ref, "\x00\r\n\t ") {
+		return nil, fmt.Errorf("invalid Git ref %q", ref)
+	}
+	if strings.HasPrefix(ref, "origin/") {
+		ref = "refs/remotes/origin/" + strings.TrimPrefix(ref, "origin/")
+	}
+	if strings.HasPrefix(ref, "refs/heads/") {
+		ref = "refs/remotes/origin/" + strings.TrimPrefix(ref, "refs/heads/")
+	}
+	if strings.HasPrefix(ref, "refs/") {
+		if !strings.HasPrefix(ref, "refs/tags/") && !strings.HasPrefix(ref, "refs/remotes/origin/") {
+			return nil, fmt.Errorf("unsupported full Git ref %q", ref)
+		}
+		if _, err := runGit(repoPath, "check-ref-format", ref); err != nil {
+			return nil, fmt.Errorf("invalid Git ref %q", ref)
+		}
+		return []string{ref}, nil
+	}
+	if _, err := runGit(repoPath, "check-ref-format", "refs/heads/"+ref); err != nil {
+		return nil, fmt.Errorf("invalid Git ref %q", ref)
+	}
+	return []string{"refs/remotes/origin/" + ref, "refs/tags/" + ref}, nil
+}
+
+func isHexObjectID(value string) bool {
+	if len(value) < 7 || len(value) > 64 {
+		return false
+	}
+	for _, char := range value {
+		if char >= '0' && char <= '9' || char >= 'a' && char <= 'f' || char >= 'A' && char <= 'F' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -10,10 +10,11 @@ import (
 
 // RepoWorktree represents a single repo's worktree within a workspace.
 type RepoWorktree struct {
-	RepoName     string `json:"repo_name"`
-	SourceRepo   string `json:"source_repo"`
-	WorktreePath string `json:"worktree_path"`
-	Branch       string `json:"branch"`
+	RepoName       string `json:"repo_name"`
+	SourceRepo     string `json:"source_repo"`
+	WorktreePath   string `json:"worktree_path"`
+	Branch         string `json:"branch"`
+	PreserveBranch bool   `json:"preserve_branch,omitempty"`
 }
 
 // Workspace represents a named collection of worktrees.

--- a/internal/recipe/executor.go
+++ b/internal/recipe/executor.go
@@ -1,0 +1,341 @@
+package recipe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/nicksenap/grove/internal/streamio"
+)
+
+const (
+	DefaultMaxParallel = 4
+	DefaultJobTimeout  = 360
+
+	ErrorStepFailed   = "recipe_step_failed"
+	ErrorJobTimeout   = "recipe_job_timeout"
+	ErrorCancelled    = "recipe_cancelled"
+	ErrorInvalidGraph = "recipe_invalid_graph"
+)
+
+// StepRunner executes one Recipe step in dir and writes combined output.
+type StepRunner func(ctx context.Context, dir, command string, output io.Writer) error
+
+// Executor runs a validated Recipe job DAG.
+type Executor struct {
+	MaxParallel int
+	Output      io.Writer
+	RunStep     StepRunner
+	timeoutUnit time.Duration
+}
+
+// Report summarizes jobs that started during one execution.
+type Report struct {
+	Jobs []JobResult `json:"jobs"`
+}
+
+// JobResult describes one completed or failed job.
+type JobResult struct {
+	ID             string `json:"id"`
+	Status         string `json:"status"`
+	StepsCompleted int    `json:"steps"`
+}
+
+// ExecutionError identifies the Recipe job and step that failed.
+type ExecutionError struct {
+	Code     string `json:"code"`
+	Job      string `json:"job,omitempty"`
+	Step     int    `json:"step,omitempty"`
+	StepName string `json:"step_name,omitempty"`
+	Err      error  `json:"-"`
+}
+
+func (e *ExecutionError) Error() string {
+	if e.Job == "" {
+		return e.Err.Error()
+	}
+	step := ""
+	if e.Step > 0 {
+		step = fmt.Sprintf(" step %d", e.Step)
+		if e.StepName != "" {
+			step += " (" + e.StepName + ")"
+		}
+	}
+	return fmt.Sprintf("Recipe job %s%s: %s", e.Job, step, e.Err)
+}
+
+func (e *ExecutionError) Unwrap() error { return e.Err }
+
+type jobOutcome struct {
+	id     string
+	result JobResult
+	err    *ExecutionError
+}
+
+type executionState struct {
+	executor     Executor
+	recipe       *Recipe
+	worktrees    map[string]string
+	output       io.Writer
+	runStep      StepRunner
+	timeoutUnit  time.Duration
+	pending      map[string]struct{}
+	completed    map[string]bool
+	runningRepos map[string]bool
+	outcomes     chan jobOutcome
+}
+
+func (s *executionState) startReady(ctx context.Context, running, maxParallel int) int {
+	for _, id := range sortedPending(s.pending) {
+		if running >= maxParallel {
+			break
+		}
+		job := s.recipe.Jobs[id]
+		if s.runningRepos[job.Repository] || !dependenciesComplete(job.Needs, s.completed) {
+			continue
+		}
+		delete(s.pending, id)
+		s.runningRepos[job.Repository] = true
+		running++
+		go func(id string, job Job) {
+			s.outcomes <- s.executor.runJob(ctx, id, job, s.worktrees[job.Repository], s.output, s.runStep, s.timeoutUnit)
+		}(id, job)
+	}
+	return running
+}
+
+// Execute runs ready jobs concurrently, while serializing jobs that target the
+// same repository. The first real failure cancels and drains running siblings.
+func (e Executor) Execute(ctx context.Context, recipe *Recipe, worktrees map[string]string) (Report, error) {
+	if len(recipe.Jobs) == 0 {
+		return Report{Jobs: []JobResult{}}, nil
+	}
+	maxParallel := e.MaxParallel
+	if maxParallel <= 0 {
+		maxParallel = DefaultMaxParallel
+	}
+	if maxParallel > len(recipe.Jobs) {
+		maxParallel = len(recipe.Jobs)
+	}
+	output := e.Output
+	if output == nil {
+		output = io.Discard
+	}
+	runStep := e.RunStep
+	if runStep == nil {
+		runStep = runShellStep
+	}
+	timeoutUnit := e.timeoutUnit
+	if timeoutUnit <= 0 {
+		timeoutUnit = time.Minute
+	}
+	output = &lockedWriter{writer: output}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	state := executionState{
+		executor: e, recipe: recipe, worktrees: worktrees, output: output,
+		runStep: runStep, timeoutUnit: timeoutUnit,
+		pending:      make(map[string]struct{}, len(recipe.Jobs)),
+		completed:    make(map[string]bool, len(recipe.Jobs)),
+		runningRepos: make(map[string]bool, len(recipe.Repositories)),
+		outcomes:     make(chan jobOutcome, len(recipe.Jobs)),
+	}
+	for id := range recipe.Jobs {
+		state.pending[id] = struct{}{}
+	}
+	running := 0
+	results := make(map[string]JobResult, len(recipe.Jobs))
+	var firstFailure *ExecutionError
+
+	for len(state.pending) > 0 || running > 0 {
+		if firstFailure == nil && runCtx.Err() == nil {
+			running = state.startReady(runCtx, running, maxParallel)
+		}
+
+		if running == 0 {
+			if firstFailure != nil {
+				break
+			}
+			if err := runCtx.Err(); err != nil {
+				firstFailure = &ExecutionError{Code: ErrorCancelled, Err: err}
+				break
+			}
+			firstFailure = &ExecutionError{Code: ErrorInvalidGraph, Err: errors.New("Recipe jobs cannot be scheduled")}
+			break
+		}
+
+		outcome := <-state.outcomes
+		running--
+		state.runningRepos[recipe.Jobs[outcome.id].Repository] = false
+		results[outcome.id] = outcome.result
+		if outcome.err != nil {
+			if firstFailure == nil {
+				firstFailure = outcome.err
+				cancel()
+			}
+			continue
+		}
+		state.completed[outcome.id] = true
+	}
+
+	report := Report{Jobs: sortedJobResults(results)}
+	if firstFailure != nil {
+		return report, firstFailure
+	}
+	return report, nil
+}
+
+func (e Executor) runJob(ctx context.Context, id string, job Job, worktree string, output io.Writer, runStep StepRunner, timeoutUnit time.Duration) jobOutcome {
+	result := JobResult{ID: id, Status: "succeeded"}
+	timeout := job.TimeoutMinutes
+	if timeout == 0 {
+		timeout = DefaultJobTimeout
+	}
+	jobCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*timeoutUnit)
+	defer cancel()
+
+	dir, err := resolveWorkingDirectory(worktree, job.WorkingDirectory)
+	if err != nil {
+		result.Status = "failed"
+		stepName := ""
+		if len(job.Steps) > 0 {
+			stepName = job.Steps[0].Name
+		}
+		return jobOutcome{id: id, result: result, err: &ExecutionError{Code: ErrorStepFailed, Job: id, Step: 1, StepName: stepName, Err: err}}
+	}
+	for index, step := range job.Steps {
+		label := step.Name
+		if label == "" {
+			label = "run"
+		}
+		fmt.Fprintf(output, "[%s/%d] %s\n", id, index+1, safeRecipeMetadata(label))
+		prefix := fmt.Sprintf("[%s/%d] ", id, index+1)
+		stepOutput := streamio.New(prefix, output)
+		err := runStep(jobCtx, dir, step.Run, stepOutput)
+		stepOutput.Flush()
+		if err == nil {
+			result.StepsCompleted++
+			continue
+		}
+		result.Status = "failed"
+		code := ErrorStepFailed
+		cause := err
+		if errors.Is(jobCtx.Err(), context.DeadlineExceeded) {
+			code = ErrorJobTimeout
+			cause = fmt.Errorf("timed out after %d minutes", timeout)
+		} else if ctx.Err() != nil {
+			code = ErrorCancelled
+			cause = ctx.Err()
+		}
+		return jobOutcome{id: id, result: result, err: &ExecutionError{Code: code, Job: id, Step: index + 1, StepName: step.Name, Err: cause}}
+	}
+	return jobOutcome{id: id, result: result}
+}
+
+func resolveWorkingDirectory(worktree, relative string) (string, error) {
+	root, err := filepath.EvalSymlinks(worktree)
+	if err != nil {
+		return "", fmt.Errorf("resolving worktree path: %w", err)
+	}
+	candidate := root
+	if relative != "" && relative != "." {
+		candidate = filepath.Join(root, filepath.FromSlash(relative))
+	}
+	resolved, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return "", fmt.Errorf("resolving working-directory: %w", err)
+	}
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("working-directory resolves outside repository worktree")
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("reading working-directory: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("working-directory is not a directory")
+	}
+	return resolved, nil
+}
+
+func safeRecipeMetadata(value string) string {
+	var result strings.Builder
+	for _, char := range value {
+		if char < 0x20 || char == 0x7f || char >= 0x80 && char <= 0x9f {
+			fmt.Fprintf(&result, "\\x%02x", char)
+			continue
+		}
+		result.WriteRune(char)
+	}
+	return result.String()
+}
+
+func runShellStep(ctx context.Context, dir, command string, output io.Writer) error {
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", command)
+	cmd.Dir = dir
+	cmd.Stdin = nil
+	cmd.Stdout = output
+	cmd.Stderr = output
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 2 * time.Second
+	return cmd.Run()
+}
+
+func dependenciesComplete(needs []string, completed map[string]bool) bool {
+	for _, dependency := range needs {
+		if !completed[dependency] {
+			return false
+		}
+	}
+	return true
+}
+
+func sortedPending(pending map[string]struct{}) []string {
+	ids := make([]string, 0, len(pending))
+	for id := range pending {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func sortedJobResults(results map[string]JobResult) []JobResult {
+	ids := make([]string, 0, len(results))
+	for id := range results {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	sorted := make([]JobResult, 0, len(ids))
+	for _, id := range ids {
+		sorted = append(sorted, results[id])
+	}
+	return sorted
+}
+
+type lockedWriter struct {
+	mu     sync.Mutex
+	writer io.Writer
+}
+
+func (w *lockedWriter) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writer.Write(data)
+}

--- a/internal/recipe/executor_test.go
+++ b/internal/recipe/executor_test.go
@@ -1,0 +1,315 @@
+package recipe
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestExecutorRunsNeedsBeforeDependentsAndStepsSequentially(t *testing.T) {
+	recipe := &Recipe{Jobs: map[string]Job{
+		"setup":  {Repository: "api", Steps: []Step{{Run: "one"}, {Run: "two"}}},
+		"verify": {Repository: "api", Needs: []string{"setup"}, Steps: []Step{{Run: "three"}}},
+	}}
+	var mu sync.Mutex
+	var commands []string
+	executor := Executor{RunStep: func(_ context.Context, _, command string, _ io.Writer) error {
+		mu.Lock()
+		commands = append(commands, command)
+		mu.Unlock()
+		return nil
+	}}
+
+	report, err := executor.Execute(context.Background(), recipe, map[string]string{"api": t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"one", "two", "three"}
+	if len(commands) != len(want) {
+		t.Fatalf("commands = %v, want %v", commands, want)
+	}
+	for i := range want {
+		if commands[i] != want[i] {
+			t.Fatalf("commands = %v, want %v", commands, want)
+		}
+	}
+	if len(report.Jobs) != 2 || report.Jobs[0].ID != "setup" || report.Jobs[1].ID != "verify" {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestExecutorParallelizesAcrossRepositoriesButSerializesWithinOne(t *testing.T) {
+	recipe := &Recipe{Jobs: map[string]Job{
+		"api-a": {Repository: "api", Steps: []Step{{Run: "api-a"}}},
+		"api-b": {Repository: "api", Steps: []Step{{Run: "api-b"}}},
+		"web":   {Repository: "web", Steps: []Step{{Run: "web"}}},
+	}}
+	var mu sync.Mutex
+	running := map[string]int{}
+	maxByRepo := map[string]int{}
+	maxGlobal := 0
+	executor := Executor{MaxParallel: 4, RunStep: func(_ context.Context, dir, _ string, _ io.Writer) error {
+		mu.Lock()
+		running[dir]++
+		global := 0
+		for _, count := range running {
+			global += count
+		}
+		if running[dir] > maxByRepo[dir] {
+			maxByRepo[dir] = running[dir]
+		}
+		if global > maxGlobal {
+			maxGlobal = global
+		}
+		mu.Unlock()
+		time.Sleep(30 * time.Millisecond)
+		mu.Lock()
+		running[dir]--
+		mu.Unlock()
+		return nil
+	}}
+	paths := map[string]string{"api": t.TempDir(), "web": t.TempDir()}
+
+	if _, err := executor.Execute(context.Background(), recipe, paths); err != nil {
+		t.Fatal(err)
+	}
+	if maxGlobal < 2 {
+		t.Fatalf("max global concurrency = %d, want at least 2", maxGlobal)
+	}
+	for dir, maxRunning := range maxByRepo {
+		if maxRunning != 1 {
+			t.Fatalf("concurrency for %s = %d, want 1", dir, maxRunning)
+		}
+	}
+}
+
+func TestExecutorUsesLexicalOrderForReadyJobsInSameRepository(t *testing.T) {
+	recipe := &Recipe{Jobs: map[string]Job{
+		"z-last":  {Repository: "api", Steps: []Step{{Run: "z"}}},
+		"a-first": {Repository: "api", Steps: []Step{{Run: "a"}}},
+	}}
+	var commands []string
+	executor := Executor{RunStep: func(_ context.Context, _, command string, _ io.Writer) error {
+		commands = append(commands, command)
+		return nil
+	}}
+	if _, err := executor.Execute(context.Background(), recipe, map[string]string{"api": t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	if len(commands) != 2 || commands[0] != "a" || commands[1] != "z" {
+		t.Fatalf("commands = %v, want [a z]", commands)
+	}
+}
+
+func TestExecutorFailureCancelsQueuedJobsAndIdentifiesStep(t *testing.T) {
+	boom := errors.New("boom")
+	recipe := &Recipe{Jobs: map[string]Job{
+		"setup": {Repository: "api", Steps: []Step{{Name: "Install", Run: "fail"}}},
+		"later": {Repository: "api", Needs: []string{"setup"}, Steps: []Step{{Run: "must-not-run"}}},
+	}}
+	var commands []string
+	executor := Executor{RunStep: func(_ context.Context, _, command string, _ io.Writer) error {
+		commands = append(commands, command)
+		if command == "fail" {
+			return boom
+		}
+		return nil
+	}}
+
+	_, err := executor.Execute(context.Background(), recipe, map[string]string{"api": t.TempDir()})
+	var executionErr *ExecutionError
+	if !errors.As(err, &executionErr) {
+		t.Fatalf("error = %v, want ExecutionError", err)
+	}
+	if executionErr.Code != ErrorStepFailed || executionErr.Job != "setup" || executionErr.Step != 1 || executionErr.StepName != "Install" {
+		t.Fatalf("unexpected execution error: %+v", executionErr)
+	}
+	if len(commands) != 1 || commands[0] != "fail" {
+		t.Fatalf("commands = %v, queued job should not run", commands)
+	}
+}
+
+func TestExecutorEscapesControlCharactersInStepMetadata(t *testing.T) {
+	var output bytes.Buffer
+	recipe := &Recipe{Jobs: map[string]Job{
+		"setup": {Repository: "api", Steps: []Step{{Name: "Build\x1b[31m\u009b", Run: "true"}}},
+	}}
+	executor := Executor{Output: &output, RunStep: func(_ context.Context, _, _ string, _ io.Writer) error { return nil }}
+	if _, err := executor.Execute(context.Background(), recipe, map[string]string{"api": t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.ContainsRune(output.String(), '\x1b') || strings.ContainsRune(output.String(), '\u009b') ||
+		!strings.Contains(output.String(), `\x1b`) || !strings.Contains(output.String(), `\x9b`) {
+		t.Fatalf("metadata was not terminal-safe: %q", output.String())
+	}
+}
+
+func TestExecutorDefaultRunnerUsesWorkingDirectory(t *testing.T) {
+	worktree := t.TempDir()
+	workingDirectory := filepath.Join(worktree, "services", "api")
+	if err := os.MkdirAll(workingDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	recipe := &Recipe{Jobs: map[string]Job{
+		"setup": {Repository: "api", WorkingDirectory: "services/api", Steps: []Step{{Run: "printf ready > marker.txt"}}},
+	}}
+	if _, err := (Executor{}).Execute(context.Background(), recipe, map[string]string{"api": worktree}); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(filepath.Join(workingDirectory, "marker.txt")); err != nil || string(data) != "ready" {
+		t.Fatalf("marker = %q, err=%v", data, err)
+	}
+}
+
+func TestExecutorRejectsWorkingDirectorySymlinkEscape(t *testing.T) {
+	worktree := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(worktree, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	recipe := &Recipe{Jobs: map[string]Job{
+		"setup": {Repository: "api", WorkingDirectory: "escape", Steps: []Step{{Run: "touch escaped"}}},
+	}}
+	_, err := (Executor{}).Execute(context.Background(), recipe, map[string]string{"api": worktree})
+	var executionErr *ExecutionError
+	if !errors.As(err, &executionErr) || executionErr.Code != ErrorStepFailed {
+		t.Fatalf("error = %v, want working-directory ExecutionError", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "escaped")); !os.IsNotExist(err) {
+		t.Fatalf("command escaped worktree: %v", err)
+	}
+}
+
+func TestExecutorTimeoutKillsChildProcessGroup(t *testing.T) {
+	worktree := t.TempDir()
+	pidFile := filepath.Join(worktree, "child.pid")
+	command := "sleep 30 & echo $! > " + pidFile + "; wait"
+	recipe := &Recipe{Jobs: map[string]Job{
+		"slow": {Repository: "api", TimeoutMinutes: 1, Steps: []Step{{Run: command}}},
+	}}
+	executor := Executor{timeoutUnit: 200 * time.Millisecond}
+	_, err := executor.Execute(context.Background(), recipe, map[string]string{"api": worktree})
+	var executionErr *ExecutionError
+	if !errors.As(err, &executionErr) || executionErr.Code != ErrorJobTimeout {
+		t.Fatalf("error = %v, want timeout", err)
+	}
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if err := syscall.Kill(pid, 0); err == nil {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+		t.Fatalf("child process %d survived job timeout", pid)
+	}
+}
+
+func TestExecutorHonorsParentCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	recipe := &Recipe{Jobs: map[string]Job{
+		"setup": {Repository: "api", Steps: []Step{{Run: "must-not-run"}}},
+	}}
+	ran := false
+	executor := Executor{RunStep: func(_ context.Context, _, _ string, _ io.Writer) error {
+		ran = true
+		return nil
+	}}
+	_, err := executor.Execute(ctx, recipe, map[string]string{"api": t.TempDir()})
+	var executionErr *ExecutionError
+	if !errors.As(err, &executionErr) || executionErr.Code != ErrorCancelled || ran {
+		t.Fatalf("error=%v ran=%v, want cancellation before execution", err, ran)
+	}
+}
+
+func TestExecutorCancellationStopsRunningSibling(t *testing.T) {
+	recipe := &Recipe{Jobs: map[string]Job{
+		"fail": {Repository: "api", Steps: []Step{{Run: "fail"}}},
+		"slow": {Repository: "web", Steps: []Step{{Run: "slow"}}},
+	}}
+	slowCancelled := make(chan struct{}, 1)
+	executor := Executor{RunStep: func(ctx context.Context, _, command string, _ io.Writer) error {
+		if command == "fail" {
+			time.Sleep(20 * time.Millisecond)
+			return errors.New("boom")
+		}
+		<-ctx.Done()
+		slowCancelled <- struct{}{}
+		return ctx.Err()
+	}}
+	_, err := executor.Execute(context.Background(), recipe, map[string]string{"api": t.TempDir(), "web": t.TempDir()})
+	var executionErr *ExecutionError
+	if !errors.As(err, &executionErr) || executionErr.Job != "fail" {
+		t.Fatalf("error = %v, want original failing job", err)
+	}
+	select {
+	case <-slowCancelled:
+	case <-time.After(time.Second):
+		t.Fatal("running sibling was not cancelled")
+	}
+}
+
+func TestExecutorEnforcesDefaultConcurrencyLimit(t *testing.T) {
+	jobs := make(map[string]Job)
+	worktrees := make(map[string]string)
+	for i := 0; i < 8; i++ {
+		id := fmt.Sprintf("job-%d", i)
+		repoID := fmt.Sprintf("repo-%d", i)
+		jobs[id] = Job{Repository: repoID, Steps: []Step{{Run: id}}}
+		worktrees[repoID] = t.TempDir()
+	}
+	var mu sync.Mutex
+	running, maxRunning := 0, 0
+	executor := Executor{RunStep: func(_ context.Context, _, _ string, _ io.Writer) error {
+		mu.Lock()
+		running++
+		if running > maxRunning {
+			maxRunning = running
+		}
+		mu.Unlock()
+		time.Sleep(30 * time.Millisecond)
+		mu.Lock()
+		running--
+		mu.Unlock()
+		return nil
+	}}
+	if _, err := executor.Execute(context.Background(), &Recipe{Jobs: jobs}, worktrees); err != nil {
+		t.Fatal(err)
+	}
+	if maxRunning != DefaultMaxParallel {
+		t.Fatalf("max concurrency = %d, want %d", maxRunning, DefaultMaxParallel)
+	}
+}
+
+func TestExecutorTimesOutJob(t *testing.T) {
+	recipe := &Recipe{Jobs: map[string]Job{
+		"slow": {Repository: "api", TimeoutMinutes: 1, Steps: []Step{{Run: "wait"}}},
+	}}
+	executor := Executor{
+		timeoutUnit: 10 * time.Millisecond,
+		RunStep: func(ctx context.Context, _, _ string, _ io.Writer) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	_, err := executor.Execute(context.Background(), recipe, map[string]string{"api": t.TempDir()})
+	var executionErr *ExecutionError
+	if !errors.As(err, &executionErr) || executionErr.Code != ErrorJobTimeout {
+		t.Fatalf("error = %v, want timeout ExecutionError", err)
+	}
+}

--- a/internal/recipe/model.go
+++ b/internal/recipe/model.go
@@ -30,6 +30,7 @@ type Repository struct {
 type Job struct {
 	Repository       string   `yaml:"repository" json:"repository"`
 	WorkingDirectory string   `yaml:"working-directory,omitempty" json:"working_directory,omitempty"`
+	TimeoutMinutes   int      `yaml:"timeout-minutes,omitempty" json:"timeout_minutes,omitempty"`
 	Needs            []string `yaml:"needs,omitempty" json:"needs,omitempty"`
 	Steps            []Step   `yaml:"steps" json:"steps"`
 }

--- a/internal/recipe/parse.go
+++ b/internal/recipe/parse.go
@@ -232,6 +232,7 @@ func validateJobTypes(job *yaml.Node, basePath string, errors *[]ValidationError
 	}
 	validateScalarField(job, "repository", basePath, "!!str", "string", errors)
 	validateScalarField(job, "working-directory", basePath, "!!str", "string", errors)
+	validateScalarField(job, "timeout-minutes", basePath, "!!int", "integer", errors)
 
 	needs := mappingValue(job, "needs")
 	if needs != nil && requireNodeType(needs, basePath+".needs", yaml.SequenceNode, "sequence", errors) {
@@ -304,7 +305,7 @@ func validateKnownFields(root *yaml.Node, locations map[string]location) []Valid
 			id := jobs.Content[i].Value
 			jobPath := "jobs." + id
 			jobNode := jobs.Content[i+1]
-			checkAllowedFields(jobNode, jobPath, set("repository", "working-directory", "needs", "steps"), &errors)
+			checkAllowedFields(jobNode, jobPath, set("repository", "working-directory", "timeout-minutes", "needs", "steps"), &errors)
 			if steps := mappingValue(jobNode, "steps"); steps != nil && steps.Kind == yaml.SequenceNode {
 				for index, step := range steps.Content {
 					checkAllowedFields(step, fmt.Sprintf("%s.steps[%d]", jobPath, index), set("name", "run"), &errors)

--- a/internal/recipe/recipe_test.go
+++ b/internal/recipe/recipe_test.go
@@ -46,6 +46,17 @@ func TestParseValidRecipe(t *testing.T) {
 	}
 }
 
+func TestParseJobTimeout(t *testing.T) {
+	input := strings.Replace(validRecipe, "needs: [setup-api]", "timeout-minutes: 30\n    needs: [setup-api]", 1)
+	result := Parse([]byte(input))
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected errors: %+v", result.Errors)
+	}
+	if got := result.Recipe.Jobs["verify"].TimeoutMinutes; got != 30 {
+		t.Fatalf("timeout-minutes = %d, want 30", got)
+	}
+}
+
 func TestGenericExample(t *testing.T) {
 	data, err := os.ReadFile("../../examples/recipes/example-stack.yaml")
 	if err != nil {
@@ -103,6 +114,7 @@ func TestParseRejectsIncorrectSchemaTypes(t *testing.T) {
 		strings.Replace(validRecipe, "url: https://github.com/acme/example-app.git", "url: true", 1),
 		strings.Replace(validRecipe, "ref: main", "ref: null", 1),
 		strings.Replace(validRecipe, "needs: [setup-api]", "needs: setup-api", 1),
+		strings.Replace(validRecipe, "needs: [setup-api]", "timeout-minutes: '30'\n    needs: [setup-api]", 1),
 		strings.Replace(validRecipe, "run: make check", "run: 123", 1),
 		strings.SplitN(validRecipe, "jobs:", 2)[0] + "jobs: null\n",
 	}
@@ -148,6 +160,8 @@ func TestParseRejectsInvalidRecipeSemantics(t *testing.T) {
 		{"duplicate dependency", strings.Replace(validRecipe, "needs: [setup-api]", "needs: [setup-api, setup-api]", 1), "duplicate_dependency"},
 		{"escaping working directory", strings.Replace(validRecipe, "services/api", "../../outside", 1), "invalid_path"},
 		{"unclean working directory", strings.Replace(validRecipe, "services/api", "services/../api", 1), "invalid_path"},
+		{"zero timeout", strings.Replace(validRecipe, "needs: [setup-api]", "timeout-minutes: 0\n    needs: [setup-api]", 1), "invalid_range"},
+		{"excessive timeout", strings.Replace(validRecipe, "needs: [setup-api]", "timeout-minutes: 361\n    needs: [setup-api]", 1), "invalid_range"},
 		{"empty steps", strings.Replace(validRecipe, "steps:\n      - name: Install\n        run: make setup", "steps: []", 1), "required"},
 		{"empty command", strings.Replace(validRecipe, "run: make check", "run: '  '", 1), "required"},
 	}

--- a/internal/recipe/validate.go
+++ b/internal/recipe/validate.go
@@ -81,6 +81,9 @@ func validateJob(id string, job Job, recipe *Recipe, validator *validator) {
 	if !validWorkingDirectory(job.WorkingDirectory) {
 		validator.add("invalid_path", basePath+".working-directory", "working-directory must be a relative path inside the repository")
 	}
+	if _, present := validator.locations[basePath+".timeout-minutes"]; present && (job.TimeoutMinutes < 1 || job.TimeoutMinutes > 360) {
+		validator.add("invalid_range", basePath+".timeout-minutes", "timeout-minutes must be between 1 and 360")
+	}
 	validateSteps(job.Steps, basePath, validator)
 	validateDependencies(id, job.Needs, recipe.Jobs, basePath, validator)
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -53,6 +54,27 @@ type CreateOpts struct {
 	Source *models.WorkspaceSource
 }
 
+// PreparationOpts configures a workspace whose exact bases are already resolved.
+type PreparationOpts struct {
+	CreateOpts
+	BaseCommits map[string]string
+}
+
+// PreparationError preserves the original preparation failure and any cleanup failure.
+type PreparationError struct {
+	Cause      error
+	CleanupErr error
+}
+
+func (e *PreparationError) Error() string {
+	if e.CleanupErr != nil {
+		return fmt.Sprintf("preparing workspace: %s; cleanup failed: %s", e.Cause, e.CleanupErr)
+	}
+	return fmt.Sprintf("preparing workspace: %s", e.Cause)
+}
+
+func (e *PreparationError) Unwrap() error { return e.Cause }
+
 // Create creates a new workspace with worktrees for the given repos.
 // repoMap is name→source_path. It preserves the historical positional signature
 // by delegating to CreateWithOpts.
@@ -84,19 +106,64 @@ func (s *Service) CreateWithOpts(name string, opts CreateOpts) error {
 		console.Infof("running setup hooks...")
 	}
 	s.runSetupHooks(ws)
-
-	s.Stats.RecordCreated(ws)
-	logging.Info("workspace %q created at %s", name, ws.Path)
-	console.Successf("Workspace %s created at %s", name, ws.Path)
-
-	if cdFile := os.Getenv("GROVE_CD_FILE"); cdFile != "" {
-		os.WriteFile(cdFile, []byte(ws.Path), 0o644)
-	}
-
+	s.finishCreate(ws)
 	return nil
 }
 
+// CreateWithPreparation provisions exact Recipe bases, runs prepare outside the
+// mutation lock, and rolls back only resources owned by this invocation.
+func (s *Service) CreateWithPreparation(name string, opts PreparationOpts, prepare func(models.Workspace) error) error {
+	var created creationResult
+	if err := s.State.WithLock(func() error {
+		var err error
+		created, err = s.createWithOptsLockedDetailed(name, opts.CreateOpts, creationSettings{
+			skipFetch:   true,
+			baseCommits: opts.BaseCommits,
+		})
+		return err
+	}); err != nil {
+		return err
+	}
+
+	if err := prepare(created.workspace); err != nil {
+		cleanupErr := s.rollbackPreparation(created)
+		return &PreparationError{Cause: err, CleanupErr: cleanupErr}
+	}
+	if err := s.verifyPreparationState(created.workspace); err != nil {
+		return &PreparationError{Cause: err, CleanupErr: err}
+	}
+	if err := verifyProvisionedWorktreeIdentity(created.provisioned); err != nil {
+		return &PreparationError{Cause: err, CleanupErr: err}
+	}
+	s.finishCreate(created.workspace)
+	return nil
+}
+
+func (s *Service) finishCreate(ws models.Workspace) {
+	s.Stats.RecordCreated(ws)
+	logging.Info("workspace %q created at %s", ws.Name, ws.Path)
+	console.Successf("Workspace %s created at %s", ws.Name, ws.Path)
+	if cdFile := os.Getenv("GROVE_CD_FILE"); cdFile != "" {
+		_ = os.WriteFile(cdFile, []byte(ws.Path), 0o644)
+	}
+}
+
+type creationSettings struct {
+	skipFetch   bool
+	baseCommits map[string]string
+}
+
+type creationResult struct {
+	workspace   models.Workspace
+	provisioned []provisionedRepo
+}
+
 func (s *Service) createWithOptsLocked(name string, opts CreateOpts) (models.Workspace, error) {
+	created, err := s.createWithOptsLockedDetailed(name, opts, creationSettings{})
+	return created.workspace, err
+}
+
+func (s *Service) createWithOptsLockedDetailed(name string, opts CreateOpts, settings creationSettings) (creationResult, error) {
 	branch := opts.Branch
 	repoNames := opts.Repos
 	repoMap := opts.RepoMap
@@ -104,51 +171,65 @@ func (s *Service) createWithOptsLocked(name string, opts CreateOpts) (models.Wor
 
 	existing, err := s.State.GetWorkspace(name)
 	if err != nil {
-		return models.Workspace{}, err
+		return creationResult{}, err
 	}
 	if existing != nil {
-		return models.Workspace{}, fmt.Errorf("workspace %s already exists", name)
+		return creationResult{}, fmt.Errorf("workspace %s already exists", name)
 	}
 
 	logging.Info("creating workspace %q (branch=%s, repos=%v)", name, branch, repoNames)
 
 	if err := os.MkdirAll(cfg.WorkspaceDir, 0o755); err != nil {
-		return models.Workspace{}, fmt.Errorf("creating workspace parent: %w", err)
+		return creationResult{}, fmt.Errorf("creating workspace parent: %w", err)
 	}
 	wsPath := filepath.Join(cfg.WorkspaceDir, name)
 	if err := os.Mkdir(wsPath, 0o755); err != nil {
-		return models.Workspace{}, fmt.Errorf("creating workspace dir: %w", err)
+		return creationResult{}, fmt.Errorf("creating workspace dir: %w", err)
 	}
 
 	ws := models.NewWorkspace(name, wsPath, branch)
 	ws.Source = opts.Source
 
-	// Validate all repo names first
+	// Validate all repo names and exact bases before provisioning.
 	sourcePaths := make([]string, len(repoNames))
+	baseCommits := make([]string, len(repoNames))
 	for i, repoName := range repoNames {
 		sourcePath, ok := repoMap[repoName]
 		if !ok {
-			return models.Workspace{}, errors.Join(
+			return creationResult{}, errors.Join(
 				fmt.Errorf("repo %s not found", repoName),
 				removeEmptyDir(wsPath),
 			)
 		}
 		sourcePaths[i] = sourcePath
+		if settings.baseCommits != nil {
+			base, ok := settings.baseCommits[repoName]
+			if !ok || base == "" {
+				return creationResult{}, errors.Join(
+					fmt.Errorf("repo %s has no resolved base commit", repoName),
+					removeEmptyDir(wsPath),
+				)
+			}
+			baseCommits[i] = base
+		}
 	}
 
-	// Phase 1: parallel fetch (the slow network part)
-	console.Infof("fetching %d repos...", len(repoNames))
-	var fetchWg sync.WaitGroup
-	for i, repoName := range repoNames {
-		fetchWg.Add(1)
-		go func(source, name string) {
-			defer fetchWg.Done()
-			if err := gitops.Fetch(source); err != nil {
-				console.Warningf("  %s: fetch failed, using local state", name)
-			}
-		}(sourcePaths[i], repoName)
+	// Phase 1: parallel fetch (the slow network part). Recipe creation resolves
+	// and fetches exact commits before acquiring the mutation lock.
+	if !settings.skipFetch {
+		console.Infof("fetching %d repos...", len(repoNames))
+		var fetchWg sync.WaitGroup
+		for i, repoName := range repoNames {
+			fetchWg.Add(1)
+			go func(source, name string) {
+				defer fetchWg.Done()
+				if err := gitops.Fetch(source); err != nil {
+					console.Warningf("  %s: fetch failed, using local state", name)
+				}
+			}(sourcePaths[i], repoName)
+		}
+		fetchWg.Wait()
 	}
-	fetchWg.Wait()
 
 	// Phase 2: sequential worktree creation (for rollback safety)
 	var created []provisionedRepo
@@ -158,10 +239,10 @@ func (s *Service) createWithOptsLocked(name string, opts CreateOpts) (models.Wor
 		if opts.TrackBranchRepo != "" && repoName != opts.TrackBranchRepo {
 			mode = BranchModeCreate
 		}
-		provisioned, err := provisionWorktreeNoFetch(sourcePaths[i], repoName, wsPath, branch, mode)
+		provisioned, err := provisionWorktreeNoFetch(sourcePaths[i], repoName, wsPath, branch, mode, baseCommits[i])
 		if err != nil {
 			logging.Error("workspace creation failed for %q — rolling back", name)
-			return models.Workspace{}, errors.Join(
+			return creationResult{}, errors.Join(
 				fmt.Errorf("provisioning %s: %w", repoName, err),
 				s.rollback(created),
 				removeEmptyDir(wsPath),
@@ -172,11 +253,11 @@ func (s *Service) createWithOptsLocked(name string, opts CreateOpts) (models.Wor
 	}
 
 	if err := s.State.AddWorkspace(ws); err != nil {
-		return models.Workspace{}, errors.Join(err, s.rollback(created), removeEmptyDir(wsPath))
+		return creationResult{}, errors.Join(err, s.rollback(created), removeEmptyDir(wsPath))
 	}
 
 	writeMCPConfig(ws)
-	return ws, nil
+	return creationResult{workspace: ws, provisioned: created}, nil
 }
 
 type provisionedRepo struct {
@@ -186,10 +267,10 @@ type provisionedRepo struct {
 
 func provisionWorktree(sourcePath, repoName, wsPath, branch string) (*provisionedRepo, error) {
 	_ = gitops.Fetch(sourcePath)
-	return provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch, BranchModeCreate)
+	return provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch, BranchModeCreate, "")
 }
 
-func provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch string, mode BranchMode) (*provisionedRepo, error) {
+func provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch string, mode BranchMode, exactBase string) (*provisionedRepo, error) {
 	wtPath := filepath.Join(wsPath, repoName)
 
 	hasWT, _ := gitops.WorktreeHasBranch(sourcePath, branch)
@@ -223,22 +304,9 @@ func provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch string, mode 
 		console.Warningf("%s: remote branch %s not found — creating a new branch from base instead", repoName, branch)
 	}
 
-	branchCreated := false
-	if !gitops.BranchExists(sourcePath, branch) {
-		base, err := gitops.ResolveBaseBranch(sourcePath)
-		if err != nil {
-			base = "HEAD"
-		}
-		logging.Info("creating branch %q in %s from %s", branch, repoName, base)
-		if err := gitops.CreateBranch(sourcePath, branch, base); err != nil {
-			plainBase := strings.TrimPrefix(base, "origin/")
-			if err2 := gitops.CreateBranch(sourcePath, branch, plainBase); err2 != nil {
-				if err3 := gitops.CreateBranch(sourcePath, branch, "HEAD"); err3 != nil {
-					return nil, fmt.Errorf("creating branch: %w", err)
-				}
-			}
-		}
-		branchCreated = true
+	branchCreated, err := ensureWorkspaceBranch(sourcePath, repoName, branch, exactBase)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := gitops.WorktreeAdd(sourcePath, wtPath, branch); err != nil {
@@ -253,13 +321,49 @@ func provisionWorktreeNoFetch(sourcePath, repoName, wsPath, branch string, mode 
 
 	return &provisionedRepo{
 		worktree: models.RepoWorktree{
-			RepoName:     repoName,
-			SourceRepo:   sourcePath,
-			WorktreePath: wtPath,
-			Branch:       branch,
+			RepoName:       repoName,
+			SourceRepo:     sourcePath,
+			WorktreePath:   wtPath,
+			Branch:         branch,
+			PreserveBranch: exactBase != "" && !branchCreated,
 		},
 		branchCreated: branchCreated,
 	}, nil
+}
+
+func ensureWorkspaceBranch(sourcePath, repoName, branch, exactBase string) (bool, error) {
+	if gitops.BranchExists(sourcePath, branch) {
+		if exactBase == "" {
+			return false, nil
+		}
+		branchCommit, err := gitops.LocalBranchCommit(sourcePath, branch)
+		if err != nil || branchCommit != exactBase {
+			return false, fmt.Errorf("branch %s already exists at a different commit", branch)
+		}
+		return false, nil
+	}
+
+	base := exactBase
+	if base == "" {
+		var err error
+		base, err = gitops.ResolveBaseBranch(sourcePath)
+		if err != nil {
+			base = "HEAD"
+		}
+	}
+	logging.Info("creating branch %q in %s from %s", branch, repoName, base)
+	if err := gitops.CreateBranch(sourcePath, branch, base); err != nil {
+		if exactBase != "" {
+			return false, fmt.Errorf("creating branch from exact base %s: %w", exactBase, err)
+		}
+		plainBase := strings.TrimPrefix(base, "origin/")
+		if err2 := gitops.CreateBranch(sourcePath, branch, plainBase); err2 != nil {
+			if err3 := gitops.CreateBranch(sourcePath, branch, "HEAD"); err3 != nil {
+				return false, fmt.Errorf("creating branch: %w", err)
+			}
+		}
+	}
+	return true, nil
 }
 
 func (s *Service) rollback(repos []provisionedRepo) error {
@@ -274,6 +378,107 @@ func (s *Service) rollback(repos []provisionedRepo) error {
 			if err := gitops.DeleteBranch(repo.worktree.SourceRepo, repo.worktree.Branch, true); err != nil {
 				errs = append(errs, fmt.Errorf("%s: rolling back branch: %w", repo.worktree.RepoName, err))
 			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (s *Service) verifyPreparationState(expected models.Workspace) error {
+	return s.State.WithLock(func() error {
+		current, err := s.State.GetWorkspace(expected.Name)
+		if err != nil {
+			return err
+		}
+		if current == nil || !reflect.DeepEqual(*current, expected) {
+			return fmt.Errorf("workspace state changed during preparation")
+		}
+		return nil
+	})
+}
+
+func (s *Service) rollbackPreparation(created creationResult) error {
+	return s.State.WithLock(func() error {
+		current, err := s.State.GetWorkspace(created.workspace.Name)
+		if err != nil {
+			return err
+		}
+		if current == nil || !reflect.DeepEqual(*current, created.workspace) {
+			return fmt.Errorf("workspace state changed during preparation; refusing automatic cleanup")
+		}
+		if err := verifyProvisionedWorktreeIdentity(created.provisioned); err != nil {
+			return err
+		}
+
+		failedWorktrees := make(map[string]bool)
+		var cleanupErrs []error
+		for i := len(created.provisioned) - 1; i >= 0; i-- {
+			repo := created.provisioned[i]
+			if err := s.removeWorktree(repo.worktree.SourceRepo, repo.worktree.WorktreePath, true); err != nil {
+				failedWorktrees[repo.worktree.WorktreePath] = true
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("%s: rolling back worktree: %w", repo.worktree.RepoName, err))
+				continue
+			}
+			if repo.branchCreated {
+				if err := gitops.DeleteBranch(repo.worktree.SourceRepo, repo.worktree.Branch, true); err != nil {
+					cleanupErrs = append(cleanupErrs, fmt.Errorf("%s: rolling back branch: %w", repo.worktree.RepoName, err))
+				}
+			}
+		}
+
+		if len(failedWorktrees) > 0 {
+			remaining := make([]models.RepoWorktree, 0, len(failedWorktrees))
+			for _, repo := range current.Repos {
+				if failedWorktrees[repo.WorktreePath] {
+					remaining = append(remaining, repo)
+				}
+			}
+			current.Repos = remaining
+			if err := s.State.UpdateWorkspace(*current); err != nil {
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("updating state after cleanup failure: %w", err))
+			}
+			return errors.Join(cleanupErrs...)
+		}
+
+		removeMCPConfig(*current)
+		if err := os.Remove(current.Path); err != nil && !os.IsNotExist(err) {
+			current.Repos = nil
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("removing workspace root %s: %w", current.Path, err))
+			if stateErr := s.State.UpdateWorkspace(*current); stateErr != nil {
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("updating state after root cleanup failure: %w", stateErr))
+			}
+			return errors.Join(cleanupErrs...)
+		}
+		if err := s.State.RemoveWorkspace(current.Name); err != nil {
+			cleanupErrs = append(cleanupErrs, err)
+		}
+		return errors.Join(cleanupErrs...)
+	})
+}
+
+func verifyProvisionedWorktreeIdentity(repos []provisionedRepo) error {
+	var errs []error
+	for _, provisioned := range repos {
+		repo := provisioned.worktree
+		entries, err := gitops.WorktreeList(repo.SourceRepo)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: reading worktree registration: %w", repo.RepoName, err))
+			continue
+		}
+		expectedPath := canonicalPath(repo.WorktreePath)
+		registered := false
+		for _, entry := range entries {
+			if canonicalPath(entry.Path) == expectedPath && entry.Branch == repo.Branch {
+				registered = true
+				break
+			}
+		}
+		if !registered {
+			errs = append(errs, fmt.Errorf("%s: worktree identity changed; refusing automatic cleanup", repo.RepoName))
+			continue
+		}
+		branch, err := gitops.CurrentBranch(repo.WorktreePath)
+		if err != nil || branch != repo.Branch {
+			errs = append(errs, fmt.Errorf("%s: current branch changed; refusing automatic cleanup", repo.RepoName))
 		}
 	}
 	return errors.Join(errs...)
@@ -501,6 +706,10 @@ func (s *Service) removeWorktree(repo, path string, force bool) error {
 }
 
 func (s *Service) deleteBranch(repo models.RepoWorktree, force bool) {
+	if repo.PreserveBranch {
+		logging.Info("preserving pre-existing branch %q in %s", repo.Branch, repo.RepoName)
+		return
+	}
 	if err := gitops.DeleteBranch(repo.SourceRepo, repo.Branch, force); err != nil {
 		logging.Warn("failed to delete branch %q in %s: %s", repo.Branch, repo.RepoName, err)
 		console.Warningf("%s: failed to delete branch %s: %s", repo.RepoName, repo.Branch, err)

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -156,6 +157,173 @@ func TestCreateSuccess(t *testing.T) {
 	branch := env.run(filepath.Join(env.wsDir, "test-ws", "api"), "git", "branch", "--show-current")
 	if branch != "feat/test" {
 		t.Errorf("expected branch feat/test, got %s", branch)
+	}
+}
+
+func TestCreateWithPreparationUsesExactCommitOutsideLockAndSkipsSetup(t *testing.T) {
+	env := setupTestEnv(t)
+	repo := env.createRepo("api")
+	baseSHA := env.run(repo, "git", "rev-parse", "HEAD")
+	setupMarker := filepath.Join(env.dir, "legacy-setup-ran")
+	os.WriteFile(filepath.Join(repo, ".grove.toml"), []byte("setup = \"touch "+setupMarker+"\"\n"), 0o644)
+	os.WriteFile(filepath.Join(repo, "later.txt"), []byte("later"), 0o644)
+	env.run(repo, "git", "add", ".")
+	env.run(repo, "git", "commit", "-q", "-m", "later")
+
+	var preparedPath string
+	err := env.svc.CreateWithPreparation("prepared", PreparationOpts{
+		CreateOpts:  CreateOpts{Branch: "feat/prepared", Repos: []string{"api"}, RepoMap: env.repoMap, Cfg: env.cfg},
+		BaseCommits: map[string]string{"api": baseSHA},
+	}, func(ws models.Workspace) error {
+		if err := env.svc.State.WithLock(func() error { return nil }); err != nil {
+			return fmt.Errorf("acquiring state lock from preparation: %w", err)
+		}
+		preparedPath = ws.Repos[0].WorktreePath
+		if got := env.run(preparedPath, "git", "rev-parse", "HEAD"); got != baseSHA {
+			return fmt.Errorf("worktree HEAD = %s, want %s", got, baseSHA)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preparedPath == "" {
+		t.Fatal("preparation callback did not run")
+	}
+	if _, err := os.Stat(setupMarker); !os.IsNotExist(err) {
+		t.Fatalf("legacy setup hook ran during Recipe creation: %v", err)
+	}
+}
+
+func TestCreateWithPreparationFailurePreservesPreexistingBranch(t *testing.T) {
+	env := setupTestEnv(t)
+	repo := env.createRepo("api")
+	baseSHA := env.run(repo, "git", "rev-parse", "HEAD")
+	env.run(repo, "git", "branch", "feat/existing", baseSHA)
+	boom := errors.New("prepare failed")
+
+	err := env.svc.CreateWithPreparation("prepared", PreparationOpts{
+		CreateOpts:  CreateOpts{Branch: "feat/existing", Repos: []string{"api"}, RepoMap: env.repoMap, Cfg: env.cfg},
+		BaseCommits: map[string]string{"api": baseSHA},
+	}, func(models.Workspace) error { return boom })
+	var preparationErr *PreparationError
+	if !errors.As(err, &preparationErr) || !errors.Is(err, boom) {
+		t.Fatalf("error = %v, want PreparationError wrapping callback failure", err)
+	}
+	if !gitops.BranchExists(repo, "feat/existing") {
+		t.Fatal("pre-existing branch was deleted")
+	}
+	if ws, _ := env.svc.State.GetWorkspace("prepared"); ws != nil {
+		t.Fatalf("failed preparation remained in state: %+v", ws)
+	}
+	if _, err := os.Stat(filepath.Join(env.wsDir, "prepared")); !os.IsNotExist(err) {
+		t.Fatalf("workspace directory remained after rollback: %v", err)
+	}
+}
+
+func TestDeletePreparedWorkspacePreservesPreexistingBranch(t *testing.T) {
+	env := setupTestEnv(t)
+	repo := env.createRepo("api")
+	baseSHA := env.run(repo, "git", "rev-parse", "HEAD")
+	env.run(repo, "git", "branch", "feat/existing", baseSHA)
+
+	if err := env.svc.CreateWithPreparation("prepared", PreparationOpts{
+		CreateOpts:  CreateOpts{Branch: "feat/existing", Repos: []string{"api"}, RepoMap: env.repoMap, Cfg: env.cfg},
+		BaseCommits: map[string]string{"api": baseSHA},
+	}, func(models.Workspace) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.svc.DeleteWithOptions("prepared", RemoveOptions{Force: true}); err != nil {
+		t.Fatal(err)
+	}
+	if !gitops.BranchExists(repo, "feat/existing") {
+		t.Fatal("normal workspace deletion removed pre-existing Recipe branch")
+	}
+}
+
+func TestCreateWithPreparationFailureRemovesOwnedBranch(t *testing.T) {
+	env := setupTestEnv(t)
+	repo := env.createRepo("api")
+	baseSHA := env.run(repo, "git", "rev-parse", "HEAD")
+
+	_ = env.svc.CreateWithPreparation("prepared", PreparationOpts{
+		CreateOpts:  CreateOpts{Branch: "feat/owned", Repos: []string{"api"}, RepoMap: env.repoMap, Cfg: env.cfg},
+		BaseCommits: map[string]string{"api": baseSHA},
+	}, func(models.Workspace) error { return errors.New("prepare failed") })
+	if gitops.BranchExists(repo, "feat/owned") {
+		t.Fatal("branch created by failed preparation was preserved")
+	}
+}
+
+func TestCreateWithPreparationRejectsSuccessfulIdentityChange(t *testing.T) {
+	env := setupTestEnv(t)
+	repo := env.createRepo("api")
+	baseSHA := env.run(repo, "git", "rev-parse", "HEAD")
+
+	err := env.svc.CreateWithPreparation("prepared", PreparationOpts{
+		CreateOpts:  CreateOpts{Branch: "feat/prepared", Repos: []string{"api"}, RepoMap: env.repoMap, Cfg: env.cfg},
+		BaseCommits: map[string]string{"api": baseSHA},
+	}, func(ws models.Workspace) error {
+		env.run(ws.Repos[0].WorktreePath, "git", "checkout", "--detach")
+		return nil
+	})
+	var preparationErr *PreparationError
+	if !errors.As(err, &preparationErr) || preparationErr.CleanupErr == nil {
+		t.Fatalf("error = %v, want identity verification failure", err)
+	}
+	if ws, _ := env.svc.State.GetWorkspace("prepared"); ws == nil {
+		t.Fatal("changed worktree state should remain recoverable")
+	}
+}
+
+func TestCreateWithPreparationRefusesRollbackAfterWorktreeIdentityChanges(t *testing.T) {
+	env := setupTestEnv(t)
+	repo := env.createRepo("api")
+	baseSHA := env.run(repo, "git", "rev-parse", "HEAD")
+
+	err := env.svc.CreateWithPreparation("prepared", PreparationOpts{
+		CreateOpts:  CreateOpts{Branch: "feat/prepared", Repos: []string{"api"}, RepoMap: env.repoMap, Cfg: env.cfg},
+		BaseCommits: map[string]string{"api": baseSHA},
+	}, func(ws models.Workspace) error {
+		env.run(ws.Repos[0].WorktreePath, "git", "checkout", "--detach")
+		return errors.New("prepare failed")
+	})
+	var preparationErr *PreparationError
+	if !errors.As(err, &preparationErr) || preparationErr.CleanupErr == nil {
+		t.Fatalf("error = %v, want identity cleanup refusal", err)
+	}
+	if ws, _ := env.svc.State.GetWorkspace("prepared"); ws == nil {
+		t.Fatal("workspace state was removed after worktree identity changed")
+	}
+	if _, err := os.Stat(filepath.Join(env.wsDir, "prepared", "api")); err != nil {
+		t.Fatalf("changed worktree was removed: %v", err)
+	}
+}
+
+func TestCreateWithPreparationRefusesRollbackAfterStateChanges(t *testing.T) {
+	env := setupTestEnv(t)
+	repo := env.createRepo("api")
+	baseSHA := env.run(repo, "git", "rev-parse", "HEAD")
+
+	err := env.svc.CreateWithPreparation("prepared", PreparationOpts{
+		CreateOpts:  CreateOpts{Branch: "feat/prepared", Repos: []string{"api"}, RepoMap: env.repoMap, Cfg: env.cfg},
+		BaseCommits: map[string]string{"api": baseSHA},
+	}, func(ws models.Workspace) error {
+		ws.Branch = "concurrently-changed"
+		if err := env.svc.State.UpdateWorkspace(ws); err != nil {
+			return err
+		}
+		return errors.New("prepare failed")
+	})
+	var preparationErr *PreparationError
+	if !errors.As(err, &preparationErr) || preparationErr.CleanupErr == nil {
+		t.Fatalf("error = %v, want cleanup refusal", err)
+	}
+	if ws, _ := env.svc.State.GetWorkspace("prepared"); ws == nil || ws.Branch != "concurrently-changed" {
+		t.Fatalf("changed workspace state was removed: %+v", ws)
+	}
+	if _, err := os.Stat(filepath.Join(env.wsDir, "prepared", "api")); err != nil {
+		t.Fatalf("worktree was removed despite changed state: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `gw create NAME --branch BRANCH --recipe recipe.yaml [--json]`
- resolve Recipe remotes canonically, fetch required refs, and freeze branches/tags/object IDs to exact commit SHAs before workspace mutation
- reuse matching clones or clone through invocation-owned temporary directories with atomic publication
- run the bounded Recipe DAG outside Grove's mutation lock: four jobs globally, one per repository, sequential steps, `needs`, per-job timeouts, prefixed output, and best-effort process-group cancellation
- skip legacy `.grove.toml` setup for Recipe creates so the Recipe owns the bake; retain ordinary create/Preset behavior
- rollback failed preparation only after verifying persisted state and every worktree path/branch identity; preserve pre-existing branches in persisted workspace state
- provide stable human/JSON job and step failures, including cleanup and `post_create` outcomes
- document the trusted-code boundary and cold Recipe execution contract

## Safety boundaries

- `--recipe` rejects `--repos`, `--preset`, `--all`, `--replace`, `--track`, and `--force`
- explicit Recipe refs never fall back to local branches or `HEAD`
- changed state/worktree identity causes rollback to fail closed instead of guessing ownership
- Recipes are trusted shell code; working-directory containment is not a sandbox

## Verification

- `PATH="$(go env GOPATH)/bin:$PATH" just check`
- `go test -race ./internal/recipe ./internal/workspace ./cmd ./internal/gitops`
- `just e2e` — 128/128 passed
- ignored private Recipe still validates without entering git
- independent final review: PASS

Closes #76
