### PR TITLE
chore: prepare v1.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v1.1.12
+
+### Features
+
+- Added strict, versioned YAML Recipes and `gw recipe validate <file> [--json]` for offline validation with path-aware diagnostics.
+- `gw create <name> --branch <branch> --recipe <file> [--json]` can now create multi-repository workspaces from a Recipe, pin repository refs to exact commits, and execute bounded `needs`-based setup jobs with timeouts and prefixed output. Recipes are trusted shell code, and failed preparation rolls back only resources created by the invocation.
+
+### Fixes
+
+- Public plugin installation no longer consumes GitHub's unauthenticated REST API quota. Grove discovers conventional GoReleaser assets through the public `releases/latest` redirect and retains the API fallback for private or nonstandard releases.
+- Workspace create, add, remove, and delete operations are now serialized and fail safely. Dirty or unexpected worktrees are rejected unless forced, failed operations preserve user-owned roots and branches, and rollback removes only resources created by the current operation.
+- Adding or removing repositories now reports progress while work is running and remains silent for no-op operations.
+
+### Maintenance
+
+- Clarified installation, shell integration, and upgrade documentation.
+- Updated `modernc.org/sqlite` from 1.54.0 to 1.56.0.
+
 ## v1.1.11
 
 ### Features


### PR DESCRIPTION
## Summary

Prepare the v1.1.12 changelog for everything currently on cleaned `master` since v1.1.11:

- strict Recipe validation and Recipe-based workspace creation
- safer serialized workspace mutations and rollback
- public plugin installation without GitHub REST API quota usage
- repository progress and setup documentation improvements
- dependency maintenance

The unfinished Oven implementation is not included; it was removed in #88 and remains on `feat/oven-machinery`.

## Verification

- `go test ./...`
- `just e2e` — 128 passed, 0 failed
- `bash scripts/release-notes.sh` extracts the intended v1.1.12 notes
- `git diff --check`