### PR TITLE
feat: add gw reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- `gw reset [NAME]` puts every worktree back on the branch Grove recorded for the workspace, then runs the same rebase as `gw sync`. Repos that wandered off and are dirty stay put. `--discard` throws away tracked local changes so those can switch too. `gw sync` still rebases whatever branch you are on.
+
 ## v1.1.13
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ gw create -b feat/login -r svc-a,svc-b    # …or an ad-hoc repo list
 gw go my-feature       # cd into the workspace
 gw status my-feature   # git status across every repo
 gw sync my-feature     # rebase all repos onto their base branch
+gw reset my-feature    # switch every repo back to the workspace branch, then sync
 gw run my-feature      # run dev processes (TUI)
 
 # Clean up when done (destructive; use a pre_delete hook to enforce policy)

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/nicksenap/grove/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+var resetDiscard bool
+
+var resetCmd = &cobra.Command{
+	Use:   "reset [NAME]",
+	Short: "Switch workspace repos back to their workspace branch, then sync",
+	Long:  "Auto-detects workspace from cwd if name omitted. Dirty repos on a different branch are skipped unless --discard is set.",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := ""
+		if len(args) > 0 {
+			name = args[0]
+		}
+
+		ws, err := workspace.ResolveWorkspace(name)
+		if err != nil {
+			exitError(err.Error())
+		}
+
+		if err := workspace.NewService().Reset(ws.Name, resetDiscard); err != nil {
+			exitError(err.Error())
+		}
+	},
+}
+
+func init() {
+	resetCmd.Flags().BoolVar(&resetDiscard, "discard", false, "Discard tracked local changes so a dirty repo can switch")
+	resetCmd.ValidArgsFunction = completeWorkspaceNames
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,6 +64,7 @@ func init() {
 		reposCmd,
 		renameCmd,
 		syncCmd,
+		resetCmd,
 		doctorCmd,
 		statsCmd,
 		shellInitCmd,

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -643,7 +643,7 @@ else
     fail "dirty wanderer should stay on feat/wander2, got: ${dirty_branch}"
 fi
 
-gw delete reset-ws --force 2>&1
+gw delete reset-ws 2>&1
 
 # ---------------------------------------------------------------------------
 # Test: doctor (healthy state)

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -608,6 +608,44 @@ fi
 gw delete sync-ws 2>&1
 
 # ---------------------------------------------------------------------------
+# Test: reset (switch back to workspace branch, then sync)
+# ---------------------------------------------------------------------------
+section "Reset"
+
+gw create reset-ws --branch feat/reset-test --repos grove 2>&1
+RESET_WS_DIR="${GROVE_HOME}/.grove/workspaces/reset-ws"
+pass "created reset workspace with Grove repo"
+
+(cd "${RESET_WS_DIR}/grove" && git switch -q -c feat/wander)
+wander=$(cd "${RESET_WS_DIR}/grove" && git branch --show-current)
+if [ "${wander}" = "feat/wander" ]; then
+    pass "worktree switched off workspace branch"
+else
+    fail "expected feat/wander, got: ${wander}"
+fi
+
+gw reset reset-ws 2>&1
+pass "reset command ran"
+
+home=$(cd "${RESET_WS_DIR}/grove" && git branch --show-current)
+if [ "${home}" = "feat/reset-test" ]; then
+    pass "worktree back on workspace branch"
+else
+    fail "expected feat/reset-test after reset, got: ${home}"
+fi
+
+(cd "${RESET_WS_DIR}/grove" && git switch -q -c feat/wander2 && echo dirt >> README.md)
+gw reset reset-ws 2>&1
+dirty_branch=$(cd "${RESET_WS_DIR}/grove" && git branch --show-current)
+if [ "${dirty_branch}" = "feat/wander2" ]; then
+    pass "reset skips dirty wanderer"
+else
+    fail "dirty wanderer should stay on feat/wander2, got: ${dirty_branch}"
+fi
+
+gw delete reset-ws --force 2>&1
+
+# ---------------------------------------------------------------------------
 # Test: doctor (healthy state)
 # ---------------------------------------------------------------------------
 section "Doctor"

--- a/internal/gitops/gitops.go
+++ b/internal/gitops/gitops.go
@@ -255,6 +255,18 @@ func CurrentBranch(path string) (string, error) {
 	return runGit(path, "branch", "--show-current")
 }
 
+// Switch checks out branch in the worktree at path.
+// discard maps to git switch --discard-changes (tracked files only).
+func Switch(path, branch string, discard bool) error {
+	args := []string{"switch", "-q"}
+	if discard {
+		args = append(args, "--discard-changes")
+	}
+	args = append(args, "--", branch)
+	_, err := runGit(path, args...)
+	return err
+}
+
 // RebaseOnto rebases the current branch onto the given base.
 func RebaseOnto(path, base string) error {
 	_, err := runGit(path, "rebase", base)

--- a/internal/gitops/gitops_test.go
+++ b/internal/gitops/gitops_test.go
@@ -308,6 +308,73 @@ func TestCurrentBranch(t *testing.T) {
 	}
 }
 
+func TestSwitch(t *testing.T) {
+	repo := initTestRepo(t)
+	home := currentBranch(t, repo)
+
+	if err := CreateBranch(repo, "feat/other", ""); err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	if err := Switch(repo, "feat/other", false); err != nil {
+		t.Fatalf("switch: %v", err)
+	}
+	got, err := CurrentBranch(repo)
+	if err != nil {
+		t.Fatalf("current branch: %v", err)
+	}
+	if got != "feat/other" {
+		t.Errorf("branch after switch: got %q, want feat/other", got)
+	}
+
+	if err := Switch(repo, home, false); err != nil {
+		t.Fatalf("switch back: %v", err)
+	}
+}
+
+func TestSwitchDiscard(t *testing.T) {
+	repo := initTestRepo(t)
+	home := currentBranch(t, repo)
+	original, err := os.ReadFile(filepath.Join(repo, "README.md"))
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+
+	if err := CreateBranch(repo, "feat/other", ""); err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	if err := Switch(repo, "feat/other", false); err != nil {
+		t.Fatalf("switch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("dirty"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := Switch(repo, home, true); err != nil {
+		t.Fatalf("switch --discard-changes: %v", err)
+	}
+	got, err := CurrentBranch(repo)
+	if err != nil {
+		t.Fatalf("current branch: %v", err)
+	}
+	if got != home {
+		t.Errorf("branch: got %q, want %q", got, home)
+	}
+	content, err := os.ReadFile(filepath.Join(repo, "README.md"))
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if string(content) != string(original) {
+		t.Errorf("README after discard: got %q, want %q", content, original)
+	}
+}
+
+func TestSwitchMissingBranch(t *testing.T) {
+	repo := initTestRepo(t)
+	if err := Switch(repo, "does-not-exist", false); err == nil {
+		t.Fatal("expected error switching to missing branch")
+	}
+}
+
 func TestFetch(t *testing.T) {
 	repo := initTestRepo(t)
 

--- a/internal/workspace/logging_test.go
+++ b/internal/workspace/logging_test.go
@@ -79,6 +79,27 @@ func TestLoggingSync(t *testing.T) {
 	}
 }
 
+func TestLoggingReset(t *testing.T) {
+	readLog := setupLogging(t)
+	env := setupTestEnv(t)
+	env.createRepoWithRemote("api")
+
+	err := env.createWorkspace("reset-log-ws", "feat/resetlog", []string{"api"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	err = env.svc.Reset("reset-log-ws", false)
+	if err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	log := readLog()
+	if !strings.Contains(log, `resetting workspace "reset-log-ws"`) {
+		t.Errorf("log should contain reset start, got:\n%s", log)
+	}
+}
+
 func TestLoggingAddAndRemoveRepos(t *testing.T) {
 	readLog := setupLogging(t)
 	env := setupTestEnv(t)

--- a/internal/workspace/reset.go
+++ b/internal/workspace/reset.go
@@ -1,0 +1,74 @@
+package workspace
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/nicksenap/grove/internal/console"
+	"github.com/nicksenap/grove/internal/gitops"
+	"github.com/nicksenap/grove/internal/logging"
+	"github.com/nicksenap/grove/internal/models"
+)
+
+// Reset switches each worktree back to its recorded branch, then syncs.
+// Dirty repos that are not on the recorded branch are skipped unless discard
+// is set. Sync itself is unchanged: it still rebases whatever HEAD it is given.
+func (s *Service) Reset(wsName string, discard bool) error {
+	ws, err := s.State.GetWorkspace(wsName)
+	if err != nil {
+		return err
+	}
+	if ws == nil {
+		return fmt.Errorf("workspace %s not found", wsName)
+	}
+
+	logging.Info("resetting workspace %q", wsName)
+
+	var wg sync.WaitGroup
+	for _, r := range ws.Repos {
+		wg.Add(1)
+		go func(repo models.RepoWorktree) {
+			defer wg.Done()
+			s.resetOneRepo(repo, discard)
+		}(r)
+	}
+	wg.Wait()
+
+	return nil
+}
+
+func (s *Service) resetOneRepo(r models.RepoWorktree, discard bool) {
+	live, err := gitops.CurrentBranch(r.WorktreePath)
+	if err != nil {
+		console.Warningf("%s: cannot determine current branch: %s", r.RepoName, err)
+		return
+	}
+	if live == r.Branch {
+		s.syncOneRepo(r)
+		return
+	}
+
+	liveLabel := live
+	if liveLabel == "" {
+		liveLabel = "detached HEAD"
+	}
+
+	if !discard {
+		status, err := gitops.RepoStatus(r.WorktreePath)
+		if err != nil {
+			console.Warningf("%s: status check failed: %s", r.RepoName, err)
+			return
+		}
+		if status != "" {
+			console.Warningf("%s: skipping (dirty working tree, on %s)", r.RepoName, liveLabel)
+			return
+		}
+	}
+
+	if err := gitops.Switch(r.WorktreePath, r.Branch, discard); err != nil {
+		console.Warningf("%s: switch to %s failed: %s", r.RepoName, r.Branch, err)
+		return
+	}
+	console.Infof("%s: switched %s → %s", r.RepoName, liveLabel, r.Branch)
+	s.syncOneRepo(r)
+}

--- a/internal/workspace/reset_test.go
+++ b/internal/workspace/reset_test.go
@@ -1,0 +1,163 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nicksenap/grove/internal/gitops"
+)
+
+func TestResetNotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	err := env.svc.Reset("nonexistent", false)
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestResetAlreadyOnBranch(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepoWithRemote("api")
+	env.createWorkspace("reset-home", "feat/reset-home", []string{"api"})
+
+	if err := env.svc.Reset("reset-home", false); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	wt := filepath.Join(env.wsDir, "reset-home", "api")
+	branch, err := gitops.CurrentBranch(wt)
+	if err != nil {
+		t.Fatalf("current branch: %v", err)
+	}
+	if branch != "feat/reset-home" {
+		t.Errorf("branch: got %q, want feat/reset-home", branch)
+	}
+}
+
+func TestResetSwitchesAndSyncs(t *testing.T) {
+	env := setupTestEnv(t)
+	repo := env.createRepoWithRemote("api")
+	env.createWorkspace("reset-ws", "feat/reset", []string{"api"})
+	wt := filepath.Join(env.wsDir, "reset-ws", "api")
+
+	env.run(wt, "git", "switch", "-q", "-c", "feat/wander")
+
+	os.WriteFile(filepath.Join(repo, "upstream.txt"), []byte("new"), 0o644)
+	env.run(repo, "git", "add", ".")
+	env.run(repo, "git", "commit", "-q", "-m", "upstream change")
+	env.run(repo, "git", "push", "-q", "origin", "HEAD")
+
+	if err := env.svc.Reset("reset-ws", false); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	branch, err := gitops.CurrentBranch(wt)
+	if err != nil {
+		t.Fatalf("current branch: %v", err)
+	}
+	if branch != "feat/reset" {
+		t.Errorf("branch: got %q, want feat/reset", branch)
+	}
+	if _, err := os.Stat(filepath.Join(wt, "upstream.txt")); os.IsNotExist(err) {
+		t.Error("upstream change should be rebased into worktree")
+	}
+}
+
+func TestResetSkipsDirtyWanderer(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepoWithRemote("api")
+	env.createWorkspace("reset-dirty", "feat/reset-dirty", []string{"api"})
+	wt := filepath.Join(env.wsDir, "reset-dirty", "api")
+
+	env.run(wt, "git", "switch", "-q", "-c", "feat/wander")
+	os.WriteFile(filepath.Join(wt, "dirt.txt"), []byte("uncommitted"), 0o644)
+
+	if err := env.svc.Reset("reset-dirty", false); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	branch, err := gitops.CurrentBranch(wt)
+	if err != nil {
+		t.Fatalf("current branch: %v", err)
+	}
+	if branch != "feat/wander" {
+		t.Errorf("branch: got %q, want feat/wander (dirty skip)", branch)
+	}
+}
+
+func TestResetDiscardSwitchesDirtyWanderer(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepoWithRemote("api")
+	env.createWorkspace("reset-discard", "feat/reset-discard", []string{"api"})
+	wt := filepath.Join(env.wsDir, "reset-discard", "api")
+
+	env.run(wt, "git", "switch", "-q", "-c", "feat/wander")
+	os.WriteFile(filepath.Join(wt, "README.md"), []byte("dirty"), 0o644)
+
+	if err := env.svc.Reset("reset-discard", true); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	branch, err := gitops.CurrentBranch(wt)
+	if err != nil {
+		t.Fatalf("current branch: %v", err)
+	}
+	if branch != "feat/reset-discard" {
+		t.Errorf("branch: got %q, want feat/reset-discard", branch)
+	}
+	data, err := os.ReadFile(filepath.Join(wt, "README.md"))
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if string(data) == "dirty" {
+		t.Error("tracked changes should be discarded")
+	}
+}
+
+func TestResetMixedRepos(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepoWithRemote("api")
+	env.createRepoWithRemote("web")
+	env.createWorkspace("reset-mixed", "feat/reset-mixed", []string{"api", "web"})
+
+	api := filepath.Join(env.wsDir, "reset-mixed", "api")
+	web := filepath.Join(env.wsDir, "reset-mixed", "web")
+	env.run(api, "git", "switch", "-q", "-c", "feat/wander")
+
+	if err := env.svc.Reset("reset-mixed", false); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	for _, wt := range []string{api, web} {
+		branch, err := gitops.CurrentBranch(wt)
+		if err != nil {
+			t.Fatalf("current branch %s: %v", wt, err)
+		}
+		if branch != "feat/reset-mixed" {
+			t.Errorf("%s branch: got %q, want feat/reset-mixed", wt, branch)
+		}
+	}
+}
+
+func TestResetDetachedHead(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepoWithRemote("api")
+	env.createWorkspace("reset-detach", "feat/reset-detach", []string{"api"})
+	wt := filepath.Join(env.wsDir, "reset-detach", "api")
+
+	env.run(wt, "git", "switch", "-q", "--detach")
+
+	if err := env.svc.Reset("reset-detach", false); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	branch, err := gitops.CurrentBranch(wt)
+	if err != nil {
+		t.Fatalf("current branch: %v", err)
+	}
+	if branch != "feat/reset-detach" {
+		t.Errorf("branch: got %q, want feat/reset-detach", branch)
+	}
+}

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -118,6 +118,7 @@ setup = ["npm install", "npm run build"]  # run after worktree creation
 | `gw go <name>` | Change directory into workspace |
 | `gw status <name>` | Git status across all repos |
 | `gw sync <name>` | Rebase all repos onto base branch |
+| `gw reset <name>` | Switch every repo back to the workspace branch, then sync |
 | `gw add-repo <name> -r <repo>` | Add a repo to existing workspace |
 | `gw remove-repo <name> -r <repo>` | Remove a repo from workspace |
 | `gw run <name>` | Run dev processes (interactive TUI) |


### PR DESCRIPTION
My workspaces live for weeks. `nats` is one of them. I branch off in a repo or two for a side thing, leave the rest on `nats`, then want everyone home before catching up to main.

```
~/.grove/workspaces/nats
❯ gw status
Workspace: nats  (~/.grove/workspaces/nats)

REPO              BRANCH                       ↑↓       STATUS
api               chore/client-golang-1.24.1   1↑ 13↓   clean
charts            nats                         0↑ 0↓    clean
cloud             nats                         0↑ 10↓   clean
control-plane     nats                         0↑ 4↓    clean
platform          feat/nats-wire               10↑ 7↓   clean
modules           nats                         0↑ 0↓    clean
ci-deployer       nats                         0↑ 2↓    clean
security-checks   nats                         0↑ 0↓    clean
outbox            nats                         0↑ 0↓    clean
```

Two repos wandered. The rest are already on `nats`, and several of those are behind `origin/main`. Today I walk the wanderers back by hand, then sync:

```
❯ cd api
❯ git switch nats
Switched to branch 'nats'
Your branch is behind 'origin/main' by 13 commits, and can be fast-forwarded.

❯ cd ../platform
❯ git switch nats
Switched to branch 'nats'
Your branch is behind 'origin/main' by 3 commits, and can be fast-forwarded.

❯ cd ..
❯ gw sync
ok: ci-deployer: rebased (2 commits)
ok: control-plane: rebased (4 commits)
outbox: ✓ up to date
charts: ✓ up to date
security-checks: ✓ up to date
modules: ✓ up to date
ok: api: rebased (13 commits)
ok: cloud: rebased (10 commits)
ok: platform: rebased (3 commits)
```

`gw reset` is that sequence. From the workspace root, or `gw reset nats` from anywhere, it switches every worktree back to the branch Grove recorded for it, then runs the same rebase as `gw sync`.

A dirty repo that is not on the workspace branch is skipped. Syncing it would rebase `chore/client-golang-1.24.1` onto main, which is the wrong branch. `--discard` throws away tracked local changes if I actually want that repo to move.

`gw sync` still rebases whatever HEAD you are on. That is on purpose. Reset is the "put me back on the workspace branch first" command.