### PR TITLE
feat: add source toggles and Oven schedule examples

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -49,6 +49,77 @@ staticcheck:
 build:
     go build -ldflags "-X github.com/nicksenap/grove/cmd.Version=$(git describe --tags --always)" -o gw ./cmd/gw
 
+# Build from this checkout and make it the active gw
+gw-use-source:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v brew >/dev/null 2>&1 || { echo "error: Homebrew is required" >&2; exit 1; }
+    brew list --versions grove >/dev/null 2>&1 || { echo "error: Homebrew grove is not installed" >&2; exit 1; }
+
+    source_dir="${XDG_DATA_HOME:-$HOME/.local/share}/grove/source"
+    source_bin="$source_dir/gw"
+    active_bin="$(brew --prefix)/bin/gw"
+    mkdir -p "$source_dir"
+    go build -ldflags "-X github.com/nicksenap/grove/cmd.Version=$(git describe --tags --always)" -o "$source_bin.tmp" ./cmd/gw
+    chmod 0755 "$source_bin.tmp"
+    mv "$source_bin.tmp" "$source_bin"
+
+    if [ -L "$active_bin" ] && [ "$(readlink "$active_bin")" = "$source_bin" ]; then
+        : # Already using the source binary; the atomic build above updated it.
+    elif [ -e "$active_bin" ] || [ -L "$active_bin" ]; then
+        resolved="$(realpath "$active_bin")"
+        case "$resolved" in
+            "$(brew --cellar)/grove/"*)
+                brew unlink grove >/dev/null
+                ln -s "$source_bin" "$active_bin"
+                ;;
+            *)
+                echo "error: refusing to replace unexpected $active_bin -> $resolved" >&2
+                exit 1
+                ;;
+        esac
+    else
+        ln -s "$source_bin" "$active_bin"
+    fi
+    echo "Using source build: $source_bin"
+    "$active_bin" --version
+
+# Restore the Homebrew-managed gw binary
+gw-use-brew:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v brew >/dev/null 2>&1 || { echo "error: Homebrew is required" >&2; exit 1; }
+    brew list --versions grove >/dev/null 2>&1 || { echo "error: Homebrew grove is not installed" >&2; exit 1; }
+
+    source_bin="${XDG_DATA_HOME:-$HOME/.local/share}/grove/source/gw"
+    active_bin="$(brew --prefix)/bin/gw"
+    if [ -L "$active_bin" ] && [ "$(readlink "$active_bin")" = "$source_bin" ]; then
+        rm "$active_bin"
+    elif [ -e "$active_bin" ] || [ -L "$active_bin" ]; then
+        resolved="$(realpath "$active_bin")"
+        case "$resolved" in
+            "$(brew --cellar)/grove/"*) ;;
+            *) echo "error: refusing to replace unexpected $active_bin -> $resolved" >&2; exit 1 ;;
+        esac
+    fi
+    brew link grove >/dev/null
+    echo "Using Homebrew build: $(realpath "$active_bin")"
+    "$active_bin" --version
+
+# Show which gw binary is active
+gw-active:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    active_bin="$(command -v gw || true)"
+    if [ -z "$active_bin" ]; then
+        echo "gw is not on PATH"
+        exit 1
+    fi
+    echo "Command:  $active_bin"
+    echo "Binary:   $(realpath "$active_bin")"
+    printf "Version:  "
+    "$active_bin" --version
+
 # Run e2e tests
 e2e: build
     bash e2e/run.sh

--- a/cmd/oven_schedule.go
+++ b/cmd/oven_schedule.go
@@ -1,0 +1,255 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	ovenScheduleEvery      time.Duration
+	ovenScheduleFormat     string
+	ovenScheduleExecutable string
+)
+
+type scheduleExampleOptions struct {
+	Format     string
+	Every      time.Duration
+	Executable string
+	RecipePath string
+}
+
+type ovenScheduleExampleOutput struct {
+	Format     string `json:"format"`
+	Every      string `json:"every"`
+	Executable string `json:"executable"`
+	Recipe     string `json:"recipe"`
+	Example    string `json:"example"`
+}
+
+var ovenScheduleExampleCmd = &cobra.Command{
+	Use:   "schedule-example RECIPE",
+	Short: "Print an external scheduler example for Oven reconciliation",
+	Long:  "Print an example for launchd, cron, or systemd. Grove does not install or manage the scheduler.",
+	Args:  cobra.ExactArgs(1),
+	Annotations: map[string]string{
+		offlineCommandAnnotation: "true",
+	},
+	RunE: runOvenScheduleExample,
+}
+
+func init() {
+	ovenScheduleExampleCmd.Flags().DurationVar(&ovenScheduleEvery, "every", 0, "Reconciliation interval (whole minutes)")
+	ovenScheduleExampleCmd.Flags().StringVar(&ovenScheduleFormat, "format", defaultOvenScheduleFormat(), "Scheduler format: launchd, cron, or systemd")
+	if err := ovenScheduleExampleCmd.MarkFlagRequired("every"); err != nil {
+		panic(err)
+	}
+	ovenCmd.AddCommand(ovenScheduleExampleCmd)
+}
+
+func runOvenScheduleExample(cmd *cobra.Command, args []string) error {
+	_, recipePath, err := loadOvenRecipe(args[0])
+	if err != nil {
+		return err
+	}
+	recipePath, err = canonicalSchedulePath(recipePath)
+	if err != nil {
+		return err
+	}
+	executable := ovenScheduleExecutable
+	if executable == "" {
+		executable, err = os.Executable()
+		if err != nil {
+			return fmt.Errorf("resolving gw executable: %w", err)
+		}
+	}
+	executable, err = canonicalSchedulePath(executable)
+	if err != nil {
+		return err
+	}
+	example, err := renderOvenScheduleExample(scheduleExampleOptions{
+		Format: ovenScheduleFormat, Every: ovenScheduleEvery, Executable: executable, RecipePath: recipePath,
+	})
+	if err != nil {
+		return err
+	}
+	output := ovenScheduleExampleOutput{
+		Format: ovenScheduleFormat, Every: ovenScheduleEvery.String(), Executable: executable, Recipe: recipePath, Example: example,
+	}
+	if ovenJSON {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(output)
+	}
+	_, err = fmt.Fprint(cmd.OutOrStdout(), example)
+	return err
+}
+
+func renderOvenScheduleExample(options scheduleExampleOptions) (string, error) {
+	if options.Every < time.Minute || options.Every%time.Minute != 0 {
+		return "", fmt.Errorf("--every must be a whole number of minutes")
+	}
+	if !filepath.IsAbs(options.Executable) || !filepath.IsAbs(options.RecipePath) {
+		return "", fmt.Errorf("scheduler examples require absolute executable and Recipe paths")
+	}
+	if err := validateSchedulerPath(options.Executable); err != nil {
+		return "", fmt.Errorf("executable path: %w", err)
+	}
+	if err := validateSchedulerPath(options.RecipePath); err != nil {
+		return "", fmt.Errorf("recipe path: %w", err)
+	}
+	switch options.Format {
+	case "launchd":
+		return renderLaunchdExample(options), nil
+	case "cron":
+		return renderCronExample(options)
+	case "systemd":
+		return renderSystemdExample(options), nil
+	default:
+		return "", fmt.Errorf("unsupported scheduler format %q (use launchd, cron, or systemd)", options.Format)
+	}
+}
+
+func renderLaunchdExample(options scheduleExampleOptions) string {
+	seconds := int64(options.Every / time.Second)
+	identifier := scheduleIdentifier(options.RecipePath)
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!-- Save as ~/Library/LaunchAgents/com.grove.oven.%s.plist, then load with:
+     launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.grove.oven.%s.plist
+     Grove does not install or manage this job. -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.grove.oven.%s</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>%s</string>
+    <string>oven</string>
+    <string>reconcile</string>
+    <string>%s</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>%d</integer>
+  <key>RunAtLoad</key>
+  <true/>
+</dict>
+</plist>
+`, identifier, identifier, identifier, xmlEscape(options.Executable), xmlEscape(options.RecipePath), seconds)
+}
+
+func renderCronExample(options scheduleExampleOptions) (string, error) {
+	minutes := int64(options.Every / time.Minute)
+	var expression string
+	switch {
+	case minutes < 60 && 60%minutes == 0:
+		expression = fmt.Sprintf("*/%d * * * *", minutes)
+	case minutes%60 == 0 && minutes/60 < 24 && 24%(minutes/60) == 0:
+		expression = fmt.Sprintf("0 */%d * * *", minutes/60)
+	case minutes == 24*60:
+		expression = "0 0 * * *"
+	default:
+		return "", fmt.Errorf("cron format supports intervals that evenly divide an hour or day")
+	}
+	return fmt.Sprintf("# Add with `crontab -e`. Grove does not install or manage this entry.\n%s %s oven reconcile %s\n",
+		expression, shellQuote(escapeCronPercent(options.Executable)), shellQuote(escapeCronPercent(options.RecipePath))), nil
+}
+
+func renderSystemdExample(options scheduleExampleOptions) string {
+	identifier := scheduleIdentifier(options.RecipePath)
+	return fmt.Sprintf(`# Save these as ~/.config/systemd/user/grove-oven-%s.service and grove-oven-%s.timer.
+# Enable with: systemctl --user enable --now grove-oven-%s.timer
+# Grove does not install or manage these units.
+
+# grove-oven.service
+[Unit]
+Description=Reconcile Grove Oven Recipe
+
+[Service]
+Type=oneshot
+ExecStart=%s oven reconcile %s
+
+# grove-oven.timer
+[Unit]
+Description=Periodically reconcile Grove Oven Recipe
+
+[Timer]
+OnBootSec=1m
+OnUnitActiveSec=%s
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+`, identifier, identifier, identifier, systemdQuote(options.Executable), systemdQuote(options.RecipePath), compactDuration(options.Every))
+}
+
+func defaultOvenScheduleFormat() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "launchd"
+	case "linux":
+		return "systemd"
+	default:
+		return "cron"
+	}
+}
+
+func canonicalSchedulePath(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("resolving path %s: %w", absolute, err)
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+func systemdQuote(value string) string {
+	value = strings.ReplaceAll(value, "%", "%%")
+	value = strings.ReplaceAll(value, "$", "$$")
+	return strconv.Quote(value)
+}
+
+func escapeCronPercent(value string) string {
+	return strings.ReplaceAll(value, "%", `\%`)
+}
+
+func validateSchedulerPath(value string) error {
+	for _, char := range value {
+		if char < 0x20 || char == 0x7f {
+			return fmt.Errorf("contains a control character")
+		}
+	}
+	return nil
+}
+
+func scheduleIdentifier(recipePath string) string {
+	sum := sha256.Sum256([]byte(recipePath))
+	return hex.EncodeToString(sum[:6])
+}
+
+func xmlEscape(value string) string {
+	replacer := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;", "'", "&apos;")
+	return replacer.Replace(value)
+}
+
+func compactDuration(duration time.Duration) string {
+	minutes := int64(duration / time.Minute)
+	if minutes%60 == 0 {
+		return fmt.Sprintf("%dh", minutes/60)
+	}
+	return fmt.Sprintf("%dm", minutes)
+}

--- a/cmd/oven_schedule_test.go
+++ b/cmd/oven_schedule_test.go
@@ -1,0 +1,219 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRenderOvenScheduleExamples(t *testing.T) {
+	executable := "/opt/homebrew/bin/gw"
+	recipePath := "/Users/example/My Recipes/stack.yaml"
+
+	t.Run("launchd", func(t *testing.T) {
+		output, err := renderOvenScheduleExample(scheduleExampleOptions{
+			Format: "launchd", Every: 30 * time.Minute, Executable: executable, RecipePath: recipePath,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, expected := range []string{
+			`<string>/opt/homebrew/bin/gw</string>`,
+			`<string>oven</string>`,
+			`<string>reconcile</string>`,
+			`<string>/Users/example/My Recipes/stack.yaml</string>`,
+			`<integer>1800</integer>`,
+			`<key>RunAtLoad</key>`,
+			`<string>com.grove.oven.`,
+		} {
+			if !strings.Contains(output, expected) {
+				t.Fatalf("launchd output missing %q:\n%s", expected, output)
+			}
+		}
+	})
+
+	t.Run("cron", func(t *testing.T) {
+		output, err := renderOvenScheduleExample(scheduleExampleOptions{
+			Format: "cron", Every: 30 * time.Minute, Executable: executable, RecipePath: recipePath,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := `*/30 * * * * '/opt/homebrew/bin/gw' oven reconcile '/Users/example/My Recipes/stack.yaml'`
+		if !strings.Contains(output, expected) {
+			t.Fatalf("cron output missing command:\n%s", output)
+		}
+	})
+
+	t.Run("systemd", func(t *testing.T) {
+		output, err := renderOvenScheduleExample(scheduleExampleOptions{
+			Format: "systemd", Every: 30 * time.Minute, Executable: executable, RecipePath: recipePath,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, expected := range []string{
+			`grove-oven-`,
+			`ExecStart="/opt/homebrew/bin/gw" oven reconcile "/Users/example/My Recipes/stack.yaml"`,
+			`OnUnitActiveSec=30m`,
+			`Persistent=true`,
+		} {
+			if !strings.Contains(output, expected) {
+				t.Fatalf("systemd output missing %q:\n%s", expected, output)
+			}
+		}
+	})
+}
+
+func TestRenderOvenScheduleExamplesEscapeSchedulerSyntax(t *testing.T) {
+	options := scheduleExampleOptions{
+		Every: 30 * time.Minute, Executable: "/opt/gw%tool", RecipePath: "/tmp/recipe's $name%.yaml",
+	}
+	options.Format = "cron"
+	cron, err := renderOvenScheduleExample(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(cron, `gw\%tool`) || !strings.Contains(cron, `recipe'\''s $name\%.yaml`) {
+		t.Fatalf("cron escaping = %q", cron)
+	}
+	options.Format = "systemd"
+	systemd, err := renderOvenScheduleExample(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(systemd, `gw%%tool`) || !strings.Contains(systemd, `$$name%%.yaml`) {
+		t.Fatalf("systemd escaping = %q", systemd)
+	}
+	options.Format = "launchd"
+	options.RecipePath = "/tmp/recipe&name.yaml"
+	launchd, err := renderOvenScheduleExample(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(launchd, `recipe&amp;name.yaml`) {
+		t.Fatalf("launchd escaping = %q", launchd)
+	}
+}
+
+func TestRenderOvenScheduleExampleRejectsControlCharacters(t *testing.T) {
+	for _, format := range []string{"launchd", "cron", "systemd"} {
+		_, err := renderOvenScheduleExample(scheduleExampleOptions{
+			Format: format, Every: 30 * time.Minute, Executable: "/bin/gw", RecipePath: "/tmp/recipe\n* * * * * injected.yaml",
+		})
+		if err == nil {
+			t.Fatalf("%s accepted newline path", format)
+		}
+	}
+}
+
+func TestRenderOvenScheduleExampleUsesDistinctRecipeIdentifiers(t *testing.T) {
+	first := renderLaunchdExample(scheduleExampleOptions{Every: time.Hour, Executable: "/bin/gw", RecipePath: "/tmp/a.yaml"})
+	second := renderLaunchdExample(scheduleExampleOptions{Every: time.Hour, Executable: "/bin/gw", RecipePath: "/tmp/b.yaml"})
+	if first == second || scheduleIdentifier("/tmp/a.yaml") == scheduleIdentifier("/tmp/b.yaml") {
+		t.Fatal("different Recipes share a scheduler identifier")
+	}
+}
+
+func TestCanonicalSchedulePathRejectsMissingPath(t *testing.T) {
+	if _, err := canonicalSchedulePath(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("expected missing path error")
+	}
+}
+
+func TestRenderOvenScheduleExampleRejectsInvalidIntervals(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		format   string
+		duration time.Duration
+	}{
+		{name: "less than minute", format: "launchd", duration: 30 * time.Second},
+		{name: "fractional minute", format: "systemd", duration: 90 * time.Second},
+		{name: "cron over hour not divisor", format: "cron", duration: 90 * time.Minute},
+		{name: "unknown format", format: "other", duration: 30 * time.Minute},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := renderOvenScheduleExample(scheduleExampleOptions{
+				Format: test.format, Every: test.duration, Executable: "/bin/gw", RecipePath: "/tmp/recipe.yaml",
+			})
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestRunOvenScheduleExampleCanonicalizesPathsAndSupportsJSON(t *testing.T) {
+	directory := t.TempDir()
+	recipePath := filepath.Join(directory, "recipe.yaml")
+	if err := os.WriteFile(recipePath, []byte("version: 1\nrepositories:\n  api:\n    url: https://example.com/api.git\n    ref: main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	command, stdout, _ := ovenTestCommand()
+	oldJSON := ovenJSON
+	oldFormat := ovenScheduleFormat
+	oldEvery := ovenScheduleEvery
+	oldExecutable := ovenScheduleExecutable
+	executablePath := filepath.Join(directory, "gw")
+	if err := os.WriteFile(executablePath, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ovenJSON = true
+	ovenScheduleFormat = "cron"
+	ovenScheduleEvery = 15 * time.Minute
+	ovenScheduleExecutable = executablePath
+	t.Cleanup(func() {
+		ovenJSON = oldJSON
+		ovenScheduleFormat = oldFormat
+		ovenScheduleEvery = oldEvery
+		ovenScheduleExecutable = oldExecutable
+	})
+
+	if err := runOvenScheduleExample(command, []string{recipePath}); err != nil {
+		t.Fatal(err)
+	}
+	var output ovenScheduleExampleOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatal(err)
+	}
+	expectedRecipe, err := canonicalSchedulePath(recipePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedExecutable, err := canonicalSchedulePath(executablePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output.Format != "cron" || output.Every != "15m0s" || output.Recipe != expectedRecipe || output.Executable != expectedExecutable {
+		t.Fatalf("schedule output = %+v", output)
+	}
+	if !strings.Contains(output.Example, "*/15 * * * *") {
+		t.Fatalf("schedule example = %q", output.Example)
+	}
+}
+
+func TestOvenScheduleExampleIsOfflineAndRequiresInterval(t *testing.T) {
+	if ovenScheduleExampleCmd.Annotations[offlineCommandAnnotation] != "true" {
+		t.Fatal("schedule-example must not run the update checker")
+	}
+	flag := ovenScheduleExampleCmd.Flags().Lookup("every")
+	if flag == nil || flag.Annotations[cobra.BashCompOneRequiredFlag] == nil {
+		t.Fatal("--every is not required")
+	}
+}
+
+func TestDefaultOvenScheduleFormat(t *testing.T) {
+	format := defaultOvenScheduleFormat()
+	if runtime.GOOS == "darwin" && format != "launchd" {
+		t.Fatalf("macOS default = %q", format)
+	}
+	if runtime.GOOS == "linux" && format != "systemd" {
+		t.Fatalf("Linux default = %q", format)
+	}
+}

--- a/docs/local-oven.md
+++ b/docs/local-oven.md
@@ -12,6 +12,8 @@ gw oven reconcile recipe.yaml
 gw oven status
 gw oven status --json
 gw oven clean [recipe.yaml]
+gw oven schedule-example recipe.yaml --every 30m
+gw oven schedule-example recipe.yaml --every 30m --format launchd|cron|systemd
 
 gw create cake --branch feat/cake --recipe recipe.yaml --oven
 ```
@@ -23,6 +25,68 @@ gw create cake --branch feat/cake --recipe recipe.yaml --oven
 - `create --oven` claims the newest ready generation known locally. A clean miss reports `Oven miss` and runs normal cold Recipe creation.
 
 Schedule `gw oven reconcile recipe.yaml` with cron, `launchd`, systemd, or another external scheduler. Grove does not install or run a daemon.
+
+## External scheduling
+
+Generate a scheduler example without installing anything:
+
+```bash
+# Defaults to launchd on macOS and systemd on Linux
+gw oven schedule-example /absolute/path/recipe.yaml --every 30m
+
+# Request another supported format
+gw oven schedule-example /absolute/path/recipe.yaml --every 30m --format cron
+gw oven schedule-example /absolute/path/recipe.yaml --every 30m --format systemd
+```
+
+The generated example contains canonical absolute paths for both the active `gw` executable and the Recipe, plus a stable Recipe-specific identifier in launchd/systemd names so multiple Recipes do not collide. Review the output before installing it. If you later switch between a Homebrew and source-built `gw`, regenerate the example so the scheduler invokes the intended binary.
+
+### macOS launchd
+
+```bash
+gw oven schedule-example recipe.yaml --every 30m --format launchd \
+  > ~/Library/LaunchAgents/com.grove.oven.<recipe-id>.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.grove.oven.<recipe-id>.plist
+```
+
+Unload it with:
+
+```bash
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.grove.oven.<recipe-id>.plist
+```
+
+`launchd` is preferred to cron on laptops because its interval jobs resume after sleep. The example also runs once when loaded.
+
+### cron
+
+```bash
+gw oven schedule-example recipe.yaml --every 30m --format cron
+crontab -e
+```
+
+Copy the generated entry into the crontab. Cron examples support intervals that evenly divide an hour or day.
+
+### Linux systemd user timer
+
+```bash
+gw oven schedule-example recipe.yaml --every 30m --format systemd
+```
+
+Split the generated service and timer sections into:
+
+```text
+~/.config/systemd/user/grove-oven.service
+~/.config/systemd/user/grove-oven.timer
+```
+
+Then enable the timer:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now grove-oven.timer
+```
+
+Grove only prints examples. It does not write scheduler files, call `launchctl`, edit crontabs, enable systemd units, store scheduling state, or run a background process.
 
 ## Freshness and generations
 


### PR DESCRIPTION
## Summary

- add `just gw-use-source`, `just gw-use-brew`, and `just gw-active`
- add `gw oven schedule-example RECIPE --every DURATION`
- generate launchd by default on macOS and systemd on Linux
- support explicit launchd, cron, and systemd formats
- use canonical absolute paths and Recipe-specific scheduler IDs
- escape scheduler syntax and reject unsafe control characters
- remain offline and install/store/manage nothing
- document launchd, cron, and systemd setup and removal

## Verification

- `PATH="$(go env GOPATH)/bin:$PATH" just check`
- `PATH="$(go env GOPATH)/bin:$PATH" staticcheck ./...`
- focused scheduler rendering and adversarial escaping tests
- macOS `plutil -lint` on generated launchd plist
- manually toggled Homebrew → source → source → Homebrew
- independent correctness and security reviews; blockers addressed