### PR TITLE
fix: install public plugins without GitHub API

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -13,6 +13,8 @@ gw plugin install github.com/user/gw-something
 
 This downloads the latest release binary for your OS/architecture from the repo's GitHub Releases. The naming convention follows [goreleaser](https://goreleaser.com/) defaults: `gw-dash_0.1.0_darwin_arm64.tar.gz`.
 
+Public releases require no token: Grove uses GitHub's public `releases/latest` redirect and downloads conventionally named assets directly without consuming the REST API quota.
+
 ### Manual
 
 Drop any executable named `gw-<name>` into `~/.grove/plugins/`:

--- a/internal/plugin/install.go
+++ b/internal/plugin/install.go
@@ -163,36 +163,119 @@ func parseRepo(repo string) (owner, name string, err error) {
 	return parts[0], parts[1], nil
 }
 
-func fetchRelease(owner, repo string) (*ghRelease, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo)
+const (
+	githubWebBaseURL = "https://github.com"
+	githubAPIBaseURL = "https://api.github.com"
+)
 
-	client := &http.Client{Timeout: 15 * time.Second}
-	req, err := http.NewRequest("GET", url, nil)
+type releaseFetcher struct {
+	client     *http.Client
+	webBaseURL string
+	apiBaseURL string
+}
+
+func fetchRelease(owner, repo string) (*ghRelease, error) {
+	fetcher := releaseFetcher{
+		client:     &http.Client{Timeout: 15 * time.Second},
+		webBaseURL: githubWebBaseURL,
+		apiBaseURL: githubAPIBaseURL,
+	}
+	return fetcher.fetch(owner, repo)
+}
+
+func (f releaseFetcher) fetch(owner, repo string) (*ghRelease, error) {
+	release, publicErr := f.fetchPublicGoReleaserRelease(owner, repo)
+	if publicErr == nil {
+		return release, nil
+	}
+
+	release, apiErr := f.fetchFromAPI(owner, repo)
+	if apiErr != nil {
+		return nil, fmt.Errorf("public release discovery failed: %v; GitHub API fallback failed: %w", publicErr, apiErr)
+	}
+	return release, nil
+}
+
+func (f releaseFetcher) fetchPublicGoReleaserRelease(owner, repo string) (*ghRelease, error) {
+	latestURL := fmt.Sprintf("%s/%s/%s/releases/latest", strings.TrimRight(f.webBaseURL, "/"), owner, repo)
+	req, err := http.NewRequest(http.MethodHead, latestURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("User-Agent", "grove-plugin-installer")
 
-	// Use GITHUB_TOKEN if available for higher rate limits
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("latest release page returned HTTP %d", resp.StatusCode)
+	}
+
+	tagPrefix := fmt.Sprintf("/%s/%s/releases/tag/", owner, repo)
+	if !strings.HasPrefix(resp.Request.URL.Path, tagPrefix) {
+		return nil, fmt.Errorf("latest release did not redirect to a release tag")
+	}
+	tag := strings.TrimPrefix(resp.Request.URL.Path, tagPrefix)
+	version := strings.TrimPrefix(tag, "v")
+	if tag == "" || version == "" {
+		return nil, fmt.Errorf("latest release has an empty tag")
+	}
+
+	assetName := fmt.Sprintf("%s_%s_%s_%s.tar.gz", repo, version, runtime.GOOS, runtime.GOARCH)
+	downloadBaseURL := fmt.Sprintf("%s/%s/%s/releases/download/%s", strings.TrimRight(f.webBaseURL, "/"), owner, repo, tag)
+	assetURL := downloadBaseURL + "/" + assetName
+
+	assetReq, err := http.NewRequest(http.MethodHead, assetURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	assetReq.Header.Set("User-Agent", "grove-plugin-installer")
+	assetResp, err := f.client.Do(assetReq)
+	if err != nil {
+		return nil, err
+	}
+	assetResp.Body.Close()
+	if assetResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("conventional release asset %s returned HTTP %d", assetName, assetResp.StatusCode)
+	}
+
+	return &ghRelease{
+		TagName: tag,
+		Assets: []ghAsset{
+			{Name: assetName, BrowserDownloadURL: assetURL},
+			{Name: "checksums.txt", BrowserDownloadURL: downloadBaseURL + "/checksums.txt"},
+		},
+	}, nil
+}
+
+func (f releaseFetcher) fetchFromAPI(owner, repo string) (*ghRelease, error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/releases/latest", strings.TrimRight(f.apiBaseURL, "/"), owner, repo)
+	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "grove-plugin-installer")
 	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
-	resp, err := client.Do(req)
+	resp, err := f.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 404 {
+	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("repository %s/%s not found or has no releases", owner, repo)
 	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
 	}
 
 	var release ghRelease
-	// Limit response body to 1 MiB to prevent memory exhaustion
+	// Limit response body to 1 MiB to prevent memory exhaustion.
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&release); err != nil {
 		return nil, fmt.Errorf("parsing release response: %w", err)
 	}

--- a/internal/plugin/install_test.go
+++ b/internal/plugin/install_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -60,6 +61,91 @@ func TestParseRepo(t *testing.T) {
 				t.Errorf("parseRepo(%q) name = %q, want %q", tt.input, name, tt.wantName)
 			}
 		})
+	}
+}
+
+func TestFetchReleaseWithoutTokenUsesPublicReleaseRoute(t *testing.T) {
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	assetName := fmt.Sprintf("gw-test_0.1.0_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	apiCalled := false
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/owner/gw-test/releases/latest":
+			http.Redirect(w, r, srv.URL+"/owner/gw-test/releases/tag/v0.1.0", http.StatusFound)
+		case "/owner/gw-test/releases/tag/v0.1.0":
+			w.WriteHeader(http.StatusOK)
+		case "/owner/gw-test/releases/download/v0.1.0/" + assetName:
+			w.WriteHeader(http.StatusOK)
+		case "/repos/owner/gw-test/releases/latest":
+			apiCalled = true
+			http.Error(w, "API should not be needed", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	release, err := (releaseFetcher{
+		client:     srv.Client(),
+		webBaseURL: srv.URL,
+		apiBaseURL: srv.URL,
+	}).fetch("owner", "gw-test")
+	if err != nil {
+		t.Fatalf("fetch() error = %v", err)
+	}
+	if apiCalled {
+		t.Fatal("GitHub API should not be called for a conventional public release")
+	}
+	if release.TagName != "v0.1.0" {
+		t.Fatalf("TagName = %q, want v0.1.0", release.TagName)
+	}
+	if len(release.Assets) != 2 || release.Assets[0].Name != assetName || release.Assets[1].Name != "checksums.txt" {
+		t.Fatalf("Assets = %#v, want archive and checksums", release.Assets)
+	}
+}
+
+func TestFetchReleaseFallsBackToAPIForNonstandardAssets(t *testing.T) {
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	assetName := fmt.Sprintf("gw-test-custom-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	apiCalled := false
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/owner/gw-test/releases/latest":
+			http.Redirect(w, r, srv.URL+"/owner/gw-test/releases/tag/v0.1.0", http.StatusFound)
+		case r.URL.Path == "/owner/gw-test/releases/tag/v0.1.0":
+			w.WriteHeader(http.StatusOK)
+		case strings.HasPrefix(r.URL.Path, "/owner/gw-test/releases/download/"):
+			http.NotFound(w, r)
+		case r.URL.Path == "/repos/owner/gw-test/releases/latest":
+			apiCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"tag_name":"v0.1.0","assets":[{"name":%q,"browser_download_url":%q}]}`,
+				assetName, srv.URL+"/assets/custom.tar.gz")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	release, err := (releaseFetcher{
+		client:     srv.Client(),
+		webBaseURL: srv.URL,
+		apiBaseURL: srv.URL,
+	}).fetch("owner", "gw-test")
+	if err != nil {
+		t.Fatalf("fetch() error = %v", err)
+	}
+	if !apiCalled {
+		t.Fatal("GitHub API fallback was not called")
+	}
+	if len(release.Assets) != 1 || release.Assets[0].Name != assetName {
+		t.Fatalf("Assets = %#v, want API assets", release.Assets)
 	}
 }
 


### PR DESCRIPTION
## Summary

- discover conventional public plugin releases through GitHub's public `releases/latest` redirect
- derive and probe the expected GoReleaser archive without consuming the REST API quota
- retain the existing releases API as a fallback for nonstandard and private releases
- document that public plugin installation requires no token

## Why

`gw plugin install` always called `api.github.com/repos/<owner>/<repo>/releases/latest`. Public installs therefore failed with HTTP 403 whenever the shared unauthenticated 60-request/hour IP quota was exhausted, even though the release page and assets remained publicly downloadable.

GitHub documents the stable `releases/latest` URL: https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases

## Verification

- `PATH="$(go env GOPATH)/bin:$PATH" just check`
- `just e2e` — 137 passed, 0 failed
- built `gw` and installed `nicksenap/gw-dispatch` into an isolated `HOME` with both `GH_TOKEN` and `GITHUB_TOKEN` unset while the REST quota was exhausted
- independent code review: approved with no critical or important findings
