### PR TITLE
feat: add local Recipe Oven

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Full documentation lives in the [OpenWiki](openwiki/quickstart.md) — start wit
 
 - [Hooks](docs/hooks.md) — global hooks (terminal integration) & per-repo hooks (`.grove.toml`, `gw run`)
 - [Plugins](docs/plugins.md) — extend gw with external commands
-- [Recipes](docs/recipe-v1.md) — strict schema, [workspace creation](docs/recipe-execution.md), and the [prepared-claim spike](docs/prepared-workspace-claim-spike.md)
+- [Recipes](docs/recipe-v1.md) — strict schema, [workspace creation](docs/recipe-execution.md), the [local Oven](docs/local-oven.md), and its [claiming safety proof](docs/prepared-workspace-claim-spike.md)
 - [AI coding tools](docs/ai-tools.md) — Claude Code workflows, MCP server
 
 ## Requirements

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -27,6 +27,7 @@ var (
 	createForce         bool
 	createTrack         bool
 	createRecipe        string
+	createOven          bool
 	createJSON          bool
 	createSourceURL     string
 	createSourceProvide string
@@ -39,6 +40,9 @@ var createCmd = &cobra.Command{
 	Short: "Create a new workspace",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		if createOven && createRecipe == "" {
+			exitError("--oven requires --recipe")
+		}
 		if createRecipe != "" {
 			if err := runRecipeCreate(cmd, args); err != nil {
 				exitError(terminalSafe(err.Error()))
@@ -272,6 +276,7 @@ func init() {
 	createCmd.Flags().BoolVarP(&createForce, "force", "f", false, "Skip --replace confirmation prompt")
 	createCmd.Flags().BoolVar(&createTrack, "track", false, "Check out an existing remote branch (e.g. a PR head) instead of creating a new one")
 	createCmd.Flags().StringVar(&createRecipe, "recipe", "", "Create from a Recipe YAML file")
+	createCmd.Flags().BoolVar(&createOven, "oven", false, "Claim a prepared local Oven slot, with cold fallback")
 	createCmd.Flags().BoolVarP(&createJSON, "json", "j", false, "Output Recipe creation result as JSON")
 	createCmd.Flags().StringVar(&createSourceURL, "source-url", "", "Record the source URL this workspace was seeded from")
 	createCmd.Flags().StringVar(&createSourceProvide, "source-provider", "", "Source provider label (e.g. github, notion, slack)")

--- a/cmd/create_recipe.go
+++ b/cmd/create_recipe.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nicksenap/grove/internal/gitops"
 	"github.com/nicksenap/grove/internal/lifecycle"
 	"github.com/nicksenap/grove/internal/models"
+	"github.com/nicksenap/grove/internal/oven"
 	"github.com/nicksenap/grove/internal/recipe"
 	"github.com/nicksenap/grove/internal/workspace"
 	"github.com/spf13/cobra"
@@ -35,6 +36,7 @@ type recipeCreateOutput struct {
 	Name    string                   `json:"name"`
 	Path    string                   `json:"path,omitempty"`
 	Recipe  string                   `json:"recipe,omitempty"`
+	Oven    string                   `json:"oven,omitempty"`
 	Jobs    *[]recipe.JobResult      `json:"jobs,omitempty"`
 	Error   *recipeCreateErrorOutput `json:"error,omitempty"`
 }
@@ -71,7 +73,7 @@ func (e *recipeCreateRunError) Unwrap() error { return e.cause }
 func runRecipeCreate(cmd *cobra.Command, args []string) error {
 	options := recipeCreateOptions{
 		Recipe: createRecipe, Repos: createRepos, Preset: createPreset,
-		All: createAll, Replace: createReplace, Track: createTrack, Force: createForce,
+		All: createAll, Replace: createReplace, Track: createTrack, Force: createForce, Oven: createOven,
 	}
 	if err := validateRecipeCreateOptions(options); err != nil {
 		return writeRecipeCreateFailure(cmd, "", "", false, recipeCreateErrorOutput{Code: createErrorRecipeInvalid, Message: err.Error()}, err)
@@ -92,20 +94,47 @@ func runRecipeCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg := config.RequireConfig()
-	resolved, err := resolveRecipeRepositories(parsed.Recipe, cfg)
-	if err != nil {
-		return writeRecipeCreateFailure(cmd, name, parsed.Recipe.Name, false, recipeCreateErrorOutput{Code: createErrorResolutionFailed, Message: err.Error()}, err)
-	}
-
 	var source *models.WorkspaceSource
 	if createSourceURL != "" || createSourceProvide != "" {
 		source = &models.WorkspaceSource{Provider: createSourceProvide, URL: createSourceURL, Ref: createSourceRef, Title: createSourceTitle}
 	}
 
+	svc := workspace.NewService()
+	ovenResult := ""
+	if createOven {
+		if err := svc.RecoverOven(); err != nil {
+			failure := recipeCreateErrorOutput{Code: createErrorProvisionFailed, Message: err.Error()}
+			return writeRecipeCreateFailure(cmd, name, parsed.Recipe.Name, false, failure, err)
+		}
+		runner := oven.LocalRunnerIdentity()
+		recipeKey, identityErr := oven.RecipeIdentity(parsed.Recipe, runner)
+		if identityErr != nil {
+			return writeRecipeCreateFailure(cmd, name, parsed.Recipe.Name, false, recipeCreateErrorOutput{Code: createErrorRecipeInvalid, Message: identityErr.Error()}, identityErr)
+		}
+		claim, claimErr := svc.ClaimOvenSlot(workspace.OvenClaimOptions{
+			RecipeKey: recipeKey, Runner: runner, Name: name, Branch: branch, Config: cfg, Source: source,
+		})
+		if claimErr == nil {
+			if claim.Warning != nil {
+				console.Warningf("Oven claim completed with recovery warning: %s", terminalSafe(claim.Warning.Error()))
+			}
+			return finishRecipeCreate(cmd, name, branch, parsed.Recipe.Name, "hit", recipe.Report{Jobs: []recipe.JobResult{}}, source)
+		}
+		if !errors.Is(claimErr, workspace.ErrOvenMiss) {
+			failure := recipeCreateErrorOutput{Code: createErrorProvisionFailed, Message: claimErr.Error()}
+			return writeRecipeCreateFailure(cmd, name, parsed.Recipe.Name, false, failure, claimErr)
+		}
+		ovenResult = "miss"
+		console.Warningf("Oven miss for %s; creating cold", parsed.Recipe.Name)
+	}
+
+	resolved, err := resolveRecipeRepositories(parsed.Recipe, cfg)
+	if err != nil {
+		return writeRecipeCreateFailure(cmd, name, parsed.Recipe.Name, false, recipeCreateErrorOutput{Code: createErrorResolutionFailed, Message: err.Error()}, err)
+	}
 	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	var report recipe.Report
-	svc := workspace.NewService()
 	err = svc.CreateWithPreparation(name, workspace.PreparationOpts{
 		CreateOpts: workspace.CreateOpts{
 			Branch: branch, Repos: resolved.Names, RepoMap: resolved.RepoMap, Cfg: cfg, Source: source,
@@ -120,12 +149,16 @@ func runRecipeCreate(cmd *cobra.Command, args []string) error {
 		report, executeErr = (recipe.Executor{Output: cmd.ErrOrStderr()}).Execute(ctx, parsed.Recipe, worktrees)
 		return executeErr
 	})
-	wsPath := filepath.Join(cfg.WorkspaceDir, name)
 	if err != nil {
 		failure := recipeCreateFailureFromError(err)
 		return writeRecipeCreateFailure(cmd, name, parsed.Recipe.Name, false, failure, err)
 	}
+	return finishRecipeCreate(cmd, name, branch, parsed.Recipe.Name, ovenResult, report, source)
+}
 
+func finishRecipeCreate(cmd *cobra.Command, name, branch, recipeName, ovenResult string, report recipe.Report, source *models.WorkspaceSource) error {
+	cfg := config.RequireConfig()
+	wsPath := filepath.Join(cfg.WorkspaceDir, name)
 	vars := lifecycle.Vars{Name: name, Path: wsPath, Branch: branch}
 	if source != nil {
 		vars.SourceURL, vars.SourceRef, vars.SourceTitle = source.URL, source.Ref, source.Title
@@ -135,7 +168,7 @@ func runRecipeCreate(cmd *cobra.Command, args []string) error {
 			failure := recipeCreateErrorOutput{Code: createErrorPostCreateFailed, Message: hookErr.Error()}
 			if createJSON {
 				if err := json.NewEncoder(cmd.OutOrStdout()).Encode(recipeCreateOutput{
-					Created: true, Name: name, Path: wsPath, Recipe: parsed.Recipe.Name, Jobs: &report.Jobs, Error: &failure,
+					Created: true, Name: name, Path: wsPath, Recipe: recipeName, Oven: ovenResult, Jobs: &report.Jobs, Error: &failure,
 				}); err != nil {
 					return err
 				}
@@ -144,10 +177,9 @@ func runRecipeCreate(cmd *cobra.Command, args []string) error {
 		}
 		console.Warning(hookErr.Error())
 	}
-
 	if createJSON {
 		return json.NewEncoder(cmd.OutOrStdout()).Encode(recipeCreateOutput{
-			Created: true, Name: name, Path: wsPath, Recipe: parsed.Recipe.Name, Jobs: &report.Jobs,
+			Created: true, Name: name, Path: wsPath, Recipe: recipeName, Oven: ovenResult, Jobs: &report.Jobs,
 		})
 	}
 	return nil
@@ -211,10 +243,14 @@ type recipeCreateOptions struct {
 	Replace bool
 	Track   bool
 	Force   bool
+	Oven    bool
 }
 
 func validateRecipeCreateOptions(options recipeCreateOptions) error {
 	if options.Recipe == "" {
+		if options.Oven {
+			return errors.New("--oven requires --recipe")
+		}
 		return nil
 	}
 	var conflicts []string

--- a/cmd/create_recipe_test.go
+++ b/cmd/create_recipe_test.go
@@ -326,15 +326,15 @@ func setupRecipeCreateCommand(t *testing.T, command string) recipeCreateCommandE
 	if err := config.Save(&models.Config{RepoDirs: []string{reposDir}, WorkspaceDir: workspaceDir}); err != nil {
 		t.Fatal(err)
 	}
-	oldRecipe, oldBranch, oldJSON := createRecipe, createBranch, createJSON
+	oldRecipe, oldBranch, oldJSON, oldOven := createRecipe, createBranch, createJSON, createOven
 	oldRepos, oldPreset, oldAll := createRepos, createPreset, createAll
 	oldReplace, oldTrack, oldForce := createReplace, createTrack, createForce
-	createRecipe, createBranch, createJSON = recipePath, "feat/recipe", true
+	createRecipe, createBranch, createJSON, createOven = recipePath, "feat/recipe", true, false
 	createRepos, createPreset, createAll = "", "", false
 	createReplace, createTrack, createForce = false, false, false
 	t.Cleanup(func() {
 		config.GroveDir, config.ConfigPath, config.DefaultWorkspaceDir = oldGroveDir, oldConfigPath, oldWorkspaceDir
-		createRecipe, createBranch, createJSON = oldRecipe, oldBranch, oldJSON
+		createRecipe, createBranch, createJSON, createOven = oldRecipe, oldBranch, oldJSON, oldOven
 		createRepos, createPreset, createAll = oldRepos, oldPreset, oldAll
 		createReplace, createTrack, createForce = oldReplace, oldTrack, oldForce
 	})

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -70,8 +70,13 @@ func doDelete(args []string, force bool) {
 	}
 
 	for _, name := range names {
+		service := workspace.NewService()
+		// Verify ownership and use immutable physical paths before invoking hooks.
+		ws, err := service.OperationWorkspace(name)
+		if err != nil {
+			exitError(err.Error())
+		}
 		// Fire pre_delete hook before teardown (e.g. harvest Claude memory)
-		ws, _ := state.GetWorkspace(name)
 		if ws != nil {
 			vars := lifecycle.Vars{Name: name, Path: ws.Path, Branch: ws.Branch}
 			if err := lifecycle.Run("pre_delete", vars); err != nil && !errors.Is(err, lifecycle.ErrNoHook) {
@@ -82,7 +87,7 @@ func doDelete(args []string, force bool) {
 			}
 		}
 
-		if err := workspace.NewService().DeleteWithOptions(name, workspace.RemoveOptions{Force: force}); err != nil {
+		if err := service.DeleteWithOptions(name, workspace.RemoveOptions{Force: force}); err != nil {
 			exitError(err.Error())
 		}
 	}

--- a/cmd/go_cmd.go
+++ b/cmd/go_cmd.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nicksenap/grove/internal/logging"
 	"github.com/nicksenap/grove/internal/picker"
 	"github.com/nicksenap/grove/internal/state"
+	"github.com/nicksenap/grove/internal/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -83,6 +84,9 @@ var goCmd = &cobra.Command{
 		}
 		if ws == nil {
 			exitError("Workspace not found: " + name)
+		}
+		if err := workspace.NewService().VerifyWorkspaceOwnership(name); err != nil {
+			exitError(err.Error())
 		}
 
 		if goDelete {

--- a/cmd/oven.go
+++ b/cmd/oven.go
@@ -1,0 +1,260 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/nicksenap/grove/internal/config"
+	"github.com/nicksenap/grove/internal/console"
+	"github.com/nicksenap/grove/internal/oven"
+	"github.com/nicksenap/grove/internal/recipe"
+	"github.com/nicksenap/grove/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+var ovenJSON bool
+
+type ovenActionOutput struct {
+	Action       string   `json:"action"`
+	Recipe       string   `json:"recipe,omitempty"`
+	RecipeKey    string   `json:"recipe_key,omitempty"`
+	Generation   string   `json:"generation,omitempty"`
+	SlotID       string   `json:"slot_id,omitempty"`
+	Status       string   `json:"status,omitempty"`
+	AlreadyReady bool     `json:"already_ready,omitempty"`
+	Removed      int      `json:"removed,omitempty"`
+	Blocked      []string `json:"blocked,omitempty"`
+	Error        string   `json:"error,omitempty"`
+}
+
+type ovenStatusOutput struct {
+	ID         string `json:"id"`
+	Recipe     string `json:"recipe,omitempty"`
+	RecipePath string `json:"recipe_path,omitempty"`
+	RecipeKey  string `json:"recipe_key"`
+	Generation string `json:"generation"`
+	Status     string `json:"status"`
+	CreatedAt  string `json:"created_at"`
+	UpdatedAt  string `json:"updated_at"`
+	Failure    string `json:"failure,omitempty"`
+	Workspace  string `json:"workspace,omitempty"`
+}
+
+var ovenCmd = &cobra.Command{
+	Use:   "oven",
+	Short: "Manage opt-in local prepared Recipe workspaces",
+}
+
+var ovenBakeCmd = &cobra.Command{
+	Use:   "bake RECIPE",
+	Short: "Bake one ready slot for the current Recipe generation",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runOvenBake(cmd, args[0], false)
+	},
+}
+
+var ovenReconcileCmd = &cobra.Command{
+	Use:   "reconcile RECIPE",
+	Short: "Refresh a Recipe generation and keep one ready slot",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runOvenBake(cmd, args[0], true)
+	},
+}
+
+var ovenStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show local Oven slots",
+	Args:  cobra.NoArgs,
+	RunE:  runOvenStatus,
+}
+
+var ovenCleanCmd = &cobra.Command{
+	Use:   "clean [RECIPE]",
+	Short: "Remove unclaimed ready and failed slots",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  runOvenClean,
+}
+
+func init() {
+	ovenCmd.PersistentFlags().BoolVarP(&ovenJSON, "json", "j", false, "Output JSON")
+	ovenCmd.AddCommand(ovenBakeCmd, ovenReconcileCmd, ovenStatusCmd, ovenCleanCmd)
+}
+
+func runOvenBake(cmd *cobra.Command, recipeFile string, reconcile bool) error {
+	model, recipePath, err := loadOvenRecipe(recipeFile)
+	if err != nil {
+		return writeOvenAction(cmd, ovenActionOutput{Action: ovenAction(reconcile), Error: err.Error()}, err)
+	}
+	cfg := config.RequireConfig()
+	service := workspace.NewService()
+	if err := service.RecoverOven(); err != nil {
+		return writeOvenAction(cmd, ovenActionOutput{Action: ovenAction(reconcile), Recipe: model.Name, Error: err.Error()}, err)
+	}
+	resolved, err := resolveRecipeRepositories(model, cfg)
+	if err != nil {
+		return writeOvenAction(cmd, ovenActionOutput{Action: ovenAction(reconcile), Recipe: model.Name, Error: err.Error()}, err)
+	}
+	runner := oven.LocalRunnerIdentity()
+	recipeKey, generation, err := oven.Identity(model, resolved.BaseCommits, runner)
+	if err != nil {
+		return writeOvenAction(cmd, ovenActionOutput{Action: ovenAction(reconcile), Recipe: model.Name, Error: err.Error()}, err)
+	}
+	inventory, err := service.Oven.Load()
+	if err != nil {
+		return writeOvenAction(cmd, ovenActionOutput{Action: ovenAction(reconcile), Recipe: model.Name, Error: err.Error()}, err)
+	}
+	ready := inventory.ReadyGeneration(recipeKey, generation, runner)
+	alreadyReady := ready != nil
+	if ready == nil {
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		ready, err = service.BakeOvenSlot(workspace.OvenBakeOptions{
+			RecipeKey: recipeKey, RecipeName: model.Name, RecipePath: recipePath,
+			Generation: generation, Runner: runner, Repos: resolved.Names,
+			RepoMap: resolved.RepoMap, Commits: resolved.BaseCommits,
+		}, func(worktrees map[string]string) error {
+			_, executeErr := (recipe.Executor{Output: cmd.ErrOrStderr()}).Execute(ctx, model, worktrees)
+			return executeErr
+		})
+		if err != nil {
+			output := ovenActionOutput{Action: ovenAction(reconcile), Recipe: model.Name, RecipeKey: recipeKey, Generation: generation, Error: err.Error()}
+			return writeOvenAction(cmd, output, err)
+		}
+	}
+
+	output := ovenActionOutput{
+		Action: ovenAction(reconcile), Recipe: model.Name, RecipeKey: recipeKey,
+		Generation: generation, SlotID: ready.ID, Status: string(ready.Status), AlreadyReady: alreadyReady,
+	}
+	cleaned, cleanErr := service.PruneOvenRecipe(recipePath, generation, runner, ready.ID)
+	output.Removed, output.Blocked = cleaned.Removed, cleaned.Blocked
+	if cleanErr != nil {
+		output.Error = cleanErr.Error()
+		return writeOvenAction(cmd, output, cleanErr)
+	}
+	if !ovenJSON {
+		if alreadyReady {
+			console.Successf("Oven slot %s is already ready for %s", shortOvenID(ready.ID), model.Name)
+		} else {
+			console.Successf("Oven slot %s is ready for %s", shortOvenID(ready.ID), model.Name)
+		}
+	}
+	return writeOvenAction(cmd, output, nil)
+}
+
+func loadOvenRecipe(path string) (*recipe.Recipe, string, error) {
+	data, err := readRecipeFile(path)
+	if err != nil {
+		return nil, "", err
+	}
+	parsed := recipe.Parse(data)
+	if parsed.Recipe == nil || len(parsed.Errors) > 0 {
+		return nil, "", errors.New(strings.TrimSpace(formatRecipeErrors(parsed.Errors)))
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return nil, "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+		absolute = resolved
+	}
+	return parsed.Recipe, filepath.Clean(absolute), nil
+}
+
+func runOvenStatus(cmd *cobra.Command, _ []string) error {
+	inventory, err := oven.NewStore(config.GroveDir).Load()
+	if err != nil {
+		return err
+	}
+	slots := make([]ovenStatusOutput, 0, len(inventory.Slots))
+	for _, slot := range inventory.Slots {
+		status := ovenStatusOutput{
+			ID: slot.ID, Recipe: slot.RecipeName, RecipePath: slot.RecipePath,
+			RecipeKey: slot.RecipeKey, Generation: slot.Generation, Status: string(slot.Status),
+			CreatedAt: slot.CreatedAt, UpdatedAt: slot.UpdatedAt, Failure: slot.Failure,
+		}
+		if slot.Claim != nil {
+			status.Workspace = slot.Claim.WorkspaceName
+		}
+		slots = append(slots, status)
+	}
+	sort.Slice(slots, func(i, j int) bool {
+		if slots[i].Recipe == slots[j].Recipe {
+			return slots[i].UpdatedAt > slots[j].UpdatedAt
+		}
+		return slots[i].Recipe < slots[j].Recipe
+	})
+	if ovenJSON {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(slots)
+	}
+	table := console.NewTable(cmd.OutOrStdout(), []string{"Slot", "Recipe", "Generation", "Status", "Workspace", "Failure"})
+	for _, slot := range slots {
+		table.AddRow([]string{
+			shortOvenID(slot.ID), terminalSafe(slot.Recipe), shortOvenID(slot.Generation),
+			terminalSafe(slot.Status), terminalSafe(slot.Workspace), terminalSafe(slot.Failure),
+		})
+	}
+	table.Render()
+	return nil
+}
+
+func runOvenClean(cmd *cobra.Command, args []string) error {
+	recipePath := ""
+	if len(args) == 1 {
+		absolute, err := filepath.Abs(args[0])
+		if err != nil {
+			return err
+		}
+		if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+			absolute = resolved
+		}
+		recipePath = filepath.Clean(absolute)
+	}
+	service := workspace.NewService()
+	if err := service.RecoverOven(); err != nil {
+		return err
+	}
+	result, err := service.CleanOven(recipePath)
+	output := ovenActionOutput{Action: "clean", Removed: result.Removed, Blocked: result.Blocked}
+	if err != nil {
+		output.Error = err.Error()
+	}
+	if !ovenJSON {
+		console.Successf("Removed %d Oven slot(s)", result.Removed)
+		if len(result.Blocked) > 0 {
+			console.Warningf("Blocked slots: %s", strings.Join(result.Blocked, ", "))
+		}
+	}
+	return writeOvenAction(cmd, output, err)
+}
+
+func writeOvenAction(cmd *cobra.Command, output ovenActionOutput, cause error) error {
+	if ovenJSON {
+		if err := json.NewEncoder(cmd.OutOrStdout()).Encode(output); err != nil {
+			return err
+		}
+	}
+	return cause
+}
+
+func ovenAction(reconcile bool) string {
+	if reconcile {
+		return "reconcile"
+	}
+	return "bake"
+}
+
+func shortOvenID(value string) string {
+	if len(value) <= 12 {
+		return value
+	}
+	return value[:12]
+}

--- a/cmd/oven_test.go
+++ b/cmd/oven_test.go
@@ -1,0 +1,206 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nicksenap/grove/internal/oven"
+	"github.com/nicksenap/grove/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+func setupOvenCommand(t *testing.T, command string) recipeCreateCommandEnv {
+	t.Helper()
+	env := setupRecipeCreateCommand(t, command)
+	oldOvenJSON := ovenJSON
+	ovenJSON = true
+	t.Cleanup(func() { ovenJSON = oldOvenJSON })
+	return env
+}
+
+func ovenTestCommand() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	var stdout, stderr bytes.Buffer
+	command := &cobra.Command{}
+	command.SetContext(context.Background())
+	command.SetOut(&stdout)
+	command.SetErr(&stderr)
+	return command, &stdout, &stderr
+}
+
+func TestOvenBakeAndReconcileKeepOneReadySlot(t *testing.T) {
+	env := setupOvenCommand(t, "mkdir -p node_modules && touch node_modules/prepared")
+	command, stdout, _ := ovenTestCommand()
+	if err := runOvenBake(command, createRecipe, false); err != nil {
+		t.Fatal(err)
+	}
+	var baked ovenActionOutput
+	if err := json.Unmarshal(stdout.Bytes(), &baked); err != nil {
+		t.Fatal(err)
+	}
+	if baked.Status != string(oven.StatusReady) || baked.SlotID == "" || baked.AlreadyReady {
+		t.Fatalf("bake output = %+v", baked)
+	}
+
+	stdout.Reset()
+	if err := runOvenBake(command, createRecipe, true); err != nil {
+		t.Fatal(err)
+	}
+	var reconciled ovenActionOutput
+	if err := json.Unmarshal(stdout.Bytes(), &reconciled); err != nil {
+		t.Fatal(err)
+	}
+	if !reconciled.AlreadyReady || reconciled.SlotID != baked.SlotID {
+		t.Fatalf("reconcile output = %+v", reconciled)
+	}
+	inventory, err := oven.NewStore(env.groveDir).Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inventory.Slots) != 1 || inventory.Slots[0].Status != oven.StatusReady {
+		t.Fatalf("inventory = %+v", inventory)
+	}
+}
+
+func TestOvenReconcileReplacesGenerationOnlyAfterSuccessfulBake(t *testing.T) {
+	env := setupOvenCommand(t, "true")
+	command, stdout, _ := ovenTestCommand()
+	if err := runOvenBake(command, createRecipe, true); err != nil {
+		t.Fatal(err)
+	}
+	inventory, _ := oven.NewStore(env.groveDir).Load()
+	oldSlot := inventory.Slots[0]
+
+	if err := os.WriteFile(filepath.Join(env.repoPath, "next.txt"), []byte("next"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runRecipeGit(t, env.repoPath, "add", "next.txt")
+	runRecipeGit(t, env.repoPath, "commit", "-m", "next")
+	runRecipeGit(t, env.repoPath, "push", "origin", "HEAD")
+	stdout.Reset()
+	if err := runOvenBake(command, createRecipe, true); err != nil {
+		t.Fatal(err)
+	}
+	inventory, _ = oven.NewStore(env.groveDir).Load()
+	if len(inventory.Slots) != 1 || inventory.Slots[0].Generation == oldSlot.Generation {
+		t.Fatalf("generation was not replaced: %+v", inventory)
+	}
+	newSlot := inventory.Slots[0]
+
+	data, err := os.ReadFile(createRecipe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = []byte(strings.Replace(string(data), "run: \"true\"", "run: \"exit 9\"", 1))
+	if err := os.WriteFile(createRecipe, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	if err := runOvenBake(command, createRecipe, true); err == nil {
+		t.Fatal("expected replacement bake failure")
+	}
+	inventory, _ = oven.NewStore(env.groveDir).Load()
+	if ready := inventory.FindSlot(newSlot.ID); ready == nil || ready.Status != oven.StatusReady {
+		t.Fatalf("previous ready generation was removed: %+v", inventory)
+	}
+}
+
+func TestRecipeCreateOvenHitDoesNotFetchAndUsesPreparedArtifacts(t *testing.T) {
+	env := setupOvenCommand(t, "mkdir -p node_modules && touch node_modules/prepared")
+	command, _, _ := ovenTestCommand()
+	if err := runOvenBake(command, createRecipe, false); err != nil {
+		t.Fatal(err)
+	}
+	runRecipeGit(t, env.repoPath, "remote", "set-url", "origin", "/dev/null")
+	createOven = true
+	var stdout, stderr bytes.Buffer
+	createCommand := &cobra.Command{}
+	createCommand.SetContext(context.Background())
+	createCommand.SetOut(&stdout)
+	createCommand.SetErr(&stderr)
+	if err := runRecipeCreate(createCommand, []string{"oven-hit"}); err != nil {
+		t.Fatal(err)
+	}
+	var output recipeCreateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.Oven != "hit" || !output.Created {
+		t.Fatalf("create output = %+v", output)
+	}
+	if _, err := os.Stat(filepath.Join(env.workspaceDir, "oven-hit", "api", "node_modules", "prepared")); err != nil {
+		t.Fatalf("prepared artifact missing after claim: %v", err)
+	}
+	if strings.Contains(stderr.String(), "fetch failed") {
+		t.Fatalf("Oven hit fetched refs: %s", stderr.String())
+	}
+	if err := workspace.NewService().DeleteWithOptions("oven-hit", workspace.RemoveOptions{Force: true}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRecipeCreateOvenMissFallsBackToColdCreation(t *testing.T) {
+	env := setupOvenCommand(t, "touch cold-marker")
+	createOven = true
+	var stdout, stderr bytes.Buffer
+	command := &cobra.Command{}
+	command.SetContext(context.Background())
+	command.SetOut(&stdout)
+	command.SetErr(&stderr)
+	if err := runRecipeCreate(command, []string{"oven-miss"}); err != nil {
+		t.Fatal(err)
+	}
+	var output recipeCreateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.Oven != "miss" || !output.Created {
+		t.Fatalf("create output = %+v", output)
+	}
+	if _, err := os.Stat(filepath.Join(env.workspaceDir, "oven-miss", "api", "cold-marker")); err != nil {
+		t.Fatalf("cold fallback did not execute Recipe: %v", err)
+	}
+	if err := workspace.NewService().DeleteWithOptions("oven-miss", workspace.RemoveOptions{Force: true}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOvenStatusExplainsFailureAndCleanRemovesSafeSlots(t *testing.T) {
+	env := setupOvenCommand(t, "exit 7")
+	command, _, _ := ovenTestCommand()
+	if err := runOvenBake(command, createRecipe, false); err == nil {
+		t.Fatal("expected bake failure")
+	}
+	statusCommand, stdout, _ := ovenTestCommand()
+	if err := runOvenStatus(statusCommand, nil); err != nil {
+		t.Fatal(err)
+	}
+	var statuses []ovenStatusOutput
+	if err := json.Unmarshal(stdout.Bytes(), &statuses); err != nil {
+		t.Fatal(err)
+	}
+	if len(statuses) != 1 || statuses[0].Status != string(oven.StatusFailed) || statuses[0].Failure == "" {
+		t.Fatalf("status output = %+v", statuses)
+	}
+	stdout.Reset()
+	if err := runOvenClean(statusCommand, nil); err != nil {
+		t.Fatal(err)
+	}
+	inventory, err := oven.NewStore(env.groveDir).Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inventory.Slots) != 0 {
+		t.Fatalf("clean inventory = %+v", inventory)
+	}
+}
+
+func TestCreateOvenFlagRequiresRecipe(t *testing.T) {
+	if err := validateRecipeCreateOptions(recipeCreateOptions{Oven: true}); err == nil {
+		t.Fatal("expected --oven without --recipe to fail")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,7 @@ func init() {
 		shellInitCmd,
 		presetCmd,
 		recipeCmd,
+		ovenCmd,
 		addDirCmd,
 		removeDirCmd,
 		runCmd,

--- a/docs/local-oven.md
+++ b/docs/local-oven.md
@@ -1,0 +1,90 @@
+# Local Oven
+
+The local Oven is an opt-in pool of prepared Recipe workspaces. It keeps one detached, ready slot per reconciled Recipe generation so workspace creation can claim prepared dependencies without rerunning Recipe jobs.
+
+Cold Recipe creation remains unchanged and is always the fallback.
+
+## Commands
+
+```bash
+gw oven bake recipe.yaml
+gw oven reconcile recipe.yaml
+gw oven status
+gw oven status --json
+gw oven clean [recipe.yaml]
+
+gw create cake --branch feat/cake --recipe recipe.yaml --oven
+```
+
+- `bake` resolves the Recipe's refs and prepares a slot for the current generation if one is not already ready.
+- `reconcile` fetches refs, resolves a fresh generation, ensures one ready slot, and only then removes older unclaimed ready/failed generations.
+- `status` shows ready, active, failed, quarantined, and cleanup-blocked slots. Failure summaries never contain captured command output.
+- `clean` removes safe unclaimed ready and failed slots. It refuses active, claimed, or quarantined slots.
+- `create --oven` claims the newest ready generation known locally. A clean miss reports `Oven miss` and runs normal cold Recipe creation.
+
+Schedule `gw oven reconcile recipe.yaml` with cron, `launchd`, systemd, or another external scheduler. Grove does not install or run a daemon.
+
+## Freshness and generations
+
+A Recipe key hashes the normalized Recipe plus local runner identity. A generation additionally hashes every resolved repository commit SHA. Map ordering and `needs` ordering do not affect identity; sequential step ordering does.
+
+Only `bake` and `reconcile` fetch refs. An Oven hit intentionally does not contact remotes: it claims the newest generation previously made ready by reconciliation. This keeps the hit path fast and makes freshness an explicit scheduling policy.
+
+Reconciliation bakes a replacement before removing the previous ready generation. If replacement preparation fails, the previous generation remains available for inspection, while `create --oven` falls back cold when no ready slot matches the current normalized Recipe key.
+
+## Storage and visibility
+
+Oven state is separate from normal workspace state:
+
+```text
+~/.grove/oven/
+├── inventory.json
+└── generations/<generation>/slots/<slot>/...
+```
+
+The Oven root is mode `0700`; its atomic inventory is mode `0600`. Slots use immutable physical backing paths. Claim creates a named symlink in `workspace_dir`, attaches the requested branches, and writes ordinary workspace state last. `state.json`, not directory existence, is the user-visible readiness authority.
+
+Normal deletion verifies the external claim record, removes Git worktrees through the alias, removes the alias, and then removes the empty backing root and inventory record.
+
+## Lifecycle and recovery
+
+Slots use a bounded lifecycle:
+
+```text
+baking → ready → claiming → claimed
+   └────→ failed/quarantined
+claimed ─→ cleanup_failed
+```
+
+- Partial or interrupted bakes are never ready.
+- A live bake carries its local process owner so concurrent reconciliation does not remove worktrees under preparation.
+- Interrupted unmodified claims return to `ready`.
+- A claim with complete matching workspace state finishes as `claimed`.
+- Ambiguous aliases, branches, paths, state, or Git registrations become `quarantined`; Grove never guesses ownership.
+- Sequential cleanup can be partial. Remaining records stay visible for deterministic reconciliation or explicit repair.
+
+Claim, reconcile, clean, and normal workspace mutations share Grove's cross-process mutation lock.
+
+## Ownership boundaries
+
+Before claim or destructive cleanup, Grove verifies:
+
+- trusted slot/generation identity and exact backing path;
+- unique safe repository names and exact child paths;
+- source repository, physical worktree, alias path, branch, and Git registration;
+- exact detached commit before claim;
+- complete workspace state against the external claim record.
+
+`--force` does not bypass Oven ownership checks. To keep the external claim record exact, `rename`, `add-repo`, and `remove-repo` currently fail closed for Oven-backed workspaces. Normal Git commits, status, sync, and deletion remain supported.
+
+## Trusted-code and secret boundary
+
+Recipes remain trusted shell code with normal host access. Commands run outside Grove's mutation lock and stream output without persistent Oven logs. The inventory stores paths, commit identities, lifecycle state, and bounded error summaries—not environments, command output, credentials, or file contents.
+
+Grove rejects ready slots containing common credential residue such as `.npmrc`, `.netrc`, `.pypirc`, Git credential files, private-key filenames, `.env` variants, and AWS/Docker credential paths outside dependency-cache directories. A detected file quarantines the slot without recording its contents.
+
+Grove still cannot generically detect every secret created by trusted commands. Credential steps must use temporary files and remove them before the Recipe succeeds. A Recipe that leaves other credentials in its worktree must not be used for ready Oven slots.
+
+## Non-goals
+
+Remote Oven, containers, services, an installed daemon, credential-provider machinery, generic CI features, and generic artifact caching are not part of the local Oven.

--- a/docs/recipe-execution.md
+++ b/docs/recipe-execution.md
@@ -61,6 +61,10 @@ Failure exits non-zero after rollback:
 
 Stable failure codes cover `recipe_invalid`, `repository_resolution_failed`, `workspace_provision_failed`, `recipe_step_failed`, `recipe_job_timeout`, `recipe_cancelled`, and `post_create_failed`. A cleanup failure adds `cleanup_error` while preserving the original job failure. An aborting global `post_create` failure reports `created: true` because the completed workspace remains present.
 
+## Local Oven
+
+Cold creation is the default. Add `--oven` to claim an explicitly prepared local slot with cold fallback; see [Local Oven](local-oven.md).
+
 ## Non-goals
 
-Oven slots, remote execution, containers, services, matrices, retries, conditions, actions, expressions, output caching, persistent logs, or credential-provider machinery.
+Remote execution, containers, services, matrices, retries, conditions, actions, expressions, output caching, persistent logs, or credential-provider machinery.

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1021,6 +1021,62 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test: local Oven
+# ---------------------------------------------------------------------------
+section "Local Oven"
+
+oven_bake_json=$(gw oven bake "${RECIPE_FILE}" --json 2>/dev/null)
+if echo "${oven_bake_json}" | jq -e '.action == "bake" and .status == "ready" and (.slot_id | length) > 0' >/dev/null; then
+    pass "oven bake creates a ready slot"
+else
+    fail "oven bake JSON failed: ${oven_bake_json}"
+fi
+
+oven_status_json=$(gw oven status --json 2>/dev/null)
+if echo "${oven_status_json}" | jq -e 'length == 1 and .[0].status == "ready" and .[0].recipe == "e2e-recipe"' >/dev/null; then
+    pass "oven status reports the ready generation"
+else
+    fail "oven status did not explain readiness: ${oven_status_json}"
+fi
+
+oven_hit_json=$(gw create oven-hit --branch feat/oven-hit --recipe "${RECIPE_FILE}" --oven --json 2>/dev/null)
+if echo "${oven_hit_json}" | jq -e '.created == true and .oven == "hit" and (.jobs | length) == 0' >/dev/null && \
+   [ -f "${GROVE_HOME}/.grove/workspaces/oven-hit/auth/.recipe-ran" ] && \
+   [ -f "${GROVE_HOME}/.grove/workspaces/oven-hit/api/.recipe-ran" ]; then
+    pass "create --oven claims prepared artifacts"
+else
+    fail "create --oven hit failed: ${oven_hit_json}"
+fi
+
+gw delete oven-hit --force >/dev/null 2>&1
+if echo "$(gw oven status --json 2>/dev/null)" | jq -e 'length == 0' >/dev/null; then
+    pass "deleting an Oven workspace cleans its backing slot"
+else
+    fail "claimed Oven slot remained after delete"
+fi
+
+oven_miss_json=$(gw create oven-miss --branch feat/oven-miss --recipe "${RECIPE_FILE}" --oven --json 2>/dev/null)
+if echo "${oven_miss_json}" | jq -e '.created == true and .oven == "miss" and (.jobs | length) == 3' >/dev/null; then
+    pass "Oven miss falls back to cold Recipe creation"
+else
+    fail "Oven miss fallback failed: ${oven_miss_json}"
+fi
+gw delete oven-miss --force >/dev/null 2>&1
+
+oven_reconcile_json=$(gw oven reconcile "${RECIPE_FILE}" --json 2>/dev/null)
+if echo "${oven_reconcile_json}" | jq -e '.action == "reconcile" and .status == "ready"' >/dev/null; then
+    pass "oven reconcile replenishes the ready slot"
+else
+    fail "oven reconcile failed: ${oven_reconcile_json}"
+fi
+oven_clean_json=$(gw oven clean "${RECIPE_FILE}" --json 2>/dev/null)
+if echo "${oven_clean_json}" | jq -e '.removed == 1 and (.blocked | length) == 0' >/dev/null; then
+    pass "oven clean removes unclaimed slots"
+else
+    fail "oven clean failed: ${oven_clean_json}"
+fi
+
+# ---------------------------------------------------------------------------
 # Test: stats
 # ---------------------------------------------------------------------------
 section "Stats"

--- a/internal/gitops/gitops.go
+++ b/internal/gitops/gitops.go
@@ -156,9 +156,57 @@ func DeleteBranch(repo, branch string, force bool) error {
 	return err
 }
 
+// DeleteBranchIfAt removes a branch only when it still names expectedCommit.
+// Without force, the branch must also be merged into the source repository HEAD.
+func DeleteBranchIfAt(repo, branch, expectedCommit string, force bool) error {
+	current, err := LocalBranchCommit(repo, branch)
+	if err != nil {
+		return err
+	}
+	if current != expectedCommit {
+		return fmt.Errorf("branch %s changed from expected commit %s", branch, expectedCommit)
+	}
+	if !force {
+		if _, err := runGit(repo, "merge-base", "--is-ancestor", expectedCommit, "HEAD"); err != nil {
+			return fmt.Errorf("branch %s is not fully merged", branch)
+		}
+	}
+	if _, err := runGit(repo, "check-ref-format", "--branch", branch); err != nil {
+		return err
+	}
+	_, err = runGit(repo, "update-ref", "-d", "refs/heads/"+branch, expectedCommit)
+	return err
+}
+
 // WorktreeAdd creates a worktree for the given branch.
 func WorktreeAdd(repo, path, branch string) error {
 	_, err := runGit(repo, "worktree", "add", path, branch)
+	return err
+}
+
+// WorktreeAddDetached creates a detached worktree at an immutable commit.
+func WorktreeAddDetached(repo, path, commit string) error {
+	_, err := runGit(repo, "worktree", "add", "--detach", path, commit)
+	return err
+}
+
+// AttachWorktreeBranch attaches a detached worktree to a branch at commit.
+func AttachWorktreeBranch(path, branch, commit string, create bool) error {
+	args := []string{"switch"}
+	if create {
+		args = append(args, "-c")
+	}
+	args = append(args, branch)
+	if create {
+		args = append(args, commit)
+	}
+	_, err := runGit(path, args...)
+	return err
+}
+
+// DetachWorktree returns a worktree to a detached exact commit.
+func DetachWorktree(path, commit string) error {
+	_, err := runGit(path, "switch", "--detach", commit)
 	return err
 }
 
@@ -250,9 +298,19 @@ func RepoStatus(path string) (string, error) {
 	return runGit(path, "status", "--short")
 }
 
+// TrackedStatus returns changes to tracked files while ignoring prepared cache artifacts.
+func TrackedStatus(path string) (string, error) {
+	return runGit(path, "status", "--short", "--untracked-files=no")
+}
+
 // CurrentBranch returns the current branch name.
 func CurrentBranch(path string) (string, error) {
 	return runGit(path, "branch", "--show-current")
+}
+
+// HeadCommit returns the exact commit checked out at path.
+func HeadCommit(path string) (string, error) {
+	return runGit(path, "rev-parse", "--verify", "HEAD")
 }
 
 // RebaseOnto rebases the current branch onto the given base.

--- a/internal/gitops/gitops_test.go
+++ b/internal/gitops/gitops_test.go
@@ -175,6 +175,27 @@ func TestRemoteBranchExists(t *testing.T) {
 	}
 }
 
+func TestWorktreeAddDetached(t *testing.T) {
+	repo := initTestRepo(t)
+	commit, err := HeadCommit(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worktree := filepath.Join(t.TempDir(), "detached")
+	if err := WorktreeAddDetached(repo, worktree, commit); err != nil {
+		t.Fatal(err)
+	}
+	if branch, err := CurrentBranch(worktree); err != nil || branch != "" {
+		t.Fatalf("branch = %q, %v; want detached", branch, err)
+	}
+	if head, err := HeadCommit(worktree); err != nil || head != commit {
+		t.Fatalf("HEAD = %q, %v; want %q", head, err, commit)
+	}
+	if err := WorktreeRemove(repo, worktree, true); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestWorktreeAddTracking(t *testing.T) {
 	repo := initTestRepo(t)
 
@@ -797,4 +818,40 @@ func TestCloneRetryCleanup(t *testing.T) {
 func currentBranch(t *testing.T, repo string) string {
 	t.Helper()
 	return run(t, repo, "git", "branch", "--show-current")
+}
+
+func TestDeleteBranchIfAtUsesExpectedCommit(t *testing.T) {
+	repo := initTestRepo(t)
+	expected, err := HeadCommit(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := CreateBranch(repo, "feat/owned", expected); err != nil {
+		t.Fatal(err)
+	}
+	if err := DeleteBranchIfAt(repo, "feat/owned", expected, true); err != nil {
+		t.Fatal(err)
+	}
+	if BranchExists(repo, "feat/owned") {
+		t.Fatal("expected owned branch to be deleted")
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, "changed.txt"), []byte("changed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(t, repo, "git", "add", "changed.txt")
+	run(t, repo, "git", "commit", "-m", "changed")
+	changed, err := HeadCommit(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := CreateBranch(repo, "feat/changed", changed); err != nil {
+		t.Fatal(err)
+	}
+	if err := DeleteBranchIfAt(repo, "feat/changed", expected, true); err == nil {
+		t.Fatal("expected changed branch deletion to fail")
+	}
+	if !BranchExists(repo, "feat/changed") {
+		t.Fatal("changed branch was deleted")
+	}
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -25,6 +25,13 @@ type Workspace struct {
 	CreatedAt string           `json:"created_at"`
 	Repos     []RepoWorktree   `json:"repos"`
 	Source    *WorkspaceSource `json:"source,omitempty"`
+	Oven      *OvenOwnership   `json:"oven,omitempty"`
+}
+
+// OvenOwnership reciprocally identifies an external prepared-workspace claim.
+type OvenOwnership struct {
+	SlotID     string `json:"slot_id"`
+	ClaimNonce string `json:"claim_nonce"`
 }
 
 // WorkspaceSource records where a workspace was seeded from (e.g. a GitHub PR,

--- a/internal/oven/identity.go
+++ b/internal/oven/identity.go
@@ -1,0 +1,145 @@
+package oven
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"sort"
+
+	"github.com/nicksenap/grove/internal/recipe"
+)
+
+const CompatibilityVersion = "oven-v1"
+
+type normalizedRecipe struct {
+	Version      int                    `json:"version"`
+	Name         string                 `json:"name,omitempty"`
+	Repositories []normalizedRepository `json:"repositories"`
+	Jobs         []normalizedJob        `json:"jobs"`
+}
+
+type normalizedRepository struct {
+	ID  string `json:"id"`
+	URL string `json:"url"`
+	Ref string `json:"ref"`
+}
+
+type normalizedJob struct {
+	ID               string           `json:"id"`
+	Repository       string           `json:"repository"`
+	Needs            []string         `json:"needs"`
+	WorkingDirectory string           `json:"working_directory,omitempty"`
+	TimeoutMinutes   int              `json:"timeout_minutes,omitempty"`
+	Steps            []normalizedStep `json:"steps"`
+}
+
+type normalizedStep struct {
+	Name string `json:"name,omitempty"`
+	Run  string `json:"run"`
+}
+
+type normalizedGeneration struct {
+	Recipe  normalizedRecipe   `json:"recipe"`
+	Commits []normalizedCommit `json:"commits"`
+	Runner  string             `json:"runner"`
+}
+
+type normalizedCommit struct {
+	Repository string `json:"repository"`
+	Commit     string `json:"commit"`
+}
+
+func Identity(model *recipe.Recipe, commits map[string]string, runner string) (string, string, error) {
+	if model == nil {
+		return "", "", fmt.Errorf("recipe is required")
+	}
+	if runner == "" {
+		return "", "", fmt.Errorf("runner identity is required")
+	}
+	normalized := normalizeRecipe(model)
+	commitList := make([]normalizedCommit, 0, len(normalized.Repositories))
+	for _, repository := range normalized.Repositories {
+		commit := commits[repository.ID]
+		if commit == "" {
+			return "", "", fmt.Errorf("repository %s has no resolved commit", repository.ID)
+		}
+		commitList = append(commitList, normalizedCommit{Repository: repository.ID, Commit: commit})
+	}
+	recipeKey, err := hashJSON(struct {
+		Recipe normalizedRecipe `json:"recipe"`
+		Runner string           `json:"runner"`
+	}{Recipe: normalized, Runner: runner})
+	if err != nil {
+		return "", "", err
+	}
+	generation, err := hashJSON(normalizedGeneration{Recipe: normalized, Commits: commitList, Runner: runner})
+	if err != nil {
+		return "", "", err
+	}
+	return recipeKey, generation, nil
+}
+
+func RecipeIdentity(model *recipe.Recipe, runner string) (string, error) {
+	if model == nil {
+		return "", fmt.Errorf("recipe is required")
+	}
+	if runner == "" {
+		return "", fmt.Errorf("runner identity is required")
+	}
+	return hashJSON(struct {
+		Recipe normalizedRecipe `json:"recipe"`
+		Runner string           `json:"runner"`
+	}{Recipe: normalizeRecipe(model), Runner: runner})
+}
+
+func LocalRunnerIdentity() string {
+	hostname, err := os.Hostname()
+	if err != nil || hostname == "" {
+		hostname = "unknown-host"
+	}
+	return CompatibilityVersion + "/" + runtime.GOOS + "/" + runtime.GOARCH + "/" + hostname
+}
+
+func normalizeRecipe(model *recipe.Recipe) normalizedRecipe {
+	normalized := normalizedRecipe{Version: model.Version, Name: model.Name}
+	repositoryIDs := make([]string, 0, len(model.Repositories))
+	for id := range model.Repositories {
+		repositoryIDs = append(repositoryIDs, id)
+	}
+	sort.Strings(repositoryIDs)
+	for _, id := range repositoryIDs {
+		repository := model.Repositories[id]
+		normalized.Repositories = append(normalized.Repositories, normalizedRepository{ID: id, URL: repository.URL, Ref: repository.Ref})
+	}
+	jobIDs := make([]string, 0, len(model.Jobs))
+	for id := range model.Jobs {
+		jobIDs = append(jobIDs, id)
+	}
+	sort.Strings(jobIDs)
+	for _, id := range jobIDs {
+		job := model.Jobs[id]
+		needs := append([]string(nil), job.Needs...)
+		sort.Strings(needs)
+		normalizedJob := normalizedJob{
+			ID: id, Repository: job.Repository, Needs: needs,
+			WorkingDirectory: job.WorkingDirectory, TimeoutMinutes: job.TimeoutMinutes,
+		}
+		for _, step := range job.Steps {
+			normalizedJob.Steps = append(normalizedJob.Steps, normalizedStep{Name: step.Name, Run: step.Run})
+		}
+		normalized.Jobs = append(normalized.Jobs, normalizedJob)
+	}
+	return normalized
+}
+
+func hashJSON(value any) (string, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/internal/oven/identity_test.go
+++ b/internal/oven/identity_test.go
@@ -1,0 +1,111 @@
+package oven
+
+import (
+	"testing"
+
+	"github.com/nicksenap/grove/internal/recipe"
+)
+
+func TestGenerationIdentityIsCanonical(t *testing.T) {
+	first := &recipe.Recipe{
+		Version: 1,
+		Name:    "stack",
+		Repositories: map[string]recipe.Repository{
+			"web": {URL: "https://example.com/web.git", Ref: "main"},
+			"api": {URL: "https://example.com/api.git", Ref: "v1"},
+		},
+		Jobs: map[string]recipe.Job{
+			"verify": {
+				Repository: "api",
+				Needs:      []string{"web", "api"},
+				Steps:      []recipe.Step{{Name: "Check", Run: "make check"}},
+			},
+		},
+	}
+	second := &recipe.Recipe{
+		Version: 1,
+		Name:    "stack",
+		Repositories: map[string]recipe.Repository{
+			"api": {URL: "https://example.com/api.git", Ref: "v1"},
+			"web": {URL: "https://example.com/web.git", Ref: "main"},
+		},
+		Jobs: map[string]recipe.Job{
+			"verify": {
+				Repository: "api",
+				Needs:      []string{"api", "web"},
+				Steps:      []recipe.Step{{Name: "Check", Run: "make check"}},
+			},
+		},
+	}
+	commitsA := map[string]string{"web": "2222", "api": "1111"}
+	commitsB := map[string]string{"api": "1111", "web": "2222"}
+
+	firstRecipe, firstGeneration, err := Identity(first, commitsA, "runner-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondRecipe, secondGeneration, err := Identity(second, commitsB, "runner-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstRecipe != secondRecipe || firstGeneration != secondGeneration {
+		t.Fatalf("canonical identities differ: recipe %s/%s generation %s/%s", firstRecipe, secondRecipe, firstGeneration, secondGeneration)
+	}
+}
+
+func TestGenerationIdentityChangesWithInputs(t *testing.T) {
+	model := &recipe.Recipe{
+		Version: 1,
+		Repositories: map[string]recipe.Repository{
+			"api": {URL: "https://example.com/api.git", Ref: "main"},
+		},
+		Jobs: map[string]recipe.Job{
+			"setup": {Repository: "api", Steps: []recipe.Step{{Run: "make setup"}, {Run: "make check"}}},
+		},
+	}
+	baseRecipe, baseGeneration, err := Identity(model, map[string]string{"api": "aaaa"}, "runner-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, changedCommit, _ := Identity(model, map[string]string{"api": "bbbb"}, "runner-a")
+	_, changedRunner, _ := Identity(model, map[string]string{"api": "aaaa"}, "runner-b")
+	changedModel := *model
+	changedModel.Jobs = map[string]recipe.Job{
+		"setup": {Repository: "api", Steps: []recipe.Step{{Run: "make check"}, {Run: "make setup"}}},
+	}
+	changedRecipe, changedSteps, _ := Identity(&changedModel, map[string]string{"api": "aaaa"}, "runner-a")
+	if baseGeneration == changedCommit || baseGeneration == changedRunner || baseGeneration == changedSteps {
+		t.Fatal("generation identity did not change with commit, runner, or ordered steps")
+	}
+	if baseRecipe == changedRecipe {
+		t.Fatal("Recipe identity did not change with Recipe steps")
+	}
+}
+
+func TestRecipeIdentityTreatsMissingJobsAsEmpty(t *testing.T) {
+	withoutJobs := &recipe.Recipe{Version: 1, Repositories: map[string]recipe.Repository{
+		"api": {URL: "https://example.com/api.git", Ref: "main"},
+	}}
+	withEmptyJobs := *withoutJobs
+	withEmptyJobs.Jobs = map[string]recipe.Job{}
+	first, _, err := Identity(withoutJobs, map[string]string{"api": "aaaa"}, "runner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := Identity(&withEmptyJobs, map[string]string{"api": "aaaa"}, "runner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("missing and empty jobs differ: %s != %s", first, second)
+	}
+}
+
+func TestGenerationIdentityRequiresEveryCommit(t *testing.T) {
+	model := &recipe.Recipe{Version: 1, Repositories: map[string]recipe.Repository{
+		"api": {URL: "https://example.com/api.git", Ref: "main"},
+	}}
+	if _, _, err := Identity(model, map[string]string{}, "runner"); err == nil {
+		t.Fatal("expected missing commit error")
+	}
+}

--- a/internal/oven/model.go
+++ b/internal/oven/model.go
@@ -1,0 +1,160 @@
+package oven
+
+import (
+	"fmt"
+	"sort"
+)
+
+const InventoryVersion = 1
+
+type SlotStatus string
+
+const (
+	StatusBaking       SlotStatus = "baking"
+	StatusReady        SlotStatus = "ready"
+	StatusClaiming     SlotStatus = "claiming"
+	StatusClaimed      SlotStatus = "claimed"
+	StatusFailed       SlotStatus = "failed"
+	StatusQuarantined  SlotStatus = "quarantined"
+	StatusCleanupError SlotStatus = "cleanup_failed"
+)
+
+type Inventory struct {
+	Version int    `json:"version"`
+	Slots   []Slot `json:"slots"`
+}
+
+type Slot struct {
+	ID           string       `json:"id"`
+	RecipeKey    string       `json:"recipe_key"`
+	RecipeName   string       `json:"recipe_name,omitempty"`
+	RecipePath   string       `json:"recipe_path,omitempty"`
+	Generation   string       `json:"generation"`
+	Runner       string       `json:"runner"`
+	BackingPath  string       `json:"backing_path"`
+	Status       SlotStatus   `json:"status"`
+	OwnerPID     int          `json:"owner_pid,omitempty"`
+	CreatedAt    string       `json:"created_at"`
+	UpdatedAt    string       `json:"updated_at"`
+	Failure      string       `json:"failure,omitempty"`
+	Repositories []Repository `json:"repositories"`
+	Claim        *Claim       `json:"claim,omitempty"`
+}
+
+type Repository struct {
+	Name         string `json:"name"`
+	SourceRepo   string `json:"source_repo"`
+	WorktreePath string `json:"worktree_path"`
+	Commit       string `json:"commit"`
+}
+
+type Claim struct {
+	Nonce         string            `json:"nonce"`
+	WorkspaceName string            `json:"workspace_name"`
+	Alias         string            `json:"alias"`
+	Branch        string            `json:"branch"`
+	StartedAt     string            `json:"started_at"`
+	CleanupForce  bool              `json:"cleanup_force,omitempty"`
+	Repositories  []ClaimRepository `json:"repositories"`
+}
+
+type ClaimRepository struct {
+	Name                 string `json:"name"`
+	SourceRepo           string `json:"source_repo"`
+	PhysicalPath         string `json:"physical_path"`
+	AliasPath            string `json:"alias_path"`
+	Branch               string `json:"branch"`
+	BranchCreated        bool   `json:"branch_created"`
+	ExpectedBranchCommit string `json:"expected_branch_commit,omitempty"`
+}
+
+func NewInventory() Inventory {
+	return Inventory{Version: InventoryVersion, Slots: []Slot{}}
+}
+
+func (inventory *Inventory) ReadySlot(recipeKey, runner string) *Slot {
+	var matches []*Slot
+	for index := range inventory.Slots {
+		slot := &inventory.Slots[index]
+		if slot.RecipeKey == recipeKey && slot.Runner == runner && slot.Status == StatusReady {
+			matches = append(matches, slot)
+		}
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].UpdatedAt == matches[j].UpdatedAt {
+			return matches[i].ID > matches[j].ID
+		}
+		return matches[i].UpdatedAt > matches[j].UpdatedAt
+	})
+	if len(matches) == 0 {
+		return nil
+	}
+	return matches[0]
+}
+
+func (inventory *Inventory) ReadyGeneration(recipeKey, generation, runner string) *Slot {
+	for index := range inventory.Slots {
+		slot := &inventory.Slots[index]
+		if slot.RecipeKey == recipeKey && slot.Generation == generation && slot.Runner == runner && slot.Status == StatusReady {
+			return slot
+		}
+	}
+	return nil
+}
+
+func (inventory *Inventory) BlockingSlot(recipeKey, runner string) *Slot {
+	for index := range inventory.Slots {
+		slot := &inventory.Slots[index]
+		if slot.RecipeKey == recipeKey && slot.Runner == runner && slot.Status == StatusQuarantined {
+			return slot
+		}
+	}
+	return nil
+}
+
+func (inventory *Inventory) ClaimForWorkspace(name string) *Slot {
+	for index := range inventory.Slots {
+		slot := &inventory.Slots[index]
+		if (slot.Status == StatusClaiming || slot.Status == StatusClaimed || slot.Status == StatusCleanupError) &&
+			slot.Claim != nil && slot.Claim.WorkspaceName == name {
+			return slot
+		}
+	}
+	return nil
+}
+
+func (inventory *Inventory) FindSlot(id string) *Slot {
+	for index := range inventory.Slots {
+		if inventory.Slots[index].ID == id {
+			return &inventory.Slots[index]
+		}
+	}
+	return nil
+}
+
+func (inventory *Inventory) UpdateSlot(id string, update func(*Slot) error) error {
+	slot := inventory.FindSlot(id)
+	if slot == nil {
+		return fmt.Errorf("oven slot %s not found", id)
+	}
+	return update(slot)
+}
+
+func (inventory *Inventory) RemoveSlot(id string) bool {
+	for index := range inventory.Slots {
+		if inventory.Slots[index].ID == id {
+			inventory.Slots = append(inventory.Slots[:index], inventory.Slots[index+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func validStatus(status SlotStatus) bool {
+	switch status {
+	case StatusBaking, StatusReady, StatusClaiming, StatusClaimed, StatusFailed, StatusQuarantined, StatusCleanupError:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/oven/store.go
+++ b/internal/oven/store.go
@@ -1,0 +1,288 @@
+package oven
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+type Store struct {
+	Root string
+	Path string
+}
+
+func NewStore(groveDir string) *Store {
+	root := filepath.Join(groveDir, "oven")
+	return &Store{Root: root, Path: filepath.Join(root, "inventory.json")}
+}
+
+func (store *Store) GenerationsPath() string {
+	return filepath.Join(store.Root, "generations")
+}
+
+func (store *Store) SlotPath(generation, slotID string) string {
+	return filepath.Join(store.GenerationsPath(), generation, "slots", slotID)
+}
+
+func (store *Store) Load() (Inventory, error) {
+	rootExists, err := store.validateRoot()
+	if err != nil {
+		return Inventory{}, err
+	}
+	info, err := os.Lstat(store.Path)
+	if os.IsNotExist(err) {
+		if rootExists {
+			return Inventory{}, fmt.Errorf("oven inventory is missing from an existing oven root")
+		}
+		return NewInventory(), nil
+	}
+	if err != nil {
+		return Inventory{}, fmt.Errorf("reading oven inventory metadata: %w", err)
+	}
+	if err := validatePrivateFile(info, store.Path); err != nil {
+		return Inventory{}, err
+	}
+	data, err := os.ReadFile(store.Path)
+	if err != nil {
+		return Inventory{}, fmt.Errorf("reading oven inventory: %w", err)
+	}
+	var inventory Inventory
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		return Inventory{}, fmt.Errorf("parsing oven inventory: %w", err)
+	}
+	if err := store.validate(inventory); err != nil {
+		return Inventory{}, err
+	}
+	return inventory, nil
+}
+
+func (store *Store) Save(inventory Inventory) error {
+	if err := store.validate(inventory); err != nil {
+		return err
+	}
+	rootExists, err := store.validateRoot()
+	if err != nil {
+		return err
+	}
+	if !rootExists {
+		if err := os.Mkdir(store.Root, 0o700); err != nil {
+			return fmt.Errorf("creating oven directory: %w", err)
+		}
+	}
+	if info, err := os.Lstat(store.Path); err == nil {
+		if err := validatePrivateFile(info, store.Path); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	data, err := json.MarshalIndent(inventory, "", "  ")
+	if err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(store.Root, "inventory-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating oven inventory temporary file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o600); err != nil {
+		temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(data); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, store.Path); err != nil {
+		return fmt.Errorf("publishing oven inventory: %w", err)
+	}
+	directory, err := os.Open(store.Root)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}
+
+func (store *Store) validateRoot() (bool, error) {
+	info, err := os.Lstat(store.Root)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return false, fmt.Errorf("oven root must be a real directory")
+	}
+	if info.Mode().Perm() != 0o700 {
+		return false, fmt.Errorf("oven root permissions must be 0700")
+	}
+	if err := validateOwner(info, store.Root); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func validatePrivateFile(info os.FileInfo, path string) error {
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("oven inventory must be a regular file")
+	}
+	if info.Mode().Perm() != 0o600 {
+		return fmt.Errorf("oven inventory permissions must be 0600")
+	}
+	if err := validateOwner(info, path); err != nil {
+		return err
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && stat.Nlink != 1 {
+		return fmt.Errorf("oven inventory must have one hard link")
+	}
+	return nil
+}
+
+func validateOwner(info os.FileInfo, path string) error {
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && int(stat.Uid) != os.Geteuid() {
+		return fmt.Errorf("%s is not owned by the current user", path)
+	}
+	return nil
+}
+
+func (store *Store) validate(inventory Inventory) error {
+	if inventory.Version != InventoryVersion {
+		return fmt.Errorf("unsupported oven inventory version %d", inventory.Version)
+	}
+	seen := make(map[string]bool, len(inventory.Slots))
+	for _, slot := range inventory.Slots {
+		if !lowerHex(slot.ID, 32) || seen[slot.ID] {
+			return fmt.Errorf("invalid or duplicate oven slot ID %q", slot.ID)
+		}
+		seen[slot.ID] = true
+		if !lowerHex(slot.RecipeKey, 64) || !lowerHex(slot.Generation, 64) || slot.Runner == "" {
+			return fmt.Errorf("oven slot %s has invalid identity", slot.ID)
+		}
+		if !validStatus(slot.Status) {
+			return fmt.Errorf("oven slot %s has invalid status %q", slot.ID, slot.Status)
+		}
+		expected := filepath.Clean(store.SlotPath(slot.Generation, slot.ID))
+		if filepath.Clean(slot.BackingPath) != expected || !pathWithin(store.GenerationsPath(), slot.BackingPath) {
+			return fmt.Errorf("oven slot %s backing path is outside its generation", slot.ID)
+		}
+		if slot.RecipePath != "" && (!filepath.IsAbs(slot.RecipePath) || filepath.Clean(slot.RecipePath) != slot.RecipePath) {
+			return fmt.Errorf("oven slot %s Recipe path is not absolute and clean", slot.ID)
+		}
+		if strings.ContainsRune(slot.Failure, '\x00') {
+			return fmt.Errorf("oven slot %s failure contains invalid data", slot.ID)
+		}
+		if err := validateSlotRepositories(slot); err != nil {
+			return err
+		}
+		if err := validateSlotLifecycle(slot); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSlotRepositories(slot Slot) error {
+	if len(slot.Repositories) == 0 && slot.Status != StatusQuarantined && slot.Status != StatusCleanupError {
+		return fmt.Errorf("oven slot %s has no repositories", slot.ID)
+	}
+	seen := make(map[string]bool, len(slot.Repositories))
+	for _, repository := range slot.Repositories {
+		if !safeName(repository.Name) || seen[repository.Name] || repository.Commit == "" {
+			return fmt.Errorf("oven slot %s has an invalid repository", slot.ID)
+		}
+		seen[repository.Name] = true
+		if !filepath.IsAbs(repository.SourceRepo) || filepath.Clean(repository.SourceRepo) != repository.SourceRepo ||
+			repository.WorktreePath != filepath.Join(slot.BackingPath, repository.Name) {
+			return fmt.Errorf("oven repository %s has an unsafe path", repository.Name)
+		}
+	}
+	return nil
+}
+
+func validateSlotLifecycle(slot Slot) error {
+	activeClaim := slot.Status == StatusClaiming || slot.Status == StatusClaimed || slot.Status == StatusCleanupError
+	if activeClaim && slot.Claim == nil || !activeClaim && slot.Claim != nil && slot.Status != StatusQuarantined {
+		return fmt.Errorf("oven slot %s claim lifecycle is inconsistent (status %s, claim present %t)", slot.ID, slot.Status, slot.Claim != nil)
+	}
+	if slot.Claim == nil {
+		return nil
+	}
+	claim := slot.Claim
+	if err := validateClaimShape(slot, *claim); err != nil {
+		return err
+	}
+	return validateClaimRepositories(slot, *claim)
+}
+
+func validateClaimShape(slot Slot, claim Claim) error {
+	if !lowerHex(claim.Nonce, 32) || !safeName(claim.WorkspaceName) || !filepath.IsAbs(claim.Alias) ||
+		filepath.Clean(claim.Alias) != claim.Alias || claim.Branch == "" || len(claim.Repositories) != len(slot.Repositories) {
+		return fmt.Errorf("oven slot %s has an invalid claim", slot.ID)
+	}
+	return nil
+}
+
+func validateClaimRepositories(slot Slot, claim Claim) error {
+	prepared := make(map[string]Repository, len(slot.Repositories))
+	for _, repository := range slot.Repositories {
+		prepared[repository.Name] = repository
+	}
+	seen := make(map[string]bool, len(claim.Repositories))
+	for _, repository := range claim.Repositories {
+		base, ok := prepared[repository.Name]
+		if !ok || seen[repository.Name] || repository.SourceRepo != base.SourceRepo ||
+			repository.PhysicalPath != base.WorktreePath || repository.AliasPath != filepath.Join(claim.Alias, repository.Name) ||
+			repository.Branch != claim.Branch {
+			return fmt.Errorf("oven slot %s has an invalid claimed repository", slot.ID)
+		}
+		seen[repository.Name] = true
+	}
+	return nil
+}
+
+func lowerHex(value string, length int) bool {
+	if len(value) != length {
+		return false
+	}
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			if char < 'a' || char > 'f' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func safeName(value string) bool {
+	if value == "" || value == "." || value == ".." || filepath.Base(value) != value {
+		return false
+	}
+	for _, char := range value {
+		if char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' || char >= '0' && char <= '9' ||
+			char == '.' || char == '_' || char == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func pathWithin(root, path string) bool {
+	relative, err := filepath.Rel(root, path)
+	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}

--- a/internal/oven/store_test.go
+++ b/internal/oven/store_test.go
@@ -1,0 +1,171 @@
+package oven
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	testStoreSlotID     = "11111111111111111111111111111111"
+	testStoreOtherID    = "22222222222222222222222222222222"
+	testStoreRecipeKey  = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testStoreGeneration = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func TestStoreRoundTripUsesPrivatePermissions(t *testing.T) {
+	store := NewStore(t.TempDir())
+	inventory := Inventory{Version: InventoryVersion, Slots: []Slot{{
+		ID: testStoreSlotID, RecipeKey: testStoreRecipeKey, Generation: testStoreGeneration, Runner: "runner",
+		RecipeName: "stack", RecipePath: "/recipes/stack.yaml", BackingPath: store.SlotPath(testStoreGeneration, testStoreSlotID),
+		Status: StatusReady, CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z",
+		Repositories: []Repository{{Name: "api", SourceRepo: "/repos/api", WorktreePath: filepath.Join(store.SlotPath(testStoreGeneration, testStoreSlotID), "api"), Commit: "aaaa"}},
+	}}}
+	if err := store.Save(inventory); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Slots) != 1 || loaded.Slots[0].ID != testStoreSlotID || loaded.Slots[0].Status != StatusReady {
+		t.Fatalf("round trip = %+v", loaded)
+	}
+	if info, err := os.Stat(store.Root); err != nil {
+		t.Fatal(err)
+	} else if info.Mode().Perm() != 0o700 {
+		t.Fatalf("root permissions = %v", info.Mode().Perm())
+	}
+	if info, err := os.Stat(store.Path); err != nil {
+		t.Fatal(err)
+	} else if info.Mode().Perm() != 0o600 {
+		t.Fatalf("inventory permissions = %v", info.Mode().Perm())
+	}
+}
+
+func TestStoreRejectsInvalidInventory(t *testing.T) {
+	store := NewStore(t.TempDir())
+	valid := Slot{
+		ID: testStoreSlotID, RecipeKey: testStoreRecipeKey, Generation: testStoreGeneration, Runner: "runner",
+		BackingPath: store.SlotPath(testStoreGeneration, testStoreSlotID), Status: StatusReady,
+		Repositories: []Repository{{Name: "api", SourceRepo: "/repos/api", WorktreePath: filepath.Join(store.SlotPath(testStoreGeneration, testStoreSlotID), "api"), Commit: "aaaa"}},
+	}
+	tests := map[string]Inventory{
+		"version":   {Version: InventoryVersion + 1},
+		"duplicate": {Version: InventoryVersion, Slots: []Slot{valid, valid}},
+		"status": func() Inventory {
+			invalid := valid
+			invalid.Repositories = append([]Repository(nil), valid.Repositories...)
+			invalid.ID = testStoreOtherID
+			invalid.BackingPath = store.SlotPath(testStoreGeneration, testStoreOtherID)
+			invalid.Repositories[0].WorktreePath = filepath.Join(invalid.BackingPath, "api")
+			invalid.Status = SlotStatus("unknown")
+			return Inventory{Version: InventoryVersion, Slots: []Slot{invalid}}
+		}(),
+		"path": func() Inventory {
+			invalid := valid
+			invalid.ID = testStoreOtherID
+			invalid.BackingPath = filepath.Join(t.TempDir(), "outside")
+			return Inventory{Version: InventoryVersion, Slots: []Slot{invalid}}
+		}(),
+	}
+	for name, inventory := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := store.Save(inventory); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestInventorySelectsNewestReadySlot(t *testing.T) {
+	inventory := Inventory{Version: InventoryVersion, Slots: []Slot{
+		{ID: "old", RecipeKey: "recipe", Runner: "runner", Status: StatusReady, UpdatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "new", RecipeKey: "recipe", Runner: "runner", Status: StatusReady, UpdatedAt: "2026-01-02T00:00:00Z"},
+		{ID: "other-runner", RecipeKey: "recipe", Runner: "other", Status: StatusReady, UpdatedAt: "2026-01-03T00:00:00Z"},
+		{ID: "failed", RecipeKey: "recipe", Runner: "runner", Status: StatusFailed, UpdatedAt: "2026-01-04T00:00:00Z"},
+	}}
+	slot := inventory.ReadySlot("recipe", "runner")
+	if slot == nil || slot.ID != "new" {
+		t.Fatalf("ready slot = %+v", slot)
+	}
+}
+
+func TestInventoryFindsActiveClaim(t *testing.T) {
+	inventory := Inventory{Version: InventoryVersion, Slots: []Slot{
+		{ID: "ready", Status: StatusReady},
+		{ID: "claiming", Status: StatusClaiming, Claim: &Claim{WorkspaceName: "cake"}},
+		{ID: "claimed", Status: StatusClaimed, Claim: &Claim{WorkspaceName: "pie"}},
+	}}
+	if slot := inventory.ClaimForWorkspace("cake"); slot == nil || slot.ID != "claiming" {
+		t.Fatalf("claiming slot = %+v", slot)
+	}
+	if slot := inventory.ClaimForWorkspace("pie"); slot == nil || slot.ID != "claimed" {
+		t.Fatalf("claimed slot = %+v", slot)
+	}
+	if slot := inventory.ClaimForWorkspace("missing"); slot != nil {
+		t.Fatalf("unexpected claim = %+v", slot)
+	}
+}
+
+func TestStoreUpdateSlot(t *testing.T) {
+	inventory := Inventory{Version: InventoryVersion, Slots: []Slot{{ID: "slot", Status: StatusBaking, UpdatedAt: "2026-01-01T00:00:00Z"}}}
+	if err := inventory.UpdateSlot("slot", func(slot *Slot) error {
+		slot.Status = StatusReady
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if inventory.Slots[0].Status != StatusReady {
+		t.Fatalf("slot = %+v", inventory.Slots[0])
+	}
+	if err := inventory.UpdateSlot("missing", func(*Slot) error { return nil }); err == nil {
+		t.Fatal("expected missing slot error")
+	}
+}
+
+func TestStoreRejectsMissingInventoryAndSymlinkRoot(t *testing.T) {
+	t.Run("missing inventory", func(t *testing.T) {
+		store := NewStore(t.TempDir())
+		if err := os.Mkdir(store.Root, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.Load(); err == nil {
+			t.Fatal("expected existing root without inventory to fail closed")
+		}
+	})
+
+	t.Run("symlink root", func(t *testing.T) {
+		base := t.TempDir()
+		target := filepath.Join(base, "target")
+		if err := os.Mkdir(target, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		store := NewStore(filepath.Join(base, "grove"))
+		if err := os.Mkdir(filepath.Dir(store.Root), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, store.Root); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.Load(); err == nil {
+			t.Fatal("expected symlink Oven root to be rejected")
+		}
+		if err := store.Save(NewInventory()); err == nil {
+			t.Fatal("expected save through symlink Oven root to be rejected")
+		}
+	})
+}
+
+func TestStoreRejectsPermissiveInventory(t *testing.T) {
+	store := NewStore(t.TempDir())
+	if err := store.Save(NewInventory()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(store.Path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Load(); err == nil {
+		t.Fatal("expected permissive inventory to be rejected")
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -54,11 +54,36 @@ func (s *Store) Save(workspaces []models.Workspace) error {
 		return err
 	}
 
-	tmp := s.Path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	temporary, err := os.CreateTemp(filepath.Dir(s.Path), "state-*.tmp")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, s.Path)
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o644); err != nil {
+		temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(data); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, s.Path); err != nil {
+		return err
+	}
+	directory, err := os.Open(filepath.Dir(s.Path))
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
 }
 
 // GetWorkspace finds a workspace by name.

--- a/internal/workspace/oven.go
+++ b/internal/workspace/oven.go
@@ -1,0 +1,398 @@
+package workspace
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/nicksenap/grove/internal/gitops"
+	"github.com/nicksenap/grove/internal/oven"
+)
+
+var (
+	ovenRepositoryName      = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+	ErrOvenGenerationActive = errors.New("oven generation already has an active slot")
+)
+
+type OvenBakeOptions struct {
+	RecipeKey  string
+	RecipeName string
+	RecipePath string
+	Generation string
+	Runner     string
+	Repos      []string
+	RepoMap    map[string]string
+	Commits    map[string]string
+
+	slotID string
+	now    func() time.Time
+}
+
+type OvenBakeError struct {
+	Cause      error
+	CleanupErr error
+}
+
+func (err *OvenBakeError) Error() string {
+	if err.CleanupErr != nil {
+		return fmt.Sprintf("baking Oven slot: %s; cleanup failed: %s", err.Cause, err.CleanupErr)
+	}
+	return fmt.Sprintf("baking Oven slot: %s", err.Cause)
+}
+
+func (err *OvenBakeError) Unwrap() error { return err.Cause }
+
+// BakeOvenSlot creates detached exact-commit worktrees under the private Oven
+// root, runs trusted Recipe preparation outside the mutation lock, and exposes
+// the slot as ready only after an ownership recheck.
+func (service *Service) BakeOvenSlot(options OvenBakeOptions, prepare func(map[string]string) error) (*oven.Slot, error) {
+	if service.Oven == nil {
+		return nil, fmt.Errorf("oven store is not configured")
+	}
+	slot, err := service.newBakingSlot(options)
+	if err != nil {
+		return nil, err
+	}
+	created, recorded, err := service.createDetachedSlot(slot)
+	if err != nil {
+		if !recorded {
+			return nil, &OvenBakeError{Cause: err}
+		}
+		cleanupErr := service.failOvenBake(slot.ID, created, err)
+		return nil, &OvenBakeError{Cause: err, CleanupErr: cleanupErr}
+	}
+
+	worktrees := make(map[string]string, len(slot.Repositories))
+	for _, repository := range slot.Repositories {
+		worktrees[repository.Name] = repository.WorktreePath
+	}
+	if err := prepare(worktrees); err != nil {
+		cleanupErr := service.failOvenBake(slot.ID, slot.Repositories, err)
+		return nil, &OvenBakeError{Cause: err, CleanupErr: cleanupErr}
+	}
+
+	var ready *oven.Slot
+	err = service.State.WithLock(func() error {
+		inventory, err := service.Oven.Load()
+		if err != nil {
+			return err
+		}
+		current := inventory.FindSlot(slot.ID)
+		if current == nil || current.Status != oven.StatusBaking || !sameOvenSlotIdentity(*current, slot) {
+			return fmt.Errorf("oven slot changed during bake; refusing readiness")
+		}
+		if err := errors.Join(
+			service.verifyOvenBackingPath(*current),
+			verifyDetachedOvenRepositories(*current, current.Repositories),
+			verifyNoOvenCredentialResidue(*current),
+		); err != nil {
+			current.Status = oven.StatusQuarantined
+			current.OwnerPID = 0
+			current.Failure = safeOvenFailure(err)
+			current.UpdatedAt = ovenTimestamp(options)
+			if saveErr := service.Oven.Save(inventory); saveErr != nil {
+				return errors.Join(err, saveErr)
+			}
+			return err
+		}
+		current.Status = oven.StatusReady
+		current.OwnerPID = 0
+		current.Failure = ""
+		current.UpdatedAt = ovenTimestamp(options)
+		if err := service.Oven.Save(inventory); err != nil {
+			return err
+		}
+		copy := *current
+		ready = &copy
+		return nil
+	})
+	if err != nil {
+		return nil, &OvenBakeError{Cause: err}
+	}
+	return ready, nil
+}
+
+func (service *Service) newBakingSlot(options OvenBakeOptions) (oven.Slot, error) {
+	if options.RecipeKey == "" || options.Generation == "" || options.Runner == "" || len(options.Repos) == 0 {
+		return oven.Slot{}, fmt.Errorf("recipe identity, generation, runner, and repositories are required")
+	}
+	id := options.slotID
+	if id == "" {
+		var err error
+		id, err = randomOvenID()
+		if err != nil {
+			return oven.Slot{}, err
+		}
+	}
+	backingPath := service.Oven.SlotPath(options.Generation, id)
+	timestamp := ovenTimestamp(options)
+	slot := oven.Slot{
+		ID: id, RecipeKey: options.RecipeKey, RecipeName: options.RecipeName,
+		RecipePath: options.RecipePath, Generation: options.Generation, Runner: options.Runner,
+		BackingPath: backingPath, Status: oven.StatusBaking, OwnerPID: os.Getpid(), CreatedAt: timestamp, UpdatedAt: timestamp,
+	}
+	seen := make(map[string]bool, len(options.Repos))
+	for _, name := range options.Repos {
+		if !ovenRepositoryName.MatchString(name) || name == "." || name == ".." || seen[name] {
+			return oven.Slot{}, fmt.Errorf("invalid or duplicate Oven repository name %q", name)
+		}
+		seen[name] = true
+		source := options.RepoMap[name]
+		commit := options.Commits[name]
+		if source == "" || commit == "" {
+			return oven.Slot{}, fmt.Errorf("repository %s has no source or exact commit", name)
+		}
+		slot.Repositories = append(slot.Repositories, oven.Repository{
+			Name: name, SourceRepo: canonicalPath(source),
+			WorktreePath: filepath.Join(backingPath, name), Commit: commit,
+		})
+	}
+	return slot, nil
+}
+
+func (service *Service) createDetachedSlot(slot oven.Slot) ([]oven.Repository, bool, error) {
+	created := make([]oven.Repository, 0, len(slot.Repositories))
+	recorded := false
+	err := service.State.WithLock(func() error {
+		inventory, err := service.Oven.Load()
+		if err != nil {
+			return err
+		}
+		if inventory.FindSlot(slot.ID) != nil {
+			return fmt.Errorf("oven slot %s already exists", slot.ID)
+		}
+		for _, existing := range inventory.Slots {
+			if existing.RecipeKey == slot.RecipeKey && existing.Generation == slot.Generation && existing.Runner == slot.Runner &&
+				(existing.Status == oven.StatusBaking || existing.Status == oven.StatusReady) {
+				return ErrOvenGenerationActive
+			}
+		}
+		inventory.Slots = append(inventory.Slots, slot)
+		if err := service.Oven.Save(inventory); err != nil {
+			return err
+		}
+		recorded = true
+		if err := createOvenBackingDirectory(service.Oven, slot); err != nil {
+			return err
+		}
+		for _, repository := range slot.Repositories {
+			if err := gitops.WorktreeAddDetached(repository.SourceRepo, repository.WorktreePath, repository.Commit); err != nil {
+				return fmt.Errorf("%s: creating detached worktree: %w", repository.Name, err)
+			}
+			created = append(created, repository)
+		}
+		return nil
+	})
+	return created, recorded, err
+}
+
+func createOvenBackingDirectory(store *oven.Store, slot oven.Slot) error {
+	directories := []string{
+		store.GenerationsPath(),
+		filepath.Join(store.GenerationsPath(), slot.Generation),
+		filepath.Join(store.GenerationsPath(), slot.Generation, "slots"),
+	}
+	for _, directory := range directories {
+		if err := ensurePrivateOvenDirectory(directory); err != nil {
+			return err
+		}
+	}
+	if err := os.Mkdir(slot.BackingPath, 0o700); err != nil {
+		return fmt.Errorf("creating Oven backing path: %w", err)
+	}
+	return nil
+}
+
+func ensurePrivateOvenDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		if err := os.Mkdir(path, 0o700); err != nil {
+			return fmt.Errorf("creating Oven directory %s: %w", path, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0o700 {
+		return fmt.Errorf("unsafe Oven directory %s", path)
+	}
+	return nil
+}
+
+func (service *Service) failOvenBake(slotID string, created []oven.Repository, cause error) error {
+	return service.State.WithLock(func() error {
+		inventory, err := service.Oven.Load()
+		if err != nil {
+			return err
+		}
+		slot := inventory.FindSlot(slotID)
+		if slot == nil || slot.Status != oven.StatusBaking {
+			return fmt.Errorf("oven slot changed after bake failure; refusing cleanup")
+		}
+		if err := verifyDetachedOvenRepositories(*slot, created); err != nil {
+			slot.Status = oven.StatusQuarantined
+			slot.OwnerPID = 0
+			slot.Failure = safeOvenFailure(errors.Join(cause, err))
+			slot.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+			return service.Oven.Save(inventory)
+		}
+
+		var cleanupErrs []error
+		for index := len(created) - 1; index >= 0; index-- {
+			repository := created[index]
+			if err := service.removeWorktree(repository.SourceRepo, repository.WorktreePath, true); err != nil {
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("%s: removing failed Oven worktree: %w", repository.Name, err))
+			}
+		}
+		if len(cleanupErrs) == 0 {
+			if err := os.Remove(slot.BackingPath); err != nil && !os.IsNotExist(err) {
+				cleanupErrs = append(cleanupErrs, err)
+			}
+		}
+		if len(cleanupErrs) > 0 {
+			slot.Status = oven.StatusQuarantined
+		} else {
+			slot.Status = oven.StatusFailed
+		}
+		slot.OwnerPID = 0
+		slot.Failure = safeOvenFailure(cause)
+		slot.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		if err := service.Oven.Save(inventory); err != nil {
+			cleanupErrs = append(cleanupErrs, err)
+		}
+		return errors.Join(cleanupErrs...)
+	})
+}
+
+func verifyDetachedOvenRepositories(slot oven.Slot, repositories []oven.Repository) error {
+	for _, repository := range repositories {
+		if filepath.Dir(repository.WorktreePath) != slot.BackingPath || filepath.Base(repository.WorktreePath) != repository.Name {
+			return fmt.Errorf("%s: worktree path escapes its Oven slot", repository.Name)
+		}
+		entries, err := gitops.WorktreeList(repository.SourceRepo)
+		if err != nil {
+			return err
+		}
+		registered := false
+		for _, entry := range entries {
+			if canonicalPath(entry.Path) == canonicalPath(repository.WorktreePath) && entry.Branch == "" {
+				registered = true
+				break
+			}
+		}
+		if !registered {
+			return fmt.Errorf("%s: detached worktree registration changed", repository.Name)
+		}
+		branch, err := gitops.CurrentBranch(repository.WorktreePath)
+		if err != nil || branch != "" {
+			return fmt.Errorf("%s: prepared worktree is not detached", repository.Name)
+		}
+		head, err := gitops.HeadCommit(repository.WorktreePath)
+		if err != nil || head != repository.Commit {
+			return fmt.Errorf("%s: prepared commit changed", repository.Name)
+		}
+		if status, err := gitops.TrackedStatus(repository.WorktreePath); err != nil || status != "" {
+			return fmt.Errorf("%s: prepared tracked files changed", repository.Name)
+		}
+	}
+	return nil
+}
+
+func verifyNoOvenCredentialResidue(slot oven.Slot) error {
+	for _, repository := range slot.Repositories {
+		entries := 0
+		err := filepath.WalkDir(repository.WorktreePath, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			entries++
+			if entries > 100000 {
+				return fmt.Errorf("%s: credential residue scan exceeded its entry limit", repository.Name)
+			}
+			if entry.IsDir() && path != repository.WorktreePath {
+				switch entry.Name() {
+				case "node_modules", ".venv", ".cache", "vendor":
+					return filepath.SkipDir
+				}
+			}
+			if entry.IsDir() || !forbiddenOvenCredentialPath(path) {
+				return nil
+			}
+			relative, _ := filepath.Rel(repository.WorktreePath, path)
+			return fmt.Errorf("%s: credential file %s remains after preparation", repository.Name, relative)
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func forbiddenOvenCredentialPath(path string) bool {
+	name := filepath.Base(path)
+	switch name {
+	case ".npmrc", ".pypirc", ".netrc", ".git-credentials", "id_rsa", "id_ed25519":
+		return true
+	case "credentials":
+		return filepath.Base(filepath.Dir(path)) == ".aws"
+	case "config.json":
+		return filepath.Base(filepath.Dir(path)) == ".docker"
+	}
+	if name == ".env" || strings.HasPrefix(name, ".env.") {
+		return !strings.HasSuffix(name, ".example") && !strings.HasSuffix(name, ".sample") && !strings.HasSuffix(name, ".template")
+	}
+	return false
+}
+
+func sameOvenSlotIdentity(left, right oven.Slot) bool {
+	if left.ID != right.ID || left.RecipeKey != right.RecipeKey || left.Generation != right.Generation ||
+		left.Runner != right.Runner || left.BackingPath != right.BackingPath || len(left.Repositories) != len(right.Repositories) {
+		return false
+	}
+	for index := range left.Repositories {
+		if left.Repositories[index] != right.Repositories[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func randomOvenID() (string, error) {
+	data := make([]byte, 16)
+	if _, err := rand.Read(data); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(data), nil
+}
+
+func ovenTimestamp(options OvenBakeOptions) string {
+	now := options.now
+	if now == nil {
+		now = time.Now
+	}
+	return now().UTC().Format(time.RFC3339Nano)
+}
+
+func safeOvenFailure(err error) string {
+	if err == nil {
+		return ""
+	}
+	message := strings.Map(func(char rune) rune {
+		if char < 0x20 || char == 0x7f || char >= 0x80 && char <= 0x9f {
+			return ' '
+		}
+		return char
+	}, err.Error())
+	message = strings.TrimSpace(message)
+	if len(message) > 1024 {
+		message = message[:1024]
+	}
+	return message
+}

--- a/internal/workspace/oven_claim.go
+++ b/internal/workspace/oven_claim.go
@@ -1,0 +1,359 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/nicksenap/grove/internal/gitops"
+	"github.com/nicksenap/grove/internal/models"
+	"github.com/nicksenap/grove/internal/oven"
+)
+
+var (
+	ErrOvenMiss    = errors.New("no ready Oven slot")
+	ErrOvenBlocked = errors.New("oven claim blocked by quarantined state")
+)
+
+type OvenClaimOptions struct {
+	RecipeKey string
+	Runner    string
+	Name      string
+	Branch    string
+	Config    *models.Config
+	Source    *models.WorkspaceSource
+
+	nonce         string
+	now           func() time.Time
+	attachBranch  func(oven.ClaimRepository, string) error
+	publishAlias  func(string, string) error
+	saveWorkspace func(models.Workspace) error
+}
+
+type OvenClaimResult struct {
+	Workspace models.Workspace
+	SlotID    string
+	Warning   error
+}
+
+func (service *Service) ClaimOvenSlot(options OvenClaimOptions) (*OvenClaimResult, error) {
+	if service.Oven == nil {
+		return nil, ErrOvenMiss
+	}
+	if options.Config == nil || options.RecipeKey == "" || options.Runner == "" || options.Name == "" || options.Branch == "" {
+		return nil, fmt.Errorf("oven claim requires Recipe identity, runner, workspace name, branch, and config")
+	}
+	if options.Name == "." || options.Name == ".." || filepath.Base(options.Name) != options.Name {
+		return nil, fmt.Errorf("invalid Oven workspace name %q", options.Name)
+	}
+
+	var result *OvenClaimResult
+	err := service.State.WithLock(func() error {
+		var err error
+		result, err = service.claimOvenSlotLocked(options)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	service.finishCreate(result.Workspace)
+	return result, nil
+}
+
+func (service *Service) claimOvenSlotLocked(options OvenClaimOptions) (*OvenClaimResult, error) {
+	inventory, err := service.Oven.Load()
+	if err != nil {
+		return nil, err
+	}
+	slot := inventory.ReadySlot(options.RecipeKey, options.Runner)
+	if slot == nil {
+		if blocked := inventory.BlockingSlot(options.RecipeKey, options.Runner); blocked != nil {
+			return nil, fmt.Errorf("%w: slot %s: %s", ErrOvenBlocked, blocked.ID, blocked.Failure)
+		}
+		return nil, ErrOvenMiss
+	}
+	if err := service.preflightReadyOvenClaim(options, *slot); err != nil {
+		slot.Status = oven.StatusQuarantined
+		slot.Failure = safeOvenFailure(err)
+		slot.UpdatedAt = ovenClaimTimestamp(options)
+		if saveErr := service.Oven.Save(inventory); saveErr != nil {
+			return nil, errors.Join(err, saveErr)
+		}
+		return nil, fmt.Errorf("%w: ready slot %s was quarantined: %v", ErrOvenBlocked, slot.ID, err)
+	}
+	return service.executeOvenClaimLocked(options, inventory, slot)
+}
+
+func (service *Service) executeOvenClaimLocked(options OvenClaimOptions, inventory oven.Inventory, slot *oven.Slot) (*OvenClaimResult, error) {
+	claim, err := service.newOvenClaim(options, *slot)
+	if err != nil {
+		return nil, err
+	}
+	slot.Status = oven.StatusClaiming
+	slot.Claim = &claim
+	slot.UpdatedAt = ovenClaimTimestamp(options)
+	if err := service.Oven.Save(inventory); err != nil {
+		return nil, err
+	}
+
+	workspace, assigned, err := service.attachOvenClaimRepositories(options, *slot, claim)
+	if err != nil {
+		return nil, service.rollbackOvenClaim(slot.ID, claim.Nonce, assigned, false, err)
+	}
+	if err := service.publishOvenClaimAlias(options, *slot, claim); err != nil {
+		return nil, service.rollbackOvenClaim(slot.ID, claim.Nonce, assigned, false, err)
+	}
+	if err := verifyOvenClaimFilesystem(*slot, claim, true); err != nil {
+		return nil, service.rollbackOvenClaim(slot.ID, claim.Nonce, assigned, true, err)
+	}
+
+	result, err := service.saveClaimedOvenWorkspace(options, workspace, slot.ID)
+	if err != nil {
+		return nil, service.rollbackOvenClaim(slot.ID, claim.Nonce, assigned, true, err)
+	}
+	writeMCPConfig(workspace)
+	slot.Status = oven.StatusClaimed
+	slot.UpdatedAt = ovenClaimTimestamp(options)
+	if err := service.Oven.Save(inventory); err != nil {
+		result.Warning = errors.Join(result.Warning, fmt.Errorf("finalizing oven claim inventory: %w", err))
+	}
+	return result, nil
+}
+
+func (service *Service) attachOvenClaimRepositories(options OvenClaimOptions, slot oven.Slot, claim oven.Claim) (models.Workspace, []oven.ClaimRepository, error) {
+	workspace := models.NewWorkspace(options.Name, claim.Alias, options.Branch)
+	workspace.Source = options.Source
+	workspace.Oven = &models.OvenOwnership{SlotID: slot.ID, ClaimNonce: claim.Nonce}
+	assigned := make([]oven.ClaimRepository, 0, len(claim.Repositories))
+	attach := options.attachBranch
+	if attach == nil {
+		attach = func(repository oven.ClaimRepository, commit string) error {
+			return gitops.AttachWorktreeBranch(repository.PhysicalPath, repository.Branch, commit, repository.BranchCreated)
+		}
+	}
+	for _, repository := range claim.Repositories {
+		prepared := ovenRepositoryByName(slot, repository.Name)
+		if err := preflightReadyOvenRepository(slot, prepared, options.Branch); err != nil {
+			return workspace, assigned, err
+		}
+		if err := attach(repository, prepared.Commit); err != nil {
+			return workspace, assigned, fmt.Errorf("%s: attaching claim branch: %w", repository.Name, err)
+		}
+		assigned = append(assigned, repository)
+		workspace.Repos = append(workspace.Repos, models.RepoWorktree{
+			RepoName: repository.Name, SourceRepo: repository.SourceRepo,
+			WorktreePath: repository.AliasPath, Branch: options.Branch,
+			PreserveBranch: !repository.BranchCreated,
+		})
+	}
+	return workspace, assigned, nil
+}
+
+func (service *Service) publishOvenClaimAlias(options OvenClaimOptions, slot oven.Slot, claim oven.Claim) error {
+	if _, err := os.Lstat(claim.Alias); !os.IsNotExist(err) {
+		return fmt.Errorf("workspace path changed before oven claim publication")
+	}
+	publish := options.publishAlias
+	if publish == nil {
+		publish = os.Symlink
+	}
+	if err := publish(slot.BackingPath, claim.Alias); err != nil {
+		return fmt.Errorf("publishing oven workspace alias: %w", err)
+	}
+	return nil
+}
+
+func (service *Service) saveClaimedOvenWorkspace(options OvenClaimOptions, workspace models.Workspace, slotID string) (*OvenClaimResult, error) {
+	save := options.saveWorkspace
+	if save == nil {
+		save = service.State.AddWorkspace
+	}
+	if err := save(workspace); err != nil {
+		current, readErr := service.State.GetWorkspace(workspace.Name)
+		if readErr != nil || current == nil || !reflect.DeepEqual(*current, workspace) {
+			return nil, errors.Join(err, readErr)
+		}
+		return &OvenClaimResult{Workspace: workspace, SlotID: slotID, Warning: err}, nil
+	}
+	return &OvenClaimResult{Workspace: workspace, SlotID: slotID}, nil
+}
+
+func (service *Service) preflightReadyOvenClaim(options OvenClaimOptions, slot oven.Slot) error {
+	if slot.Status != oven.StatusReady || slot.Claim != nil || slot.RecipeKey != options.RecipeKey || slot.Runner != options.Runner {
+		return fmt.Errorf("oven slot is not ready for this Recipe and runner")
+	}
+	if existing, err := service.State.GetWorkspace(options.Name); err != nil {
+		return err
+	} else if existing != nil {
+		return fmt.Errorf("workspace %s already exists", options.Name)
+	}
+	alias := filepath.Join(options.Config.WorkspaceDir, options.Name)
+	if _, err := os.Lstat(alias); err == nil {
+		return fmt.Errorf("workspace path already exists: %s", alias)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := service.verifyOvenBackingPath(slot); err != nil {
+		return err
+	}
+	if err := verifyDetachedOvenRepositories(slot, slot.Repositories); err != nil {
+		return err
+	}
+	for _, repository := range slot.Repositories {
+		if !sourceRepoAllowed(options.Config, repository.SourceRepo) {
+			return fmt.Errorf("%s: source repository is outside configured repository directories", repository.Name)
+		}
+		if err := preflightReadyOvenRepository(slot, repository, options.Branch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func sourceRepoAllowed(config *models.Config, sourceRepo string) bool {
+	canonicalSource := canonicalPath(sourceRepo)
+	for _, root := range config.RepoDirs {
+		canonicalRoot := canonicalPath(root)
+		relative, err := filepath.Rel(canonicalRoot, canonicalSource)
+		if err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+func preflightReadyOvenRepository(slot oven.Slot, repository oven.Repository, branch string) error {
+	if repository.Name == "" {
+		return fmt.Errorf("oven repository is missing")
+	}
+	hasWorktree, err := gitops.WorktreeHasBranch(repository.SourceRepo, branch)
+	if err != nil {
+		return err
+	}
+	if hasWorktree {
+		return fmt.Errorf("%s: branch %s already has a worktree", repository.Name, branch)
+	}
+	if gitops.BranchExists(repository.SourceRepo, branch) {
+		commit, err := gitops.LocalBranchCommit(repository.SourceRepo, branch)
+		if err != nil || commit != repository.Commit {
+			return fmt.Errorf("%s: branch %s exists at a different commit", repository.Name, branch)
+		}
+	}
+	return nil
+}
+
+func (service *Service) newOvenClaim(options OvenClaimOptions, slot oven.Slot) (oven.Claim, error) {
+	nonce := options.nonce
+	if nonce == "" {
+		var err error
+		nonce, err = randomOvenID()
+		if err != nil {
+			return oven.Claim{}, err
+		}
+	}
+	alias := filepath.Join(options.Config.WorkspaceDir, options.Name)
+	claim := oven.Claim{
+		Nonce: nonce, WorkspaceName: options.Name, Alias: alias,
+		Branch: options.Branch, StartedAt: ovenClaimTimestamp(options),
+	}
+	for _, repository := range slot.Repositories {
+		claim.Repositories = append(claim.Repositories, oven.ClaimRepository{
+			Name: repository.Name, SourceRepo: repository.SourceRepo,
+			PhysicalPath: repository.WorktreePath, AliasPath: filepath.Join(alias, repository.Name),
+			Branch: options.Branch, BranchCreated: !gitops.BranchExists(repository.SourceRepo, options.Branch),
+		})
+	}
+	return claim, nil
+}
+
+func (service *Service) rollbackOvenClaim(slotID, nonce string, assigned []oven.ClaimRepository, aliasCreated bool, cause error) error {
+	inventory, err := service.Oven.Load()
+	if err != nil {
+		return errors.Join(cause, err)
+	}
+	slot := inventory.FindSlot(slotID)
+	if slot == nil || slot.Status != oven.StatusClaiming || slot.Claim == nil || slot.Claim.Nonce != nonce {
+		return errors.Join(cause, fmt.Errorf("oven claim identity changed; preserving artifacts"))
+	}
+	if err := preflightOvenClaimRollback(*slot, *slot.Claim, assigned, aliasCreated); err != nil {
+		slot.Status = oven.StatusQuarantined
+		slot.Failure = safeOvenFailure(errors.Join(cause, err))
+		if saveErr := service.Oven.Save(inventory); saveErr != nil {
+			return errors.Join(cause, err, saveErr)
+		}
+		return errors.Join(cause, err)
+	}
+
+	var rollbackErrs []error
+	if aliasCreated {
+		if err := os.Remove(slot.Claim.Alias); err != nil && !os.IsNotExist(err) {
+			rollbackErrs = append(rollbackErrs, err)
+		}
+	}
+	for index := len(assigned) - 1; index >= 0; index-- {
+		repository := assigned[index]
+		commit := ovenRepositoryByName(*slot, repository.Name).Commit
+		if err := gitops.DetachWorktree(repository.PhysicalPath, commit); err != nil {
+			rollbackErrs = append(rollbackErrs, fmt.Errorf("%s: detaching rollback: %w", repository.Name, err))
+			continue
+		}
+		if repository.BranchCreated {
+			if err := gitops.DeleteBranchIfAt(repository.SourceRepo, repository.Branch, commit, true); err != nil {
+				rollbackErrs = append(rollbackErrs, fmt.Errorf("%s: deleting rollback branch: %w", repository.Name, err))
+			}
+		}
+	}
+	if len(rollbackErrs) > 0 {
+		slot.Status = oven.StatusQuarantined
+		slot.Failure = safeOvenFailure(errors.Join(cause, errors.Join(rollbackErrs...)))
+	} else {
+		slot.Status = oven.StatusReady
+		slot.Claim = nil
+		slot.Failure = ""
+	}
+	if err := service.Oven.Save(inventory); err != nil {
+		rollbackErrs = append(rollbackErrs, err)
+	}
+	return errors.Join(cause, errors.Join(rollbackErrs...))
+}
+
+func preflightOvenClaimRollback(slot oven.Slot, claim oven.Claim, assigned []oven.ClaimRepository, aliasCreated bool) error {
+	if aliasCreated {
+		target, err := os.Readlink(claim.Alias)
+		if err != nil || canonicalPath(target) != canonicalPath(slot.BackingPath) {
+			return fmt.Errorf("oven claim alias changed; preserving artifacts")
+		}
+	}
+	for _, repository := range assigned {
+		branch, err := gitops.CurrentBranch(repository.PhysicalPath)
+		if err != nil || branch != claim.Branch {
+			return fmt.Errorf("%s: claim branch changed; preserving artifacts", repository.Name)
+		}
+		head, err := gitops.HeadCommit(repository.PhysicalPath)
+		if err != nil || head != ovenRepositoryByName(slot, repository.Name).Commit {
+			return fmt.Errorf("%s: claim commit changed; preserving artifacts", repository.Name)
+		}
+	}
+	return nil
+}
+
+func ovenRepositoryByName(slot oven.Slot, name string) oven.Repository {
+	for _, repository := range slot.Repositories {
+		if repository.Name == name {
+			return repository
+		}
+	}
+	return oven.Repository{}
+}
+
+func ovenClaimTimestamp(options OvenClaimOptions) string {
+	now := options.now
+	if now == nil {
+		now = time.Now
+	}
+	return now().UTC().Format(time.RFC3339Nano)
+}

--- a/internal/workspace/oven_claim_test.go
+++ b/internal/workspace/oven_claim_test.go
@@ -1,0 +1,588 @@
+package workspace
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicksenap/grove/internal/gitops"
+	"github.com/nicksenap/grove/internal/models"
+	"github.com/nicksenap/grove/internal/oven"
+)
+
+func bakeTestOvenSlot(t *testing.T, env *testEnv, slotID string, repoNames ...string) *oven.Slot {
+	t.Helper()
+	configureTestOven(env)
+	options := ovenBakeOptions(env, slotID, repoNames...)
+	slot, err := env.svc.BakeOvenSlot(options, func(worktrees map[string]string) error {
+		for _, path := range worktrees {
+			if err := os.MkdirAll(filepath.Join(path, "node_modules"), 0o755); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return slot
+}
+
+func ovenClaimOptions(env *testEnv, name, branch string) OvenClaimOptions {
+	return OvenClaimOptions{
+		RecipeKey: testOvenRecipeKey, Runner: "test-runner", Name: name, Branch: branch, Config: env.cfg,
+		nonce: "cccccccccccccccccccccccccccccccc", now: func() time.Time { return time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC) },
+	}
+}
+
+func TestClaimOvenSlotCreatesNormalWorkspaceAndCleansBackingOnDelete(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	env.createRepo("web")
+	slot := bakeTestOvenSlot(t, env, "slot-claim", "api", "web")
+
+	result, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "cake", "feat/cake"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SlotID != slot.ID || result.Warning != nil {
+		t.Fatalf("claim result = %+v", result)
+	}
+	assertClaimedOvenWorkspace(t, env, *slot)
+	if err := env.svc.Delete("cake"); err != nil {
+		t.Fatal(err)
+	}
+	assertDeletedOvenBacking(t, env, *slot)
+}
+
+func assertClaimedOvenWorkspace(t *testing.T, env *testEnv, slot oven.Slot) {
+	t.Helper()
+	workspace, err := env.svc.State.GetWorkspace("cake")
+	if err != nil || workspace == nil {
+		t.Fatalf("workspace = %+v, %v", workspace, err)
+	}
+	if target, err := os.Readlink(workspace.Path); err != nil || canonicalPath(target) != canonicalPath(slot.BackingPath) {
+		t.Fatalf("workspace alias = %q, %v", target, err)
+	}
+	for _, repository := range workspace.Repos {
+		if branch, err := gitops.CurrentBranch(repository.WorktreePath); err != nil || branch != "feat/cake" {
+			t.Fatalf("%s branch = %q, %v", repository.RepoName, branch, err)
+		}
+		if _, err := os.Stat(filepath.Join(repository.WorktreePath, "node_modules")); err != nil {
+			t.Fatalf("%s prepared dependency missing: %v", repository.RepoName, err)
+		}
+	}
+	inventory, err := env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimed := inventory.ClaimForWorkspace("cake")
+	if claimed == nil || claimed.Status != oven.StatusClaimed || claimed.Claim.Nonce != "cccccccccccccccccccccccccccccccc" {
+		t.Fatalf("claimed inventory = %+v", claimed)
+	}
+	if err := env.svc.Status("cake", StatusOptions{JSON: true}); err != nil {
+		t.Fatalf("status through oven alias: %v", err)
+	}
+}
+
+func assertDeletedOvenBacking(t *testing.T, env *testEnv, slot oven.Slot) {
+	t.Helper()
+	inventory, err := env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inventory.FindSlot(slot.ID) != nil {
+		t.Fatalf("deleted claim remained in inventory: %+v", inventory)
+	}
+	if _, err := os.Stat(slot.BackingPath); !os.IsNotExist(err) {
+		t.Fatalf("backing path remained after delete: %v", err)
+	}
+}
+
+func TestClaimOvenSlotPreservesPreexistingExactBranch(t *testing.T) {
+	env := setupTestEnv(t)
+	source := env.createRepo("api")
+	slot := bakeTestOvenSlot(t, env, "slot-existing-branch", "api")
+	if err := gitops.CreateBranch(source, "feat/existing", slot.Repositories[0].Commit); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "existing", "feat/existing")); err != nil {
+		t.Fatal(err)
+	}
+	workspace, _ := env.svc.State.GetWorkspace("existing")
+	if workspace == nil || !workspace.Repos[0].PreserveBranch {
+		t.Fatalf("pre-existing branch ownership not persisted: %+v", workspace)
+	}
+	if err := env.svc.DeleteWithOptions("existing", RemoveOptions{Force: true}); err != nil {
+		t.Fatal(err)
+	}
+	if !gitops.BranchExists(source, "feat/existing") {
+		t.Fatal("pre-existing branch was deleted")
+	}
+}
+
+func TestClaimOvenSlotMissDoesNotMutateWorkspaceState(t *testing.T) {
+	env := setupTestEnv(t)
+	configureTestOven(env)
+	_, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "miss", "feat/miss"))
+	if !errors.Is(err, ErrOvenMiss) {
+		t.Fatalf("claim error = %v, want Oven miss", err)
+	}
+	if workspace, _ := env.svc.State.GetWorkspace("miss"); workspace != nil {
+		t.Fatalf("miss created workspace: %+v", workspace)
+	}
+}
+
+func TestClaimOvenSlotRollsBackSecondBranchFailure(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	env.createRepo("web")
+	slot := bakeTestOvenSlot(t, env, "slot-attach-failure", "api", "web")
+	injected := errors.New("attach failed")
+	options := ovenClaimOptions(env, "failed", "feat/failed")
+	options.attachBranch = func(repository oven.ClaimRepository, commit string) error {
+		if repository.Name == "web" {
+			return injected
+		}
+		return gitops.AttachWorktreeBranch(repository.PhysicalPath, repository.Branch, commit, repository.BranchCreated)
+	}
+
+	if _, err := env.svc.ClaimOvenSlot(options); !errors.Is(err, injected) {
+		t.Fatalf("claim error = %v", err)
+	}
+	inventory, err := env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ready := inventory.FindSlot(slot.ID)
+	if ready == nil || ready.Status != oven.StatusReady || ready.Claim != nil {
+		t.Fatalf("rolled-back slot = %+v", ready)
+	}
+	for _, repository := range slot.Repositories {
+		if branch, err := gitops.CurrentBranch(repository.WorktreePath); err != nil || branch != "" {
+			t.Fatalf("%s branch after rollback = %q, %v", repository.Name, branch, err)
+		}
+		if gitops.BranchExists(repository.SourceRepo, "feat/failed") {
+			t.Fatalf("%s rollback branch remained", repository.Name)
+		}
+	}
+	if workspace, _ := env.svc.State.GetWorkspace("failed"); workspace != nil {
+		t.Fatalf("failed claim entered state: %+v", workspace)
+	}
+}
+
+func TestClaimOvenSlotPreservesExternalAliasRace(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	slot := bakeTestOvenSlot(t, env, "slot-alias-race", "api")
+	injected := errors.New("alias occupied")
+	options := ovenClaimOptions(env, "raced", "feat/raced")
+	options.publishAlias = func(_, target string) error {
+		if err := os.WriteFile(target, []byte("external"), 0o644); err != nil {
+			return err
+		}
+		return injected
+	}
+	if _, err := env.svc.ClaimOvenSlot(options); !errors.Is(err, injected) {
+		t.Fatalf("claim error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(env.wsDir, "raced"))
+	if err != nil || string(data) != "external" {
+		t.Fatalf("external target changed: %q, %v", data, err)
+	}
+	inventory, _ := env.svc.Oven.Load()
+	if current := inventory.FindSlot(slot.ID); current == nil || current.Status != oven.StatusReady {
+		t.Fatalf("slot after alias race = %+v", current)
+	}
+}
+
+func TestClaimOvenSlotTreatsCommittedStateWriteAsSuccess(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	bakeTestOvenSlot(t, env, "slot-uncertain", "api")
+	injected := errors.New("uncertain state result")
+	options := ovenClaimOptions(env, "uncertain", "feat/uncertain")
+	options.saveWorkspace = func(workspace models.Workspace) error {
+		if err := env.svc.State.AddWorkspace(workspace); err != nil {
+			return err
+		}
+		return injected
+	}
+	result, err := env.svc.ClaimOvenSlot(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !errors.Is(result.Warning, injected) {
+		t.Fatalf("claim warning = %v", result.Warning)
+	}
+	if workspace, _ := env.svc.State.GetWorkspace("uncertain"); workspace == nil {
+		t.Fatal("committed state was rolled back")
+	}
+	if err := env.svc.DeleteWithOptions("uncertain", RemoveOptions{Force: true}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOvenOwnershipBlocksTamperedStatusDeleteAndShapeChanges(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	slot := bakeTestOvenSlot(t, env, "slot-tamper", "api")
+	if _, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "claimed", "feat/claimed")); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(env.wsDir, "claimed")
+	if err := os.Remove(alias); err != nil {
+		t.Fatal(err)
+	}
+	replacement := filepath.Join(env.dir, "replacement")
+	if err := os.Mkdir(replacement, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(replacement, alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.svc.Status("claimed", StatusOptions{}); err == nil {
+		t.Fatal("status accepted retargeted alias")
+	}
+	if err := env.svc.DeleteWithOptions("claimed", RemoveOptions{Force: true}); err == nil {
+		t.Fatal("force delete accepted retargeted alias")
+	}
+	issues, fixed, err := env.svc.Doctor(true)
+	if err != nil || fixed != 0 || len(issues) == 0 {
+		t.Fatalf("Doctor changed tampered Oven state: issues=%+v fixed=%d err=%v", issues, fixed, err)
+	}
+	if workspace, _ := env.svc.State.GetWorkspace("claimed"); workspace == nil {
+		t.Fatal("tampered workspace state was removed")
+	}
+	if _, err := os.Stat(slot.BackingPath); err != nil {
+		t.Fatalf("owned backing was removed: %v", err)
+	}
+	if err := os.Remove(alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(slot.BackingPath, alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.svc.Rename("claimed", "renamed"); err == nil {
+		t.Fatal("renamed Oven-backed workspace")
+	}
+	if err := env.svc.AddRepos("claimed", []string{"api"}, env.repoMap); err == nil {
+		t.Fatal("added repository to Oven-backed workspace")
+	}
+	if err := env.svc.RemoveRepos("claimed", []string{"api"}); err == nil {
+		t.Fatal("removed repository from Oven-backed workspace")
+	}
+	if err := env.svc.DeleteWithOptions("claimed", RemoveOptions{Force: true}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOvenDeletePersistsPartialCleanupAndRetries(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	env.createRepo("web")
+	bakeTestOvenSlot(t, env, "slot-partial-delete", "api", "web")
+	if _, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "partial", "feat/partial")); err != nil {
+		t.Fatal(err)
+	}
+
+	realRemove := env.svc.RemoveWorktree
+	failed := false
+	env.svc.RemoveWorktree = func(repo, path string, force bool) error {
+		if filepath.Base(path) == "web" && !failed {
+			failed = true
+			return errors.New("injected worktree removal failure")
+		}
+		return gitops.WorktreeRemove(repo, path, force)
+	}
+	if err := env.svc.DeleteWithOptions("partial", RemoveOptions{Force: true}); err == nil {
+		t.Fatal("expected partial deletion failure")
+	}
+	workspace, err := env.svc.State.GetWorkspace("partial")
+	if err != nil || workspace == nil || len(workspace.Repos) != 1 || workspace.Repos[0].RepoName != "web" {
+		t.Fatalf("partial workspace state = %+v, %v", workspace, err)
+	}
+	inventory, err := env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	slot := inventory.ClaimForWorkspace("partial")
+	if slot == nil || slot.Status != oven.StatusCleanupError || len(slot.Repositories) != 1 || slot.Repositories[0].Name != "web" {
+		t.Fatalf("partial Oven state = %+v", slot)
+	}
+
+	env.svc.RemoveWorktree = realRemove
+	if err := env.svc.DeleteWithOptions("partial", RemoveOptions{Force: true}); err != nil {
+		t.Fatal(err)
+	}
+	inventory, err = env.svc.Oven.Load()
+	if err != nil || len(inventory.Slots) != 0 {
+		t.Fatalf("final inventory = %+v, %v", inventory, err)
+	}
+}
+
+func TestRecoverOvenResumesPersistedCleanupIntent(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	env.createRepo("web")
+	bakeTestOvenSlot(t, env, "slot-crashed-delete", "api", "web")
+	if _, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "crashed", "feat/crashed")); err != nil {
+		t.Fatal(err)
+	}
+
+	inventory, err := env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimed := inventory.ClaimForWorkspace("crashed")
+	if claimed == nil {
+		t.Fatal("missing claim")
+	}
+	cleanup, err := env.svc.beginOvenCleanup(claimed.ID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api := ovenClaimRepositoryByName(*cleanup.Claim, "api")
+	if err := gitops.WorktreeRemove(api.SourceRepo, api.PhysicalPath, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.svc.RecoverOven(); err != nil {
+		t.Fatal(err)
+	}
+	if workspace, _ := env.svc.State.GetWorkspace("crashed"); workspace != nil {
+		t.Fatalf("workspace survived cleanup recovery: %+v", workspace)
+	}
+	inventory, err = env.svc.Oven.Load()
+	if err != nil || len(inventory.Slots) != 0 {
+		t.Fatalf("inventory after cleanup recovery = %+v, %v", inventory, err)
+	}
+}
+
+func TestOvenOwnershipFailsClosedWhenInventoryDisappears(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	slot := bakeTestOvenSlot(t, env, "slot-missing-inventory", "api")
+	if _, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "missing", "feat/missing")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(env.svc.Oven.Path); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.svc.VerifyWorkspaceOwnership("missing"); err == nil {
+		t.Fatal("missing inventory disabled ownership checks")
+	}
+	if err := env.svc.DeleteWithOptions("missing", RemoveOptions{Force: true}); err == nil {
+		t.Fatal("force delete bypassed missing inventory")
+	}
+	if workspace, _ := env.svc.State.GetWorkspace("missing"); workspace == nil {
+		t.Fatal("workspace state was removed")
+	}
+	if _, err := os.Stat(slot.BackingPath); err != nil {
+		t.Fatalf("backing path was removed: %v", err)
+	}
+}
+
+func TestTamperedReadySlotBlocksInsteadOfFallingBack(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	slot := bakeTestOvenSlot(t, env, "slot-blocked-claim", "api")
+	if err := os.WriteFile(filepath.Join(slot.Repositories[0].WorktreePath, "README.md"), []byte("tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "blocked", "feat/blocked"))
+	if !errors.Is(err, ErrOvenBlocked) || errors.Is(err, ErrOvenMiss) {
+		t.Fatalf("tampered claim error = %v", err)
+	}
+	_, err = env.svc.ClaimOvenSlot(ovenClaimOptions(env, "blocked", "feat/blocked"))
+	if !errors.Is(err, ErrOvenBlocked) {
+		t.Fatalf("quarantined claim error = %v", err)
+	}
+	if workspace, _ := env.svc.State.GetWorkspace("blocked"); workspace != nil {
+		t.Fatalf("blocked claim created workspace: %+v", workspace)
+	}
+}
+
+func TestRecoverOvenRollsBackPartiallyAttachedClaim(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	env.createRepo("web")
+	slot := bakeTestOvenSlot(t, env, "slot-partial-claim", "api", "web")
+	options := ovenClaimOptions(env, "partial-claim", "feat/partial-claim")
+	claim, err := env.svc.newOvenClaim(options, *slot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inventory, err := env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	current := inventory.FindSlot(slot.ID)
+	current.Status = oven.StatusClaiming
+	current.Claim = &claim
+	if err := env.svc.Oven.Save(inventory); err != nil {
+		t.Fatal(err)
+	}
+	first := claim.Repositories[0]
+	commit := ovenRepositoryByName(*slot, first.Name).Commit
+	if err := gitops.AttachWorktreeBranch(first.PhysicalPath, first.Branch, commit, first.BranchCreated); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(slot.BackingPath, claim.Alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.svc.RecoverOven(); err != nil {
+		t.Fatal(err)
+	}
+	inventory, err = env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	current = inventory.FindSlot(slot.ID)
+	if current == nil || current.Status != oven.StatusReady || current.Claim != nil {
+		t.Fatalf("recovered slot = %+v", current)
+	}
+	if _, err := os.Lstat(claim.Alias); !os.IsNotExist(err) {
+		t.Fatalf("interrupted alias survived: %v", err)
+	}
+	for _, repository := range current.Repositories {
+		if branch, err := gitops.CurrentBranch(repository.WorktreePath); err != nil || branch != "" {
+			t.Fatalf("%s branch after recovery = %q, %v", repository.Name, branch, err)
+		}
+	}
+}
+
+func TestOvenOwnershipRejectsClaimNonceTampering(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	bakeTestOvenSlot(t, env, "slot-nonce-tamper", "api")
+	if _, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "nonce", "feat/nonce")); err != nil {
+		t.Fatal(err)
+	}
+	inventory, err := env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	slot := inventory.ClaimForWorkspace("nonce")
+	original := slot.Claim.Nonce
+	slot.Claim.Nonce = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	if err := env.svc.Oven.Save(inventory); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.svc.Status("nonce", StatusOptions{}); err == nil {
+		t.Fatal("status accepted a changed claim nonce")
+	}
+	if err := env.svc.DeleteWithOptions("nonce", RemoveOptions{Force: true}); err == nil {
+		t.Fatal("delete accepted a changed claim nonce")
+	}
+	inventory, _ = env.svc.Oven.Load()
+	inventory.ClaimForWorkspace("nonce").Claim.Nonce = original
+	if err := env.svc.Oven.Save(inventory); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.svc.DeleteWithOptions("nonce", RemoveOptions{Force: true}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClaimOvenRejectsSourceOutsideConfiguredRepoDirs(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	bakeTestOvenSlot(t, env, "slot-source-allowlist", "api")
+	env.cfg.RepoDirs = []string{filepath.Join(env.dir, "other-repositories")}
+	_, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "blocked-source", "feat/blocked-source"))
+	if !errors.Is(err, ErrOvenBlocked) {
+		t.Fatalf("claim error = %v", err)
+	}
+	if workspace, _ := env.svc.State.GetWorkspace("blocked-source"); workspace != nil {
+		t.Fatalf("blocked source created workspace: %+v", workspace)
+	}
+}
+
+func TestClaimOvenRejectsSymlinkedBackingComponent(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	slot := bakeTestOvenSlot(t, env, "slot-symlink-component", "api")
+	generationRoot := filepath.Dir(filepath.Dir(slot.BackingPath))
+	relocated := generationRoot + "-relocated"
+	if err := os.Rename(generationRoot, relocated); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(relocated, generationRoot); err != nil {
+		t.Fatal(err)
+	}
+	_, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "blocked-symlink", "feat/blocked-symlink"))
+	if !errors.Is(err, ErrOvenBlocked) {
+		t.Fatalf("claim error = %v", err)
+	}
+	if workspace, _ := env.svc.State.GetWorkspace("blocked-symlink"); workspace != nil {
+		t.Fatalf("symlinked backing created workspace: %+v", workspace)
+	}
+}
+
+func TestRecoverOvenRetriesAfterWorkspaceStateRemovalFailure(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	bakeTestOvenSlot(t, env, "slot-state-remove-failure", "api")
+	if _, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "state-failure", "feat/state-failure")); err != nil {
+		t.Fatal(err)
+	}
+	inventory, err := env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimed := inventory.ClaimForWorkspace("state-failure")
+	if _, err := env.svc.beginOvenCleanup(claimed.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	failed := false
+	env.svc.RemoveWorkspace = func(string) error {
+		if !failed {
+			failed = true
+			return errors.New("injected state removal failure")
+		}
+		return env.svc.State.RemoveWorkspace("state-failure")
+	}
+	if err := env.svc.RecoverOven(); err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := env.svc.State.GetWorkspace("state-failure")
+	if err != nil || workspace == nil {
+		t.Fatalf("state was unexpectedly removed: %+v, %v", workspace, err)
+	}
+	if _, err := os.Lstat(workspace.Path); !os.IsNotExist(err) {
+		t.Fatalf("alias should have been removed before injected state error: %v", err)
+	}
+	if err := env.svc.RecoverOven(); err != nil {
+		t.Fatal(err)
+	}
+	if workspace, _ = env.svc.State.GetWorkspace("state-failure"); workspace != nil {
+		t.Fatalf("state survived retry: %+v", workspace)
+	}
+	inventory, err = env.svc.Oven.Load()
+	if err != nil || len(inventory.Slots) != 0 {
+		t.Fatalf("inventory after retry = %+v, %v", inventory, err)
+	}
+}
+
+func TestDoctorReportsClaimWithoutWorkspaceState(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	bakeTestOvenSlot(t, env, "slot-orphaned-claim", "api")
+	if _, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "orphaned", "feat/orphaned")); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.svc.State.RemoveWorkspace("orphaned"); err != nil {
+		t.Fatal(err)
+	}
+	issues, fixed, err := env.svc.Doctor(true)
+	if err != nil || fixed != 0 || len(issues) == 0 || !strings.Contains(issues[0].Issue, "has no workspace state") {
+		t.Fatalf("Doctor result = issues %+v, fixed %d, err %v", issues, fixed, err)
+	}
+	inventory, err := env.svc.Oven.Load()
+	if err != nil || inventory.ClaimForWorkspace("orphaned") == nil {
+		t.Fatalf("Doctor mutated orphaned claim: %+v, %v", inventory, err)
+	}
+}

--- a/internal/workspace/oven_maintenance.go
+++ b/internal/workspace/oven_maintenance.go
@@ -1,0 +1,520 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/nicksenap/grove/internal/gitops"
+	"github.com/nicksenap/grove/internal/logging"
+	"github.com/nicksenap/grove/internal/models"
+	"github.com/nicksenap/grove/internal/oven"
+)
+
+type OvenCleanResult struct {
+	Removed int      `json:"removed"`
+	Blocked []string `json:"blocked"`
+}
+
+// RecoverOven resolves interrupted lifecycle records without making a slot
+// ready unless readiness was durably recorded.
+func (service *Service) RecoverOven() error {
+	if service.Oven == nil {
+		return nil
+	}
+	return service.State.WithLock(func() error {
+		inventory, err := service.Oven.Load()
+		if err != nil {
+			return err
+		}
+		changed := false
+		var removeSlots []string
+		for index := range inventory.Slots {
+			slot := &inventory.Slots[index]
+			switch slot.Status {
+			case oven.StatusBaking:
+				if processIsAlive(slot.OwnerPID) {
+					continue
+				}
+				if err := service.recoverInterruptedBake(slot); err != nil {
+					slot.Status = oven.StatusQuarantined
+					slot.Failure = safeOvenFailure(err)
+				} else {
+					slot.Status = oven.StatusFailed
+					slot.Failure = "interrupted bake cleaned before readiness"
+				}
+				slot.OwnerPID = 0
+				slot.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+				changed = true
+			case oven.StatusClaiming:
+				claimChanged, err := service.recoverInterruptedClaim(slot)
+				if err != nil {
+					slot.Status = oven.StatusQuarantined
+					slot.Failure = safeOvenFailure(err)
+					changed = true
+				} else if claimChanged {
+					changed = true
+				}
+			case oven.StatusClaimed, oven.StatusCleanupError:
+				remove, err := service.recoverDeletedClaim(slot)
+				if err != nil {
+					if slot.Status == oven.StatusClaimed {
+						slot.Status = oven.StatusQuarantined
+					}
+					slot.Failure = safeOvenFailure(err)
+					changed = true
+				} else if remove {
+					removeSlots = append(removeSlots, slot.ID)
+					changed = true
+				}
+			}
+		}
+		for _, id := range removeSlots {
+			inventory.RemoveSlot(id)
+		}
+		if !changed {
+			return nil
+		}
+		return service.Oven.Save(inventory)
+	})
+}
+
+func processIsAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}
+
+func (service *Service) recoverInterruptedBake(slot *oven.Slot) error {
+	created, err := inspectInterruptedBake(*slot)
+	if err != nil {
+		return err
+	}
+	for index := len(created) - 1; index >= 0; index-- {
+		repository := created[index]
+		if err := service.removeWorktree(repository.SourceRepo, repository.WorktreePath, true); err != nil {
+			return fmt.Errorf("%s: removing interrupted bake worktree: %w", repository.Name, err)
+		}
+	}
+	if err := os.Remove(slot.BackingPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing interrupted bake root: %w", err)
+	}
+	return nil
+}
+
+func inspectInterruptedBake(slot oven.Slot) ([]oven.Repository, error) {
+	var created []oven.Repository
+	for _, repository := range slot.Repositories {
+		entries, err := gitops.WorktreeList(repository.SourceRepo)
+		if err != nil {
+			return nil, err
+		}
+		registered := false
+		for _, entry := range entries {
+			if canonicalPath(entry.Path) == canonicalPath(repository.WorktreePath) {
+				if entry.Branch != "" {
+					return nil, fmt.Errorf("%s: interrupted bake worktree is no longer detached", repository.Name)
+				}
+				registered = true
+				break
+			}
+		}
+		_, statErr := os.Lstat(repository.WorktreePath)
+		if !registered && os.IsNotExist(statErr) {
+			continue
+		}
+		if !registered || statErr != nil {
+			return nil, fmt.Errorf("%s: interrupted bake path and Git registration disagree", repository.Name)
+		}
+		head, err := gitops.HeadCommit(repository.WorktreePath)
+		if err != nil || head != repository.Commit {
+			return nil, fmt.Errorf("%s: interrupted bake commit changed", repository.Name)
+		}
+		created = append(created, repository)
+	}
+	return created, nil
+}
+
+func (service *Service) recoverOvenCleanup(slot *oven.Slot, workspace *models.Workspace) (bool, error) {
+	workspaceByName, err := validateCleanupWorkspace(*slot.Claim, *workspace)
+	if err != nil {
+		return false, err
+	}
+	remainingNames, cleanupErrs := service.resumeOvenRepositoryCleanup(*slot, workspaceByName)
+
+	keep := make(map[string]bool, len(remainingNames))
+	for _, name := range remainingNames {
+		keep[name] = true
+	}
+	slot.Repositories = filterOvenRepositories(slot.Repositories, keep)
+	slot.Claim.Repositories = filterClaimRepositories(slot.Claim.Repositories, keep)
+	remainingState := workspace.Repos[:0]
+	for _, repository := range workspace.Repos {
+		if keep[repository.RepoName] {
+			remainingState = append(remainingState, repository)
+		}
+	}
+	workspace.Repos = remainingState
+	if err := service.State.UpdateWorkspace(*workspace); err != nil {
+		cleanupErrs = append(cleanupErrs, err)
+	}
+	if len(remainingNames) > 0 || len(cleanupErrs) > 0 {
+		return false, errors.Join(cleanupErrs...)
+	}
+
+	removeMCPConfig(*workspace)
+	aliasExists := false
+	target, err := os.Readlink(slot.Claim.Alias)
+	if err == nil {
+		if canonicalPath(target) != canonicalPath(slot.BackingPath) {
+			return false, fmt.Errorf("cleanup alias ownership changed")
+		}
+		aliasExists = true
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("cleanup alias ownership changed")
+	}
+	if aliasExists {
+		if err := os.Remove(slot.Claim.Alias); err != nil {
+			return false, err
+		}
+	}
+	if err := service.removeWorkspaceState(workspace.Name); err != nil {
+		return false, err
+	}
+	if err := os.Remove(slot.BackingPath); err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	return true, nil
+}
+
+func validateCleanupWorkspace(claim oven.Claim, workspace models.Workspace) (map[string]models.RepoWorktree, error) {
+	claimByName := make(map[string]bool, len(claim.Repositories))
+	for _, repository := range claim.Repositories {
+		claimByName[repository.Name] = true
+	}
+	workspaceByName := make(map[string]models.RepoWorktree, len(workspace.Repos))
+	for _, repository := range workspace.Repos {
+		workspaceByName[repository.RepoName] = repository
+		if !claimByName[repository.RepoName] {
+			if _, err := os.Lstat(repository.WorktreePath); !os.IsNotExist(err) {
+				return nil, fmt.Errorf("%s: workspace cleanup state has an unclaimed repository", repository.RepoName)
+			}
+		}
+	}
+	return workspaceByName, nil
+}
+
+func (service *Service) resumeOvenRepositoryCleanup(slot oven.Slot, workspaceByName map[string]models.RepoWorktree) ([]string, []error) {
+	var remaining []string
+	var cleanupErrs []error
+	for _, claimed := range slot.Claim.Repositories {
+		if err := service.resumeOvenRepository(slot, claimed, workspaceByName[claimed.Name]); err != nil {
+			remaining = append(remaining, claimed.Name)
+			cleanupErrs = append(cleanupErrs, err)
+		}
+	}
+	return remaining, cleanupErrs
+}
+
+func (service *Service) resumeOvenRepository(slot oven.Slot, claimed oven.ClaimRepository, stateRepository models.RepoWorktree) error {
+	_, pathErr := os.Lstat(claimed.PhysicalPath)
+	if pathErr == nil {
+		if stateRepository.RepoName == "" {
+			return fmt.Errorf("%s: claimed worktree remains without workspace repository state", claimed.Name)
+		}
+		stateRepository.WorktreePath = claimed.PhysicalPath
+		if err := preflightRemoval(stateRepository); err != nil && !slot.Claim.CleanupForce {
+			return err
+		}
+		if err := service.removeWorktree(claimed.SourceRepo, claimed.PhysicalPath, slot.Claim.CleanupForce); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(pathErr) {
+		return pathErr
+	} else if ovenWorktreeRegistered(claimed.SourceRepo, claimed.PhysicalPath) {
+		return fmt.Errorf("%s: missing claimed path remains registered", claimed.Name)
+	}
+	return service.finishOvenCleanupBranch(claimed, slot.Claim.CleanupForce)
+}
+
+func (service *Service) removeWorkspaceState(name string) error {
+	if service.RemoveWorkspace != nil {
+		return service.RemoveWorkspace(name)
+	}
+	return service.State.RemoveWorkspace(name)
+}
+
+func (service *Service) finishOvenCleanupBranch(claimed oven.ClaimRepository, force bool) error {
+	if !claimed.BranchCreated || claimed.ExpectedBranchCommit == "" || !gitops.BranchExists(claimed.SourceRepo, claimed.Branch) {
+		return nil
+	}
+	current, err := gitops.LocalBranchCommit(claimed.SourceRepo, claimed.Branch)
+	if err != nil || current != claimed.ExpectedBranchCommit {
+		return nil
+	}
+	if err := gitops.DeleteBranchIfAt(claimed.SourceRepo, claimed.Branch, claimed.ExpectedBranchCommit, force); err != nil {
+		logging.Warn("failed to finish Oven branch cleanup for %s: %s", claimed.Name, err)
+		return err
+	}
+	return nil
+}
+
+func ovenWorktreeRegistered(sourceRepo, path string) bool {
+	entries, err := gitops.WorktreeList(sourceRepo)
+	if err != nil {
+		return true
+	}
+	for _, entry := range entries {
+		if canonicalPath(entry.Path) == canonicalPath(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func filterOvenRepositories(repositories []oven.Repository, keep map[string]bool) []oven.Repository {
+	filtered := repositories[:0]
+	for _, repository := range repositories {
+		if keep[repository.Name] {
+			filtered = append(filtered, repository)
+		}
+	}
+	return filtered
+}
+
+func filterClaimRepositories(repositories []oven.ClaimRepository, keep map[string]bool) []oven.ClaimRepository {
+	filtered := repositories[:0]
+	for _, repository := range repositories {
+		if keep[repository.Name] {
+			filtered = append(filtered, repository)
+		}
+	}
+	return filtered
+}
+
+func (service *Service) recoverDeletedClaim(slot *oven.Slot) (bool, error) {
+	if slot.Claim == nil {
+		return false, fmt.Errorf("claimed slot has no claim record")
+	}
+	workspace, err := service.State.GetWorkspace(slot.Claim.WorkspaceName)
+	if err != nil {
+		return false, err
+	}
+	if workspace != nil {
+		if slot.Status == oven.StatusCleanupError {
+			return service.recoverOvenCleanup(slot, workspace)
+		}
+		return false, service.verifyOvenWorkspaceOwnership(*workspace, *slot)
+	}
+	if _, err := os.Lstat(slot.Claim.Alias); !os.IsNotExist(err) {
+		return false, fmt.Errorf("claimed alias remains without workspace state")
+	}
+	for _, repository := range slot.Repositories {
+		entries, err := gitops.WorktreeList(repository.SourceRepo)
+		if err != nil {
+			return false, err
+		}
+		for _, entry := range entries {
+			if canonicalPath(entry.Path) == canonicalPath(repository.WorktreePath) {
+				return false, fmt.Errorf("%s: claimed worktree remains without workspace state", repository.Name)
+			}
+		}
+		if _, err := os.Lstat(repository.WorktreePath); !os.IsNotExist(err) {
+			return false, fmt.Errorf("%s: claimed worktree path remains without workspace state", repository.Name)
+		}
+	}
+	if err := os.Remove(slot.BackingPath); err != nil && !os.IsNotExist(err) {
+		return false, fmt.Errorf("removing orphaned claimed backing root: %w", err)
+	}
+	return true, nil
+}
+
+func (service *Service) recoverInterruptedClaim(slot *oven.Slot) (bool, error) {
+	if slot.Claim == nil {
+		return false, fmt.Errorf("claiming slot has no claim record")
+	}
+	workspace, err := service.State.GetWorkspace(slot.Claim.WorkspaceName)
+	if err != nil {
+		return false, err
+	}
+	if workspace != nil {
+		if err := service.verifyOvenWorkspaceOwnership(*workspace, *slot); err != nil {
+			return false, err
+		}
+		slot.Status = oven.StatusClaimed
+		slot.Failure = ""
+		slot.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		return true, nil
+	}
+	if err := service.rollbackInterruptedClaim(*slot); err != nil {
+		return false, err
+	}
+	slot.Status = oven.StatusReady
+	slot.Claim = nil
+	slot.Failure = ""
+	slot.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	return true, nil
+}
+
+func (service *Service) rollbackInterruptedClaim(slot oven.Slot) error {
+	if err := service.verifyOvenBackingPath(slot); err != nil {
+		return err
+	}
+	aliasExists := false
+	if target, err := os.Readlink(slot.Claim.Alias); err == nil {
+		if canonicalPath(target) != canonicalPath(slot.BackingPath) {
+			return fmt.Errorf("interrupted claim alias target changed")
+		}
+		aliasExists = true
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("interrupted claim alias is not owned: %w", err)
+	}
+
+	assigned := make([]oven.ClaimRepository, 0, len(slot.Claim.Repositories))
+	for _, claimed := range slot.Claim.Repositories {
+		prepared := ovenRepositoryByName(slot, claimed.Name)
+		branch, err := gitops.CurrentBranch(claimed.PhysicalPath)
+		if err != nil {
+			return fmt.Errorf("%s: reading interrupted claim branch: %w", claimed.Name, err)
+		}
+		head, err := gitops.HeadCommit(claimed.PhysicalPath)
+		if err != nil || head != prepared.Commit {
+			return fmt.Errorf("%s: interrupted claim commit changed", claimed.Name)
+		}
+		status, err := gitops.TrackedStatus(claimed.PhysicalPath)
+		if err != nil || status != "" {
+			return fmt.Errorf("%s: interrupted claim has tracked changes", claimed.Name)
+		}
+		switch branch {
+		case "":
+			continue
+		case claimed.Branch:
+			assigned = append(assigned, claimed)
+		default:
+			return fmt.Errorf("%s: interrupted claim branch changed", claimed.Name)
+		}
+	}
+
+	if aliasExists {
+		if err := os.Remove(slot.Claim.Alias); err != nil {
+			return err
+		}
+	}
+	for index := len(assigned) - 1; index >= 0; index-- {
+		claimed := assigned[index]
+		commit := ovenRepositoryByName(slot, claimed.Name).Commit
+		if err := gitops.DetachWorktree(claimed.PhysicalPath, commit); err != nil {
+			return fmt.Errorf("%s: detaching interrupted claim: %w", claimed.Name, err)
+		}
+		if claimed.BranchCreated {
+			if err := gitops.DeleteBranchIfAt(claimed.SourceRepo, claimed.Branch, commit, true); err != nil {
+				return fmt.Errorf("%s: deleting interrupted claim branch: %w", claimed.Name, err)
+			}
+		}
+	}
+	if err := verifyDetachedOvenRepositories(slot, slot.Repositories); err != nil {
+		return fmt.Errorf("interrupted claim recovery did not restore readiness: %w", err)
+	}
+	return nil
+}
+
+// PruneOvenRecipe removes stale ready and failed slots only after a replacement
+// generation is ready. Claimed, active, and quarantined slots are retained.
+func (service *Service) PruneOvenRecipe(recipePath, _ string, runner, keepSlotID string) (OvenCleanResult, error) {
+	return service.cleanOvenSlots(func(slot oven.Slot) bool {
+		return slot.RecipePath == recipePath && slot.Runner == runner && slot.ID != keepSlotID &&
+			(slot.Status == oven.StatusReady || slot.Status == oven.StatusFailed)
+	})
+}
+
+// CleanOven removes unclaimed ready and failed slots, optionally restricted to
+// one canonical Recipe path. Unsafe lifecycle states remain visible as blocked.
+func (service *Service) CleanOven(recipePath string) (OvenCleanResult, error) {
+	return service.cleanOvenSlots(func(slot oven.Slot) bool {
+		return recipePath == "" || slot.RecipePath == recipePath
+	})
+}
+
+func (service *Service) cleanOvenSlots(selectSlot func(oven.Slot) bool) (OvenCleanResult, error) {
+	result := OvenCleanResult{Blocked: []string{}}
+	if service.Oven == nil {
+		return result, nil
+	}
+	err := service.State.WithLock(func() error {
+		inventory, err := service.Oven.Load()
+		if err != nil {
+			return err
+		}
+		var cleanupErrs []error
+		ids := make([]string, 0, len(inventory.Slots))
+		for _, slot := range inventory.Slots {
+			if selectSlot(slot) {
+				ids = append(ids, slot.ID)
+			}
+		}
+		for _, id := range ids {
+			slot := inventory.FindSlot(id)
+			if slot == nil {
+				continue
+			}
+			switch slot.Status {
+			case oven.StatusReady:
+				if err := removeReadyOvenSlot(service, *slot); err != nil {
+					slot.Status = oven.StatusQuarantined
+					slot.Failure = safeOvenFailure(err)
+					result.Blocked = append(result.Blocked, slot.ID)
+					cleanupErrs = append(cleanupErrs, err)
+					continue
+				}
+				inventory.RemoveSlot(id)
+				result.Removed++
+			case oven.StatusFailed:
+				if err := removeFailedOvenSlot(*slot); err != nil {
+					result.Blocked = append(result.Blocked, slot.ID)
+					cleanupErrs = append(cleanupErrs, err)
+					continue
+				}
+				inventory.RemoveSlot(id)
+				result.Removed++
+			default:
+				result.Blocked = append(result.Blocked, slot.ID)
+			}
+		}
+		if err := service.Oven.Save(inventory); err != nil {
+			cleanupErrs = append(cleanupErrs, err)
+		}
+		return errors.Join(cleanupErrs...)
+	})
+	return result, err
+}
+
+func removeReadyOvenSlot(service *Service, slot oven.Slot) error {
+	if err := verifyDetachedOvenRepositories(slot, slot.Repositories); err != nil {
+		return err
+	}
+	for index := len(slot.Repositories) - 1; index >= 0; index-- {
+		repository := slot.Repositories[index]
+		if err := service.removeWorktree(repository.SourceRepo, repository.WorktreePath, true); err != nil {
+			return err
+		}
+	}
+	if err := os.Remove(slot.BackingPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	_ = os.Remove(filepath.Dir(slot.BackingPath))
+	_ = os.Remove(filepath.Dir(filepath.Dir(slot.BackingPath)))
+	return nil
+}
+
+func removeFailedOvenSlot(slot oven.Slot) error {
+	if _, err := os.Lstat(slot.BackingPath); err == nil {
+		return fmt.Errorf("failed slot still has a backing path")
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/workspace/oven_ownership.go
+++ b/internal/workspace/oven_ownership.go
@@ -1,0 +1,364 @@
+package workspace
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nicksenap/grove/internal/gitops"
+	"github.com/nicksenap/grove/internal/models"
+	"github.com/nicksenap/grove/internal/oven"
+)
+
+var ErrOvenOwnership = fmt.Errorf("oven ownership verification failed")
+
+// VerifyWorkspaceOwnership checks external Oven ownership when name belongs to a claimed slot.
+func (service *Service) VerifyWorkspaceOwnership(name string) error {
+	workspace, err := service.State.GetWorkspace(name)
+	if err != nil {
+		return err
+	}
+	if workspace == nil {
+		return fmt.Errorf("workspace %s not found", name)
+	}
+	_, err = service.verifyOvenWorkspaceIfClaimed(*workspace)
+	return err
+}
+
+// OperationWorkspace returns verified physical paths for operations on an Oven claim.
+func (service *Service) OperationWorkspace(name string) (*models.Workspace, error) {
+	workspace, err := service.State.GetWorkspace(name)
+	if err != nil || workspace == nil {
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("workspace %s not found", name)
+	}
+	slot, err := service.verifyOvenWorkspaceIfClaimed(*workspace)
+	if err != nil {
+		return nil, err
+	}
+	if slot != nil {
+		applyOvenPhysicalPaths(workspace, *slot)
+		workspace.Path = slot.BackingPath
+	}
+	return workspace, nil
+}
+
+func applyOvenPhysicalPaths(workspace *models.Workspace, slot oven.Slot) {
+	for index := range workspace.Repos {
+		claimed := ovenClaimRepositoryByName(*slot.Claim, workspace.Repos[index].RepoName)
+		workspace.Repos[index].WorktreePath = claimed.PhysicalPath
+	}
+}
+
+func (service *Service) ovenClaimForWorkspace(name string) (*oven.Slot, error) {
+	if service.Oven == nil {
+		return nil, nil
+	}
+	inventory, err := service.Oven.Load()
+	if err != nil {
+		return nil, err
+	}
+	slot := inventory.ClaimForWorkspace(name)
+	if slot == nil {
+		return nil, nil
+	}
+	copy := *slot
+	return &copy, nil
+}
+
+func (service *Service) verifyOvenWorkspaceIfClaimed(workspace models.Workspace) (*oven.Slot, error) {
+	slot, err := service.ovenClaimForWorkspace(workspace.Name)
+	if err != nil {
+		return nil, err
+	}
+	if slot == nil {
+		if workspace.Oven != nil {
+			return nil, fmt.Errorf("%w: workspace %s references missing Oven slot %s", ErrOvenOwnership, workspace.Name, workspace.Oven.SlotID)
+		}
+		ovenBacked, err := service.looksOvenBacked(workspace)
+		if err != nil {
+			return nil, err
+		}
+		if ovenBacked {
+			return nil, fmt.Errorf("%w: workspace %s appears Oven-backed but has no claim record", ErrOvenOwnership, workspace.Name)
+		}
+		return nil, nil
+	}
+	if err := service.verifyOvenWorkspaceOwnership(workspace, *slot); err != nil {
+		return nil, fmt.Errorf("oven ownership mismatch: %w", err)
+	}
+	return slot, nil
+}
+
+func (service *Service) looksOvenBacked(workspace models.Workspace) (bool, error) {
+	if service.Oven == nil {
+		return false, nil
+	}
+	if info, err := os.Lstat(workspace.Path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return true, nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	for _, repository := range workspace.Repos {
+		entries, err := gitops.WorktreeList(repository.SourceRepo)
+		if err != nil {
+			return false, err
+		}
+		for _, entry := range entries {
+			if ovenPathWithin(service.Oven.Root, entry.Path) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func ovenPathWithin(root, path string) bool {
+	relative, err := filepath.Rel(root, path)
+	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func (service *Service) verifyOvenWorkspaceOwnership(workspace models.Workspace, slot oven.Slot) error {
+	claim := slot.Claim
+	if workspace.Oven == nil || workspace.Oven.SlotID != slot.ID || claim == nil || workspace.Oven.ClaimNonce != claim.Nonce {
+		return fmt.Errorf("workspace Oven identity differs from its claim record")
+	}
+	if slot.Status != oven.StatusClaiming && slot.Status != oven.StatusClaimed && slot.Status != oven.StatusCleanupError {
+		return fmt.Errorf("slot is not an active claim")
+	}
+	if claim.WorkspaceName != workspace.Name || claim.Alias != workspace.Path || claim.Branch != workspace.Branch ||
+		len(claim.Repositories) != len(workspace.Repos) || len(slot.Repositories) != len(workspace.Repos) {
+		return fmt.Errorf("workspace state differs from its claim record")
+	}
+	if err := service.verifyOvenBackingPath(slot); err != nil {
+		return err
+	}
+	target, err := os.Readlink(claim.Alias)
+	if err != nil || canonicalPath(target) != canonicalPath(slot.BackingPath) {
+		return fmt.Errorf("workspace alias does not target its claimed backing path")
+	}
+
+	prepared, claimed, err := ovenOwnershipMaps(slot, *claim)
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]bool, len(workspace.Repos))
+	for _, repository := range workspace.Repos {
+		if seen[repository.RepoName] {
+			return fmt.Errorf("duplicate workspace repository %s", repository.RepoName)
+		}
+		seen[repository.RepoName] = true
+		if err := verifyOvenWorkspaceRepository(repository, slot, *claim, prepared, claimed); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ovenOwnershipMaps(slot oven.Slot, claim oven.Claim) (map[string]oven.Repository, map[string]oven.ClaimRepository, error) {
+	prepared := make(map[string]oven.Repository, len(slot.Repositories))
+	for _, repository := range slot.Repositories {
+		if _, duplicate := prepared[repository.Name]; duplicate {
+			return nil, nil, fmt.Errorf("duplicate prepared repository %s", repository.Name)
+		}
+		prepared[repository.Name] = repository
+	}
+	claimed := make(map[string]oven.ClaimRepository, len(claim.Repositories))
+	for _, repository := range claim.Repositories {
+		if _, duplicate := claimed[repository.Name]; duplicate {
+			return nil, nil, fmt.Errorf("duplicate claimed repository %s", repository.Name)
+		}
+		claimed[repository.Name] = repository
+	}
+	return prepared, claimed, nil
+}
+
+func verifyOvenWorkspaceRepository(
+	repository models.RepoWorktree,
+	slot oven.Slot,
+	claim oven.Claim,
+	prepared map[string]oven.Repository,
+	claimed map[string]oven.ClaimRepository,
+) error {
+	preparedRepo, preparedOK := prepared[repository.RepoName]
+	claimedRepo, claimedOK := claimed[repository.RepoName]
+	if !preparedOK || !claimedOK || repository.SourceRepo != claimedRepo.SourceRepo ||
+		repository.WorktreePath != claimedRepo.AliasPath || repository.Branch != claimedRepo.Branch ||
+		repository.PreserveBranch != !claimedRepo.BranchCreated ||
+		preparedRepo.SourceRepo != claimedRepo.SourceRepo || preparedRepo.WorktreePath != claimedRepo.PhysicalPath ||
+		filepath.Dir(preparedRepo.WorktreePath) != slot.BackingPath || filepath.Dir(claimedRepo.AliasPath) != claim.Alias {
+		return fmt.Errorf("repository %s differs from its claim record", repository.RepoName)
+	}
+	return verifyClaimedOvenRepository(preparedRepo, claimedRepo)
+}
+
+func verifyOvenClaimFilesystem(slot oven.Slot, claim oven.Claim, requirePreparedCommit bool) error {
+	target, err := os.Readlink(claim.Alias)
+	if err != nil || canonicalPath(target) != canonicalPath(slot.BackingPath) {
+		return fmt.Errorf("workspace alias does not target its claimed backing path")
+	}
+	if len(claim.Repositories) != len(slot.Repositories) {
+		return fmt.Errorf("claim repository set changed")
+	}
+	for _, claimed := range claim.Repositories {
+		prepared := ovenRepositoryByName(slot, claimed.Name)
+		if prepared.Name == "" || claimed.SourceRepo != prepared.SourceRepo || claimed.PhysicalPath != prepared.WorktreePath ||
+			claimed.AliasPath != filepath.Join(claim.Alias, claimed.Name) || claimed.Branch != claim.Branch {
+			return fmt.Errorf("%s: claim repository identity changed", claimed.Name)
+		}
+		if err := verifyClaimedOvenRepository(prepared, claimed); err != nil {
+			return err
+		}
+		if requirePreparedCommit {
+			head, err := gitops.HeadCommit(claimed.PhysicalPath)
+			if err != nil || head != prepared.Commit {
+				return fmt.Errorf("%s: claimed commit changed", claimed.Name)
+			}
+		}
+	}
+	return nil
+}
+
+func (service *Service) verifyOvenBackingPath(slot oven.Slot) error {
+	expected := service.Oven.SlotPath(slot.Generation, slot.ID)
+	if filepath.Clean(slot.BackingPath) != filepath.Clean(expected) {
+		return fmt.Errorf("backing path is outside its generation")
+	}
+	relative, err := filepath.Rel(service.Oven.Root, slot.BackingPath)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("backing path escapes the Oven root")
+	}
+	current := service.Oven.Root
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if err != nil || info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("backing path is missing or contains a symlink")
+		}
+	}
+	return nil
+}
+
+func (service *Service) beginOvenCleanup(slotID string, force bool) (*oven.Slot, error) {
+	inventory, err := service.Oven.Load()
+	if err != nil {
+		return nil, err
+	}
+	slot := inventory.FindSlot(slotID)
+	if slot == nil || slot.Claim == nil || (slot.Status != oven.StatusClaimed && slot.Status != oven.StatusCleanupError) {
+		return nil, fmt.Errorf("oven claim changed before cleanup")
+	}
+	if slot.Status == oven.StatusClaimed {
+		for index := range slot.Claim.Repositories {
+			repository := &slot.Claim.Repositories[index]
+			commit, err := gitops.LocalBranchCommit(repository.SourceRepo, repository.Branch)
+			if err != nil {
+				return nil, fmt.Errorf("%s: reading cleanup branch: %w", repository.Name, err)
+			}
+			repository.ExpectedBranchCommit = commit
+		}
+		slot.Status = oven.StatusCleanupError
+		slot.Claim.CleanupForce = force
+		slot.Failure = "cleanup in progress"
+		if err := service.Oven.Save(inventory); err != nil {
+			return nil, err
+		}
+	}
+	copy := *slot
+	return &copy, nil
+}
+
+func (service *Service) updateOvenCleanupProgress(slotID, nonce string, remaining []models.RepoWorktree) (*oven.Slot, error) {
+	inventory, err := service.Oven.Load()
+	if err != nil {
+		return nil, err
+	}
+	slot := inventory.FindSlot(slotID)
+	if slot == nil || slot.Status != oven.StatusCleanupError || slot.Claim == nil || slot.Claim.Nonce != nonce {
+		return nil, fmt.Errorf("oven cleanup identity changed")
+	}
+	keep := make(map[string]bool, len(remaining))
+	for _, repository := range remaining {
+		keep[repository.RepoName] = true
+	}
+	prepared := slot.Repositories[:0]
+	for _, repository := range slot.Repositories {
+		if keep[repository.Name] {
+			prepared = append(prepared, repository)
+		}
+	}
+	claimed := slot.Claim.Repositories[:0]
+	for _, repository := range slot.Claim.Repositories {
+		if keep[repository.Name] {
+			claimed = append(claimed, repository)
+		}
+	}
+	slot.Repositories = prepared
+	slot.Claim.Repositories = claimed
+	slot.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	if err := service.Oven.Save(inventory); err != nil {
+		return nil, err
+	}
+	copy := *slot
+	return &copy, nil
+}
+
+func ovenClaimRepositoryByName(claim oven.Claim, name string) oven.ClaimRepository {
+	for _, repository := range claim.Repositories {
+		if repository.Name == name {
+			return repository
+		}
+	}
+	return oven.ClaimRepository{}
+}
+
+func (service *Service) finalizeDeletedOvenClaim(expected oven.Slot) error {
+	inventory, err := service.Oven.Load()
+	if err != nil {
+		return err
+	}
+	slot := inventory.FindSlot(expected.ID)
+	if slot == nil || slot.Claim == nil || expected.Claim == nil || slot.Claim.Nonce != expected.Claim.Nonce {
+		return fmt.Errorf("oven claim changed before backing cleanup")
+	}
+	if err := os.Remove(slot.BackingPath); err != nil && !os.IsNotExist(err) {
+		slot.Status = oven.StatusCleanupError
+		slot.Failure = safeOvenFailure(fmt.Errorf("removing claimed backing root: %w", err))
+		if saveErr := service.Oven.Save(inventory); saveErr != nil {
+			return fmt.Errorf("removing claimed backing root: %w; recording cleanup failure: %v", err, saveErr)
+		}
+		return fmt.Errorf("removing claimed backing root: %w", err)
+	}
+	inventory.RemoveSlot(slot.ID)
+	return service.Oven.Save(inventory)
+}
+
+func verifyClaimedOvenRepository(prepared oven.Repository, claimed oven.ClaimRepository) error {
+	if filepath.Dir(prepared.WorktreePath) == "." || filepath.Base(prepared.WorktreePath) != prepared.Name ||
+		claimed.PhysicalPath != prepared.WorktreePath || filepath.Base(claimed.AliasPath) != prepared.Name {
+		return fmt.Errorf("%s: claimed repository path changed", prepared.Name)
+	}
+	entries, err := gitops.WorktreeList(prepared.SourceRepo)
+	if err != nil {
+		return err
+	}
+	registered := false
+	for _, entry := range entries {
+		if canonicalPath(entry.Path) == canonicalPath(claimed.PhysicalPath) && entry.Branch == claimed.Branch {
+			registered = true
+			break
+		}
+	}
+	if !registered {
+		return fmt.Errorf("%s: claimed worktree registration changed", prepared.Name)
+	}
+	branch, err := gitops.CurrentBranch(claimed.AliasPath)
+	if err != nil || branch != claimed.Branch {
+		return fmt.Errorf("%s: claimed branch changed", prepared.Name)
+	}
+	return nil
+}

--- a/internal/workspace/oven_test.go
+++ b/internal/workspace/oven_test.go
@@ -1,0 +1,528 @@
+package workspace
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicksenap/grove/internal/gitops"
+	"github.com/nicksenap/grove/internal/oven"
+	"github.com/nicksenap/grove/internal/state"
+)
+
+const (
+	testOvenRecipeKey  = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testOvenGeneration = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func testOvenSlotID(label string) string {
+	sum := sha256.Sum256([]byte(label))
+	return fmt.Sprintf("%x", sum[:16])
+}
+
+func ovenBakeOptions(env *testEnv, slotID string, repoNames ...string) OvenBakeOptions {
+	commits := make(map[string]string, len(repoNames))
+	for _, name := range repoNames {
+		commits[name] = env.run(env.repoMap[name], "git", "rev-parse", "HEAD")
+	}
+	return OvenBakeOptions{
+		RecipeKey: testOvenRecipeKey, RecipeName: "stack", RecipePath: "/recipes/stack.yaml",
+		Generation: testOvenGeneration, Runner: "test-runner", Repos: repoNames,
+		RepoMap: env.repoMap, Commits: commits, slotID: testOvenSlotID(slotID),
+		now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	}
+}
+
+func configureTestOven(env *testEnv) {
+	env.svc.Oven = oven.NewStore(env.groveDir)
+}
+
+func TestBakeOvenSlotPreparesDetachedWorktreesOutsideLock(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	env.createRepo("web")
+	configureTestOven(env)
+	options := ovenBakeOptions(env, "slot-ready", "api", "web")
+	callbackRan := false
+
+	slot, err := env.svc.BakeOvenSlot(options, func(worktrees map[string]string) error {
+		callbackRan = true
+		otherStore := state.NewStore(env.groveDir)
+		if err := otherStore.WithLock(func() error { return nil }); err != nil {
+			return err
+		}
+		for name, path := range worktrees {
+			if branch, err := gitops.CurrentBranch(path); err != nil || branch != "" {
+				return errors.New(name + " was not detached")
+			}
+			if err := os.MkdirAll(filepath.Join(path, "node_modules"), 0o755); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !callbackRan || slot.Status != oven.StatusReady {
+		t.Fatalf("ready slot = %+v, callback = %v", slot, callbackRan)
+	}
+	inventory, err := env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ready := inventory.ReadySlot(options.RecipeKey, options.Runner)
+	if ready == nil || ready.ID != slot.ID {
+		t.Fatalf("inventory ready slot = %+v", ready)
+	}
+	for _, repository := range slot.Repositories {
+		if branch, err := gitops.CurrentBranch(repository.WorktreePath); err != nil || branch != "" {
+			t.Fatalf("%s branch = %q, %v", repository.Name, branch, err)
+		}
+		if head, err := gitops.HeadCommit(repository.WorktreePath); err != nil || head != repository.Commit {
+			t.Fatalf("%s HEAD = %q, %v", repository.Name, head, err)
+		}
+	}
+}
+
+func TestBakeOvenSlotFailureIsNeverReadyAndCleansOwnedWorktrees(t *testing.T) {
+	env := setupTestEnv(t)
+	source := env.createRepo("api")
+	configureTestOven(env)
+	options := ovenBakeOptions(env, "slot-failed", "api")
+	injected := errors.New("prepare failed")
+
+	_, err := env.svc.BakeOvenSlot(options, func(worktrees map[string]string) error {
+		return errors.Join(injected, os.WriteFile(filepath.Join(worktrees["api"], "partial"), []byte("partial"), 0o644))
+	})
+	var bakeErr *OvenBakeError
+	if !errors.As(err, &bakeErr) || !errors.Is(err, injected) {
+		t.Fatalf("bake error = %v", err)
+	}
+	inventory, loadErr := env.svc.Oven.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if len(inventory.Slots) != 1 || inventory.Slots[0].Status != oven.StatusFailed || inventory.ReadySlot(options.RecipeKey, options.Runner) != nil {
+		t.Fatalf("failed inventory = %+v", inventory)
+	}
+	if _, statErr := os.Stat(optionsPath(env, options)); !os.IsNotExist(statErr) {
+		t.Fatalf("failed backing path remained: %v", statErr)
+	}
+	for _, entry := range mustWorktreeList(t, source) {
+		if canonicalPath(entry.Path) == canonicalPath(filepath.Join(optionsPath(env, options), "api")) {
+			t.Fatalf("failed worktree remained registered: %+v", entry)
+		}
+	}
+}
+
+func TestBakeOvenSlotDuplicateIDDoesNotTouchExistingSlot(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	configureTestOven(env)
+	options := ovenBakeOptions(env, "slot-existing", "api")
+	first, err := env.svc.BakeOvenSlot(options, func(map[string]string) error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.svc.BakeOvenSlot(options, func(map[string]string) error { return nil }); err == nil {
+		t.Fatal("expected duplicate slot ID failure")
+	}
+	options.slotID = "slot-other"
+	if _, err := env.svc.BakeOvenSlot(options, func(map[string]string) error { return nil }); !errors.Is(err, ErrOvenGenerationActive) {
+		t.Fatalf("concurrent generation error = %v", err)
+	}
+	inventory, err := env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inventory.Slots) != 1 || inventory.Slots[0].Status != oven.StatusReady {
+		t.Fatalf("existing slot changed: %+v", inventory)
+	}
+	if _, err := os.Stat(first.Repositories[0].WorktreePath); err != nil {
+		t.Fatalf("existing worktree was removed: %v", err)
+	}
+}
+
+func TestBakeOvenSlotCleansEarlierWorktreeAfterPartialProvisionFailure(t *testing.T) {
+	env := setupTestEnv(t)
+	api := env.createRepo("api")
+	env.createRepo("web")
+	configureTestOven(env)
+	options := ovenBakeOptions(env, "slot-partial", "api", "web")
+	options.Commits["web"] = "missing-object"
+
+	if _, err := env.svc.BakeOvenSlot(options, func(map[string]string) error { return nil }); err == nil {
+		t.Fatal("expected partial provisioning failure")
+	}
+	inventory, err := env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inventory.Slots[0].Status != oven.StatusFailed {
+		t.Fatalf("partial slot = %+v", inventory.Slots[0])
+	}
+	for _, entry := range mustWorktreeList(t, api) {
+		if canonicalPath(entry.Path) == canonicalPath(filepath.Join(optionsPath(env, options), "api")) {
+			t.Fatalf("first partial worktree remained: %+v", entry)
+		}
+	}
+}
+
+func TestBakeOvenSlotNeverReadiesCredentialResidue(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	configureTestOven(env)
+	options := ovenBakeOptions(env, "slot-credential", "api")
+
+	_, err := env.svc.BakeOvenSlot(options, func(worktrees map[string]string) error {
+		return os.WriteFile(filepath.Join(worktrees["api"], ".npmrc"), []byte("token=secret-value"), 0o600)
+	})
+	if err == nil {
+		t.Fatal("credential-bearing slot became ready")
+	}
+	inventory, loadErr := env.svc.Oven.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	slot := inventory.FindSlot(options.slotID)
+	if slot == nil || slot.Status != oven.StatusQuarantined || inventory.ReadySlot(options.RecipeKey, options.Runner) != nil {
+		t.Fatalf("credential slot = %+v", slot)
+	}
+	if strings.Contains(slot.Failure, "secret-value") {
+		t.Fatalf("credential value entered inventory: %q", slot.Failure)
+	}
+}
+
+func TestBakeOvenSlotQuarantinesChangedWorktreeIdentity(t *testing.T) {
+	env := setupTestEnv(t)
+	source := env.createRepo("api")
+	configureTestOven(env)
+	options := ovenBakeOptions(env, "slot-quarantine", "api")
+
+	_, err := env.svc.BakeOvenSlot(options, func(worktrees map[string]string) error {
+		_, err := spikeGit(worktrees["api"], "switch", "-c", "unexpected")
+		return err
+	})
+	if err == nil {
+		t.Fatal("expected changed identity failure")
+	}
+	inventory, loadErr := env.svc.Oven.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if inventory.Slots[0].Status != oven.StatusQuarantined || inventory.ReadySlot(options.RecipeKey, options.Runner) != nil {
+		t.Fatalf("quarantined inventory = %+v", inventory)
+	}
+	worktreePath := filepath.Join(optionsPath(env, options), "api")
+	if _, statErr := os.Stat(worktreePath); statErr != nil {
+		t.Fatalf("quarantined worktree was removed: %v", statErr)
+	}
+	if err := gitops.WorktreeRemove(source, worktreePath, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := gitops.DeleteBranch(source, "unexpected", true); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRecoverOvenSkipsLiveBakeAndCleansInterruptedBake(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	configureTestOven(env)
+	liveOptions := ovenBakeOptions(env, "slot-live", "api")
+	liveSlot, err := env.svc.newBakingSlot(liveOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, recorded, err := env.svc.createDetachedSlot(liveSlot); err != nil || !recorded {
+		t.Fatalf("creating live slot: recorded=%v err=%v", recorded, err)
+	}
+	if err := env.svc.RecoverOven(); err != nil {
+		t.Fatal(err)
+	}
+	inventory, _ := env.svc.Oven.Load()
+	if slot := inventory.FindSlot(liveSlot.ID); slot == nil || slot.Status != oven.StatusBaking {
+		t.Fatalf("live bake was recovered concurrently: %+v", slot)
+	}
+
+	if err := inventory.UpdateSlot(liveSlot.ID, func(slot *oven.Slot) error {
+		slot.OwnerPID = 0
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.svc.Oven.Save(inventory); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.svc.RecoverOven(); err != nil {
+		t.Fatal(err)
+	}
+	inventory, _ = env.svc.Oven.Load()
+	if slot := inventory.FindSlot(liveSlot.ID); slot == nil || slot.Status != oven.StatusFailed {
+		t.Fatalf("interrupted bake was not failed: %+v", slot)
+	}
+	if _, err := os.Stat(liveSlot.BackingPath); !os.IsNotExist(err) {
+		t.Fatalf("interrupted backing remained: %v", err)
+	}
+}
+
+func TestRecoverOvenResolvesClaimingRecordsConservatively(t *testing.T) {
+	t.Run("completed-state", func(t *testing.T) {
+		env := setupTestEnv(t)
+		env.createRepo("api")
+		slot := bakeTestOvenSlot(t, env, "slot-claim-recovery", "api")
+		if _, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "claimed", "feat/claimed")); err != nil {
+			t.Fatal(err)
+		}
+		inventory, _ := env.svc.Oven.Load()
+		inventory.FindSlot(slot.ID).Status = oven.StatusClaiming
+		if err := env.svc.Oven.Save(inventory); err != nil {
+			t.Fatal(err)
+		}
+		if err := env.svc.RecoverOven(); err != nil {
+			t.Fatal(err)
+		}
+		inventory, _ = env.svc.Oven.Load()
+		if inventory.FindSlot(slot.ID).Status != oven.StatusClaimed {
+			t.Fatalf("completed claim was not finalized: %+v", inventory.FindSlot(slot.ID))
+		}
+		if err := env.svc.DeleteWithOptions("claimed", RemoveOptions{Force: true}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("unstarted", func(t *testing.T) {
+		env := setupTestEnv(t)
+		env.createRepo("api")
+		slot := bakeTestOvenSlot(t, env, "slot-unstarted-claim", "api")
+		inventory, _ := env.svc.Oven.Load()
+		current := inventory.FindSlot(slot.ID)
+		current.Status = oven.StatusClaiming
+		current.Claim = &oven.Claim{
+			Nonce: "dddddddddddddddddddddddddddddddd", WorkspaceName: "unused", Alias: filepath.Join(env.wsDir, "unused"), Branch: "feat/unused",
+			Repositories: []oven.ClaimRepository{{
+				Name: "api", SourceRepo: slot.Repositories[0].SourceRepo,
+				PhysicalPath: slot.Repositories[0].WorktreePath,
+				AliasPath:    filepath.Join(env.wsDir, "unused", "api"), Branch: "feat/unused", BranchCreated: true,
+			}},
+		}
+		if err := env.svc.Oven.Save(inventory); err != nil {
+			t.Fatal(err)
+		}
+		if err := env.svc.RecoverOven(); err != nil {
+			t.Fatal(err)
+		}
+		inventory, _ = env.svc.Oven.Load()
+		current = inventory.FindSlot(slot.ID)
+		if current.Status != oven.StatusReady || current.Claim != nil {
+			t.Fatalf("unstarted claim was not reset: %+v", current)
+		}
+	})
+}
+
+func TestCleanOvenRemovesReadyButBlocksClaimedAndQuarantined(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	claimed := bakeTestOvenSlot(t, env, "slot-claimed-clean", "api")
+	if _, err := env.svc.ClaimOvenSlot(ovenClaimOptions(env, "claimed", "feat/claimed")); err != nil {
+		t.Fatal(err)
+	}
+	ready := bakeTestOvenSlot(t, env, "slot-ready-clean", "api")
+	inventory, _ := env.svc.Oven.Load()
+	quarantinedID := testOvenSlotID("slot-quarantined")
+	quarantined := oven.Slot{
+		ID: quarantinedID, RecipeKey: testOvenRecipeKey, RecipePath: "/recipes/stack.yaml",
+		Generation: testOvenGeneration, Runner: "test-runner", Status: oven.StatusQuarantined,
+		BackingPath: env.svc.Oven.SlotPath(testOvenGeneration, quarantinedID),
+	}
+	inventory.Slots = append(inventory.Slots, quarantined)
+	if err := env.svc.Oven.Save(inventory); err != nil {
+		t.Fatal(err)
+	}
+	result, err := env.svc.CleanOven("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Removed != 1 || len(result.Blocked) != 2 {
+		t.Fatalf("clean result = %+v", result)
+	}
+	inventory, _ = env.svc.Oven.Load()
+	if inventory.FindSlot(ready.ID) != nil || inventory.FindSlot(claimed.ID) == nil || inventory.FindSlot(quarantinedID) == nil {
+		t.Fatalf("clean inventory = %+v", inventory)
+	}
+	if err := env.svc.DeleteWithOptions("claimed", RemoveOptions{Force: true}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func optionsPath(env *testEnv, options OvenBakeOptions) string {
+	return env.svc.Oven.SlotPath(options.Generation, options.slotID)
+}
+
+func mustWorktreeList(t *testing.T, source string) []gitops.WorktreeEntry {
+	t.Helper()
+	entries, err := gitops.WorktreeList(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return entries
+}
+
+func TestConcurrentBakePublishesAtMostOneReadySlot(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	configureTestOven(env)
+	first := ovenBakeOptions(env, "slot-concurrent-first", "api")
+	second := ovenBakeOptions(env, "slot-concurrent-second", "api")
+	started := make(chan struct{})
+	release := make(chan struct{})
+	firstResult := make(chan error, 1)
+	go func() {
+		_, err := env.svc.BakeOvenSlot(first, func(map[string]string) error {
+			close(started)
+			<-release
+			return nil
+		})
+		firstResult <- err
+	}()
+	<-started
+	if _, err := env.svc.BakeOvenSlot(second, nil); !errors.Is(err, ErrOvenGenerationActive) {
+		t.Fatalf("concurrent bake error = %v", err)
+	}
+	close(release)
+	if err := <-firstResult; err != nil {
+		t.Fatal(err)
+	}
+	inventory, err := env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ready := 0
+	for _, slot := range inventory.Slots {
+		if slot.Status == oven.StatusReady {
+			ready++
+		}
+	}
+	if ready != 1 {
+		t.Fatalf("ready slots = %d: %+v", ready, inventory.Slots)
+	}
+}
+
+func TestFailedReplacementBakePreservesReadyGeneration(t *testing.T) {
+	env := setupTestEnv(t)
+	source := env.createRepo("api")
+	ready := bakeTestOvenSlot(t, env, "slot-old-generation", "api")
+	if err := os.WriteFile(filepath.Join(source, "next.txt"), []byte("next"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := spikeGit(source, "add", "next.txt"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := spikeGit(source, "commit", "-m", "next"); err != nil {
+		t.Fatal(err)
+	}
+	commit, err := gitops.HeadCommit(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := ovenBakeOptions(env, "slot-new-generation", "api")
+	replacement.Generation = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	replacement.Commits["api"] = commit
+	if _, err := env.svc.BakeOvenSlot(replacement, func(map[string]string) error {
+		return errors.New("replacement preparation failed")
+	}); err == nil {
+		t.Fatal("expected replacement bake failure")
+	}
+	inventory, err := env.svc.Oven.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slot := inventory.FindSlot(ready.ID); slot == nil || slot.Status != oven.StatusReady {
+		t.Fatalf("previous ready generation was not preserved: %+v", slot)
+	}
+	if inventory.ReadySlot(replacement.RecipeKey, replacement.Runner).ID != ready.ID {
+		t.Fatal("failed replacement became claimable")
+	}
+}
+
+func TestBakeOvenSlotAllowsEnvironmentTemplates(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	configureTestOven(env)
+	options := ovenBakeOptions(env, "slot-env-template", "api")
+	if _, err := env.svc.BakeOvenSlot(options, func(worktrees map[string]string) error {
+		return os.WriteFile(filepath.Join(worktrees["api"], ".env.local.example"), []byte("TOKEN="), 0o644)
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClaimAndCleanSerializeThroughStateLock(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	bakeTestOvenSlot(t, env, "slot-claim-clean-race", "api")
+	options := ovenClaimOptions(env, "serialized", "feat/serialized")
+	started := make(chan struct{})
+	release := make(chan struct{})
+	options.attachBranch = func(repository oven.ClaimRepository, commit string) error {
+		close(started)
+		<-release
+		return gitops.AttachWorktreeBranch(repository.PhysicalPath, repository.Branch, commit, repository.BranchCreated)
+	}
+	claimResult := make(chan error, 1)
+	go func() {
+		_, err := env.svc.ClaimOvenSlot(options)
+		claimResult <- err
+	}()
+	<-started
+	cleanResult := make(chan OvenCleanResult, 1)
+	cleanError := make(chan error, 1)
+	go func() {
+		result, err := env.svc.CleanOven("")
+		cleanResult <- result
+		cleanError <- err
+	}()
+	select {
+	case <-cleanResult:
+		t.Fatal("clean bypassed the claim mutation lock")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	if err := <-claimResult; err != nil {
+		t.Fatal(err)
+	}
+	result := <-cleanResult
+	if err := <-cleanError; err != nil {
+		t.Fatal(err)
+	}
+	if result.Removed != 0 || len(result.Blocked) != 1 {
+		t.Fatalf("clean result after claim = %+v", result)
+	}
+	if err := env.svc.DeleteWithOptions("serialized", RemoveOptions{Force: true}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOvenCredentialPathMatrix(t *testing.T) {
+	forbidden := []string{
+		".netrc", ".pypirc", ".git-credentials", "id_rsa", "id_ed25519", ".env", ".env.local",
+		filepath.Join(".aws", "credentials"), filepath.Join(".docker", "config.json"),
+	}
+	for _, path := range forbidden {
+		if !forbiddenOvenCredentialPath(path) {
+			t.Errorf("expected %s to be forbidden", path)
+		}
+	}
+	allowed := []string{".env.example", ".env.local.example", ".env.dev.sample", ".env.prod.template"}
+	for _, path := range allowed {
+		if forbiddenOvenCredentialPath(path) {
+			t.Errorf("expected %s to be allowed", path)
+		}
+	}
+}

--- a/internal/workspace/run.go
+++ b/internal/workspace/run.go
@@ -53,6 +53,13 @@ func Run(wsName string) error {
 	if err != nil {
 		return err
 	}
+	ovenSlot, err := NewService().verifyOvenWorkspaceIfClaimed(*ws)
+	if err != nil {
+		return err
+	}
+	if ovenSlot != nil {
+		applyOvenPhysicalPaths(ws, *ovenSlot)
+	}
 
 	runnable := GetRunnable(ws)
 	if len(runnable) == 0 {

--- a/internal/workspace/service.go
+++ b/internal/workspace/service.go
@@ -5,23 +5,27 @@ import (
 	"os/exec"
 
 	"github.com/nicksenap/grove/internal/config"
+	"github.com/nicksenap/grove/internal/oven"
 	"github.com/nicksenap/grove/internal/state"
 	"github.com/nicksenap/grove/internal/stats"
 )
 
 // Service orchestrates workspace operations with injectable dependencies.
 type Service struct {
-	State          *state.Store
-	Stats          *stats.Tracker
-	RunCmd         func(dir, cmd string) error
-	RunCmdSilent   func(dir, cmd string) error
-	RemoveWorktree func(repo, path string, force bool) error // optional test seam
+	State           *state.Store
+	Oven            *oven.Store
+	Stats           *stats.Tracker
+	RunCmd          func(dir, cmd string) error
+	RunCmdSilent    func(dir, cmd string) error
+	RemoveWorktree  func(repo, path string, force bool) error // optional test seam
+	RemoveWorkspace func(name string) error                   // optional test seam
 }
 
 // NewService creates a Service with production dependencies.
 func NewService() *Service {
 	return &Service{
 		State:        state.NewStore(config.GroveDir),
+		Oven:         oven.NewStore(config.GroveDir),
 		Stats:        stats.NewTracker(config.GroveDir),
 		RunCmd:       prodRunCmd,
 		RunCmdSilent: prodRunCmdSilent,

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nicksenap/grove/internal/gitops"
 	"github.com/nicksenap/grove/internal/logging"
 	"github.com/nicksenap/grove/internal/models"
+	"github.com/nicksenap/grove/internal/oven"
 )
 
 // BranchMode determines how a worktree's branch is provisioned.
@@ -615,6 +616,10 @@ func (s *Service) DeleteWithOptions(name string, opts RemoveOptions) error {
 	if ws == nil {
 		return fmt.Errorf("workspace %s not found", name)
 	}
+	ovenSlot, err := s.verifyOvenWorkspaceIfClaimed(*ws)
+	if err != nil {
+		return err
+	}
 
 	if err := preflightRemovals(ws.Repos, opts.Force); err != nil {
 		return err
@@ -622,7 +627,11 @@ func (s *Service) DeleteWithOptions(name string, opts RemoveOptions) error {
 
 	// Teardown commands are user-owned and may invoke gw. Run them before the
 	// mutation lock, then reload and preflight state again while locked.
-	s.runTeardownHooks(ws.Repos)
+	operationWorkspace := *ws
+	if ovenSlot != nil {
+		applyOvenPhysicalPaths(&operationWorkspace, *ovenSlot)
+	}
+	s.runTeardownHooks(operationWorkspace.Repos)
 
 	var deleted *models.Workspace
 	if err := s.State.WithLock(func() error {
@@ -647,30 +656,25 @@ func (s *Service) deleteLocked(name string, opts RemoveOptions) (*models.Workspa
 	if ws == nil {
 		return nil, fmt.Errorf("workspace %s not found", name)
 	}
+	ovenSlot, err := s.verifyOvenWorkspaceIfClaimed(*ws)
+	if err != nil {
+		return nil, err
+	}
 	if err := preflightRemovals(ws.Repos, opts.Force); err != nil {
 		return nil, err
+	}
+	if ovenSlot != nil {
+		ovenSlot, err = s.beginOvenCleanup(ovenSlot.ID, opts.Force)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	logging.Info("deleting workspace %q", name)
 	original := *ws
-	remaining := make([]models.RepoWorktree, 0, len(ws.Repos))
-	var cleanupErrs []error
-
-	for _, repo := range ws.Repos {
-		if err := s.removeWorktree(repo.SourceRepo, repo.WorktreePath, opts.Force); err != nil {
-			remaining = append(remaining, repo)
-			cleanupErrs = append(cleanupErrs, fmt.Errorf("%s: removing worktree: %w", repo.RepoName, err))
-			continue
-		}
-		s.deleteBranch(repo, opts.Force)
-	}
-
+	remaining, cleanupErrs := s.removeWorkspaceRepositories(ws.Repos, ovenSlot, opts.Force)
 	if len(remaining) > 0 {
-		ws.Repos = remaining
-		if err := s.State.UpdateWorkspace(*ws); err != nil {
-			cleanupErrs = append(cleanupErrs, fmt.Errorf("updating state: %w", err))
-		}
-		return nil, errors.Join(cleanupErrs...)
+		return nil, s.persistPartialDelete(ws, ovenSlot, remaining, cleanupErrs)
 	}
 
 	removeMCPConfig(*ws)
@@ -686,7 +690,61 @@ func (s *Service) deleteLocked(name string, opts RemoveOptions) (*models.Workspa
 	if err := s.State.RemoveWorkspace(name); err != nil {
 		return nil, err
 	}
+	if ovenSlot != nil {
+		if err := s.finalizeDeletedOvenClaim(*ovenSlot); err != nil {
+			return &original, err
+		}
+	}
 	return &original, nil
+}
+
+func (s *Service) removeWorkspaceRepositories(repositories []models.RepoWorktree, slot *oven.Slot, force bool) ([]models.RepoWorktree, []error) {
+	remaining := make([]models.RepoWorktree, 0, len(repositories))
+	var cleanupErrs []error
+	for _, repository := range repositories {
+		removePath, expectedBranch, err := deletionOwnership(repository, slot)
+		if err != nil {
+			remaining = append(remaining, repository)
+			cleanupErrs = append(cleanupErrs, err)
+			continue
+		}
+		if err := s.removeWorktree(repository.SourceRepo, removePath, force); err != nil {
+			remaining = append(remaining, repository)
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("%s: removing worktree: %w", repository.RepoName, err))
+			continue
+		}
+		s.deleteBranchIfOwned(repository, force, expectedBranch)
+	}
+	return remaining, cleanupErrs
+}
+
+func deletionOwnership(repository models.RepoWorktree, slot *oven.Slot) (string, string, error) {
+	if slot != nil {
+		claimed := ovenClaimRepositoryByName(*slot.Claim, repository.RepoName)
+		return claimed.PhysicalPath, claimed.ExpectedBranchCommit, nil
+	}
+	if repository.PreserveBranch {
+		return repository.WorktreePath, "", nil
+	}
+	commit, err := gitops.LocalBranchCommit(repository.SourceRepo, repository.Branch)
+	if err != nil {
+		return "", "", fmt.Errorf("%s: reading branch ownership: %w", repository.RepoName, err)
+	}
+	return repository.WorktreePath, commit, nil
+}
+
+func (s *Service) persistPartialDelete(workspace *models.Workspace, slot *oven.Slot, remaining []models.RepoWorktree, cleanupErrs []error) error {
+	if slot != nil {
+		if _, err := s.updateOvenCleanupProgress(slot.ID, slot.Claim.Nonce, remaining); err != nil {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("recording Oven cleanup progress: %w", err))
+			return errors.Join(cleanupErrs...)
+		}
+	}
+	workspace.Repos = remaining
+	if err := s.State.UpdateWorkspace(*workspace); err != nil {
+		cleanupErrs = append(cleanupErrs, fmt.Errorf("updating state: %w", err))
+	}
+	return errors.Join(cleanupErrs...)
 }
 
 func (s *Service) runTeardownHooks(repos []models.RepoWorktree) {
@@ -706,11 +764,23 @@ func (s *Service) removeWorktree(repo, path string, force bool) error {
 }
 
 func (s *Service) deleteBranch(repo models.RepoWorktree, force bool) {
+	expected := ""
+	if !repo.PreserveBranch {
+		expected, _ = gitops.LocalBranchCommit(repo.SourceRepo, repo.Branch)
+	}
+	s.deleteBranchIfOwned(repo, force, expected)
+}
+
+func (s *Service) deleteBranchIfOwned(repo models.RepoWorktree, force bool, expected string) {
 	if repo.PreserveBranch {
 		logging.Info("preserving pre-existing branch %q in %s", repo.Branch, repo.RepoName)
 		return
 	}
-	if err := gitops.DeleteBranch(repo.SourceRepo, repo.Branch, force); err != nil {
+	if expected == "" {
+		logging.Warn("could not verify branch %q ownership in %s; preserving it", repo.Branch, repo.RepoName)
+		return
+	}
+	if err := gitops.DeleteBranchIfAt(repo.SourceRepo, repo.Branch, expected, force); err != nil {
 		logging.Warn("failed to delete branch %q in %s: %s", repo.Branch, repo.RepoName, err)
 		console.Warningf("%s: failed to delete branch %s: %s", repo.RepoName, repo.Branch, err)
 		return
@@ -797,6 +867,11 @@ func (s *Service) renameLocked(oldName, newName string) error {
 	if ws == nil {
 		return fmt.Errorf("workspace %s not found", oldName)
 	}
+	if slot, err := s.ovenClaimForWorkspace(oldName); err != nil {
+		return err
+	} else if slot != nil {
+		return fmt.Errorf("oven-backed workspaces cannot be renamed")
+	}
 
 	existing, err := s.State.GetWorkspace(newName)
 	if err != nil {
@@ -879,6 +954,11 @@ func (s *Service) addReposLocked(wsName string, repoNames []string, repoMap map[
 	if ws == nil {
 		return nil, fmt.Errorf("workspace %s not found", wsName)
 	}
+	if slot, err := s.ovenClaimForWorkspace(wsName); err != nil {
+		return nil, err
+	} else if slot != nil {
+		return nil, fmt.Errorf("repositories cannot be added to an Oven-backed workspace")
+	}
 
 	existing := make(map[string]bool)
 	for _, r := range ws.Repos {
@@ -943,6 +1023,11 @@ func (s *Service) RemoveReposWithOptions(wsName string, repoNames []string, opts
 	if ws == nil {
 		return fmt.Errorf("workspace %s not found", wsName)
 	}
+	if slot, err := s.ovenClaimForWorkspace(wsName); err != nil {
+		return err
+	} else if slot != nil {
+		return fmt.Errorf("repositories cannot be removed from an Oven-backed workspace")
+	}
 
 	selected := selectRepos(ws, repoNames)
 	if err := preflightRemovals(selected, opts.Force); err != nil {
@@ -979,6 +1064,11 @@ func (s *Service) removeReposLocked(wsName string, repoNames []string, opts Remo
 	}
 	if ws == nil {
 		return 0, fmt.Errorf("workspace %s not found", wsName)
+	}
+	if slot, err := s.ovenClaimForWorkspace(wsName); err != nil {
+		return 0, err
+	} else if slot != nil {
+		return 0, fmt.Errorf("repositories cannot be removed from an Oven-backed workspace")
 	}
 
 	items := selectRepos(ws, repoNames)
@@ -1083,6 +1173,13 @@ func (s *Service) Sync(wsName string) error {
 	}
 	if ws == nil {
 		return fmt.Errorf("workspace %s not found", wsName)
+	}
+	ovenSlot, err := s.verifyOvenWorkspaceIfClaimed(*ws)
+	if err != nil {
+		return err
+	}
+	if ovenSlot != nil {
+		applyOvenPhysicalPaths(ws, *ovenSlot)
 	}
 
 	logging.Info("syncing workspace %q", wsName)
@@ -1211,6 +1308,13 @@ func (s *Service) Status(wsName string, opts StatusOptions) error {
 	}
 	if ws == nil {
 		return fmt.Errorf("workspace %s not found", wsName)
+	}
+	ovenSlot, err := s.verifyOvenWorkspaceIfClaimed(*ws)
+	if err != nil {
+		return err
+	}
+	if ovenSlot != nil {
+		applyOvenPhysicalPaths(ws, *ovenSlot)
 	}
 
 	results := s.fetchStatusResults(ws.Repos, opts.PR)
@@ -1405,11 +1509,27 @@ func (s *Service) doctor(fix bool) ([]models.DoctorIssue, int, error) {
 	if err != nil {
 		return nil, 0, err
 	}
+	var ovenInventory oven.Inventory
+	if s.Oven != nil {
+		ovenInventory, err = s.Oven.Load()
+		if err != nil {
+			return nil, 0, err
+		}
+	}
 
 	var issues []models.DoctorIssue
 	fixed := 0
 
+	workspaceNames := make(map[string]bool, len(workspaces))
 	for _, ws := range workspaces {
+		workspaceNames[ws.Name] = true
+		if _, err := s.verifyOvenWorkspaceIfClaimed(ws); err != nil {
+			issues = append(issues, models.DoctorIssue{
+				Workspace: ws.Name, Issue: "Oven ownership mismatch: " + err.Error(),
+				SuggestedAction: "inspect with gw oven status; manual recovery required",
+			})
+			continue
+		}
 		f, iss := s.checkWorkspaceExists(ws, fix)
 		if f > 0 {
 			fixed += f
@@ -1422,6 +1542,15 @@ func (s *Service) doctor(fix bool) ([]models.DoctorIssue, int, error) {
 		f, iss = s.checkWorkspaceRepos(&ws, fix)
 		fixed += f
 		issues = append(issues, iss...)
+	}
+	for _, slot := range ovenInventory.Slots {
+		if slot.Claim != nil && !workspaceNames[slot.Claim.WorkspaceName] {
+			issues = append(issues, models.DoctorIssue{
+				Workspace:       slot.Claim.WorkspaceName,
+				Issue:           fmt.Sprintf("Oven claim %s has no workspace state", slot.ID),
+				SuggestedAction: "inspect with gw oven status; manual recovery required",
+			})
+		}
 	}
 
 	return issues, fixed, nil


### PR DESCRIPTION
## Summary

Implements #78 with an additive, opt-in local Oven for Recipe workspaces.

- adds `gw oven bake`, `reconcile`, `status`, and `clean`
- adds `gw create NAME --recipe FILE --oven`
- claims ready slots without fetching and preserves cold Recipe creation as the fallback for clean misses
- keeps prepared dependencies at immutable physical paths and exposes claimed workspaces through named symlinks
- uses a private atomic inventory with bounded bake/claim/cleanup lifecycle recovery
- enforces reciprocal workspace/slot ownership, source-repository allowlisting, branch compare-delete, and fail-closed tamper checks
- keeps scheduling external: cron, launchd, or systemd may invoke idempotent reconciliation

## Safety behavior

- incomplete bakes are never visible as ready
- quarantined or mismatched slots block claiming rather than falling back cold
- claims write workspace state last
- interrupted and partial claims are conservatively rolled back or quarantined
- partial deletion persists progress and is retryable
- normal status, sync, run, go, delete, and doctor paths verify Oven ownership
- rename/add/remove remain unsupported for Oven-backed workspaces
- credentials are not persisted in inventory; common residue files block readiness

## Verification

- `PATH="$(go env GOPATH)/bin:$PATH" just check`
- `PATH="$(go env GOPATH)/bin:$PATH" staticcheck ./...`
- focused Oven race tests
- `just e2e` — 135/135 passed
- independent correctness and security review with all blocking findings addressed

## Notes

This intentionally does not add a daemon, scheduler, generic artifact cache, CI framework, or hosted Oven. Performance and caching decisions remain in #79.

Closes #78
