### PR TITLE
docs: refresh OpenWiki for workspace reset

### DIFF
--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,7 +1,7 @@
 {
-  "updatedAt": "2026-07-31T16:30:06.977Z",
+  "updatedAt": "2026-08-25T19:30:51.776Z",
   "command": "update",
-  "gitHead": "bb672b4cf542679b1a2bed674f3b3460db9f404a",
+  "gitHead": "96f17d4da566b8c2683d10d137334a80ed39d324",
   "model": "gpt-5.6-luna",
   "status": "complete",
   "language": "en"

--- a/openwiki/architecture.md
+++ b/openwiki/architecture.md
@@ -46,6 +46,7 @@ Cobra command handlers that:
 - `cmd/delete.go` — Destroy workspace (clean up worktrees + branches)
 - `cmd/status.go` — Show git status across repos
 - `cmd/sync_cmd.go` — Rebase all repos
+- `cmd/reset.go` — Return repos to their recorded workspace branch, then sync
 - `cmd/add_repo.go`, `cmd/remove_repo.go` — Modify existing workspace
 - `cmd/run.go` — Launch interactive TUI for running per-repo processes
 - `cmd/preset.go` — Manage presets (named repo groups)
@@ -56,6 +57,7 @@ Cobra command handlers that:
 - `Delete()` — Clean up worktrees and branches
 - `Status()` — Query git status across repos (concurrent)
 - `Sync()` — Rebase all repos onto their base branches
+- `Reset()` — Switch repos to their recorded workspace branches, then sync
 - `AddRepo()`, `RemoveRepo()` — Modify existing workspace
 - `Run()` — Execute per-repo commands (from `.grove.toml` [run] sections)
 
@@ -133,6 +135,7 @@ Subprocess wrappers around git commands:
 - `Clone()` — Clone a remote repo
 - `CreateWorktree()` — Create a new worktree
 - `Checkout()` — Check out a branch
+- `Switch()` — Switch a worktree to a branch, optionally discarding tracked changes
 - `Fetch()` — Fetch latest refs
 - `Status()` — Get short git status
 - `IsGitURL()` — Validate git URL format
@@ -192,7 +195,7 @@ Structured debug logging:
    - Validates that `svc-a` and `svc-b` exist
    - Calls `workspace.Service.Create()`
 
-2. **internal/workspace/workspace.go**
+2. **internal/workspace/create.go** (through `workspace.Service`)
    - Checks if `my-feature` already exists (error if so)
    - For each repo (`svc-a`, `svc-b`):
      - Calls `gitops.CreateWorktree(sourceRepo, workspacePath, branchName)`
@@ -240,10 +243,14 @@ Hooks are not an afterthought; they're central to the design:
 - Support shell integration (terminal multiplexer panes)
 - Allow automation (CI/CD on workspace creation)
 
-### 6. **Plugin Extensibility**
+### 6. **Workspace Operations Are Split by Responsibility**
+
+The workspace service remains the orchestration boundary, but its operations are implemented in focused files such as `internal/workspace/create.go`, `status.go`, `sync.go`, `remove.go`, `rename.go`, and `reset.go`. This keeps command-specific lifecycle behavior close to its implementation while preserving one service API for the CLI. The reset path uses `internal/gitops.Switch()` to restore each recorded branch before reusing the existing sync operation.
+
+### 7. **Plugin Extensibility**
 Rather than embedding tool-specific logic for coding agents, terminal multiplexers, or dashboards, Grove exposes hooks and environment variables. Plugins decide what to do with workspace lifecycle events.
 
-### 7. **Per-Repo Configuration**
+### 8. **Per-Repo Configuration**
 Each repo can have its own `.grove.toml` to define:
 - Default base branch (override main/master)
 - Setup commands to run after worktree creation
@@ -276,7 +283,7 @@ No explicit queuing or scheduling — the OS scheduler handles fairness.
 ## Testing
 
 - **Unit tests**: `*_test.go` files throughout (`cmd/`, `internal/`), testing individual functions
-- **Integration tests**: `internal/workspace/workspace_test.go` tests the full workspace lifecycle
+- **Integration tests**: focused `internal/workspace/*_test.go` files test each workspace operation, including `reset_test.go` for branch restoration and discard behavior
 - **End-to-end tests**: `/e2e/run.sh` spins up a temporary repo directory and exercises real `gw` commands
 - **Run tests**: `just check` (tests + vet), `just e2e` (end-to-end)
 
@@ -292,9 +299,11 @@ Test fixtures often create temporary directories with real git repos, allowing t
 | `cmd/delete.go` | Cleanup | Removes worktrees and branches |
 | `cmd/status.go` | Status query | Calls `workspace.Status()` |
 | `cmd/sync_cmd.go` | Rebase | Calls `workspace.Sync()` |
+| `cmd/reset.go` | Workspace recovery | Calls `workspace.Service.Reset()`; supports `--discard` |
 | `cmd/preset.go` | Preset management | CRUD for presets |
-| `internal/workspace/workspace.go` | Core orchestration | 27K — main business logic |
-| `internal/workspace/workspace_test.go` | Workspace tests | 51K — comprehensive test suite |
+| `internal/workspace/service.go` | Core service boundary | Coordinates focused workspace operations |
+| `internal/workspace/reset.go` | Workspace recovery | Restores recorded branches, skips dirty wanderers, then syncs |
+| `internal/workspace/*_test.go` | Workspace tests | Focused tests by operation, including `reset_test.go` |
 | `internal/state/state.go` | State persistence | ~200 lines, atomic writes |
 | `internal/models/models.go` | Data structures | ~300 lines, JSON serialization |
 | `internal/config/config.go` | Config loading | TOML parsing, legacy migration |

--- a/openwiki/index.md
+++ b/openwiki/index.md
@@ -5,7 +5,7 @@ okf_version: "0.1"
 # Files
 
 - [Architecture](architecture.md) - Architecture of Grove's CLI, workspace orchestration, Git operation wrappers, persisted state, repository discovery, lifecycle hooks, and plugins.
-- [Integrations](integrations.md) - Grove integration points, including external plugins, lifecycle hooks, coding-agent support, and Zellij workflows.
+- [Integrations](integrations.md) - Vendor-neutral Grove integration points, including external plugins, lifecycle hooks, coding agents, and editors.
 - [Operations](operations.md) - Operational guidance for installing, configuring, maintaining, troubleshooting, and validating Grove workspaces and its local runtime state.
 - [Grove Documentation](quickstart.md) - Entry point for Grove, a CLI that creates and manages multi-repository Git worktree workspaces, with setup commands, configuration, architecture pointers, workflows, operations, integrations, and testing guidance.
 - [Workflows](workflows.md) - Main Grove user workflows, from repository discovery and workspace creation through navigation, synchronization, execution, cleanup, and recovery.

--- a/openwiki/operations.md
+++ b/openwiki/operations.md
@@ -479,10 +479,12 @@ just check
 # or: go test ./...
 ```
 
-Test a single package:
+Test the workspace package:
 ```bash
 go test ./internal/workspace -v
 ```
+
+The workspace tests are split by responsibility (`create_test.go`, `doctor_test.go`, `remove_test.go`, `rename_test.go`, `repos_test.go`, `status_test.go`, `sync_test.go`, and `reset_test.go`), so run the focused file's package tests when changing one operation. `reset_test.go` covers branch restoration and the `--discard` safety path.
 
 Test a single test function:
 ```bash

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -158,7 +158,8 @@ All repos are discovered once at command start via `internal/discover/`, then ma
 - `cmd/root.go` — Cobra setup and command registration
 - `cmd/create.go` — Workspace creation
 - `cmd/delete.go` — Cleanup
-- `internal/workspace/workspace.go` — Core orchestration logic
+- `internal/workspace/service.go` — Core service boundary
+- `internal/workspace/create.go`, `sync.go`, `reset.go` — Focused workspace operations
 - `internal/state/state.go` — State persistence
 - `internal/models/models.go` — Data structures (Workspace, Preset, Hook, Config)
 - `internal/config/config.go` — Config file loading

--- a/openwiki/workflows.md
+++ b/openwiki/workflows.md
@@ -98,7 +98,7 @@ The `create` command also supports:
    - Validates selections and branch name
    - Calls `workspace.Service.Create()` or `workspace.Service.CreateWithOpts()`
 
-2. **`internal/workspace/workspace.go`** — Core creation logic
+2. **`internal/workspace/create.go`** (through `workspace.Service`) — Core creation logic
    - **`CreateWithOpts()`** — Main orchestrator
      - Checks for duplicate workspace (error if exists)
      - Resolves branch name (default: workspace name with `/` → `-`)
@@ -159,6 +159,28 @@ gw sync feat-login
 - For each repo: runs `git rebase origin/<base-branch>`
 - Useful after new commits are pushed to main/master
 
+### Return Repositories to the Workspace Branch
+
+```bash
+# Detect the workspace from the current directory
+gw reset
+
+# Or name it explicitly
+gw reset feat-login
+
+# Allow switching away from a different branch with tracked local changes
+gw reset feat-login --discard
+```
+
+`reset` first resolves the workspace, then processes its repositories concurrently. A repository already on its recorded workspace branch goes directly through the normal sync path. A repository on another branch is switched back only when its working tree is clean; dirty repositories are skipped unless `--discard` is supplied. Detached `HEAD` is treated as a branch different from the recorded branch. After a successful switch, reset runs the same fetch/status/base-branch/rebase behavior as `gw sync`, including per-repository `pre_sync` and `post_sync` commands. Failures are reported per repository while the other repositories continue.
+
+**Code flow**:
+
+- **`cmd/reset.go`** — Resolves an explicit name or auto-detects from the current directory and passes the `--discard` flag to the service.
+- **`internal/workspace/reset.go`** — Compares the live branch with the recorded branch, protects dirty worktrees, switches with `gitops.Switch`, and calls `syncOneRepo`.
+- **`internal/workspace/sync.go`** — Shared sync implementation: fetches, skips dirty trees, determines the base branch, and rebases when behind.
+- **`internal/gitops/gitops.go`** — Provides the branch/status/switch subprocess wrappers used by reset.
+
 ### Add a Repo to Existing Workspace
 
 ```bash
@@ -183,12 +205,13 @@ gw remove-repo feat-login -r svc-a
 
 - **`cmd/status.go`** — Calls `workspace.Service.Status()` and displays results
 - **`cmd/sync_cmd.go`** — Calls `workspace.Service.Sync()` for rebase
+- **`cmd/reset.go`** — Resolves the workspace and calls `workspace.Service.Reset()`; `--discard` controls switching dirty repos
 - **`cmd/addrepo.go`** / **`cmd/removerepo.go`** — Add/remove logic
-- **`internal/workspace/workspace.go`**
-  - `Status()` — Spawns goroutines for concurrent `git status` calls
-  - `Sync()` — Spawns goroutines for concurrent `git rebase` calls
-  - `AddRepo()` — Calls `CreateWorktree()` and persists updated workspace
-  - `RemoveRepo()` — Calls `gitops.DeleteWorktree()` and persists update
+- **`internal/workspace/status.go`** — Spawns goroutines for concurrent `git status` calls
+- **`internal/workspace/sync.go`** — Spawns goroutines for concurrent `git rebase` calls
+- **`internal/workspace/reset.go`** — Compares each live branch with the recorded branch, skips dirty wanderers unless requested, switches clean repos, and invokes sync
+- **`internal/workspace/repos.go`** — Add/remove workspace repositories
+- **`internal/gitops/gitops.go`** — Provides the Git subprocess wrappers, including `Switch()`
 
 ### Key Decisions When Modifying
 
@@ -253,7 +276,7 @@ gw delete feat-login
 
 1. **`cmd/delete.go`** — Runs `pre_delete` and orchestrates destructive deletion
 2. **`internal/lifecycle/lifecycle.go`** — Fires `pre_delete` hook with `{path}` placeholder
-3. **`internal/workspace/workspace.go`** — `Delete()` method
+3. **`internal/workspace/remove.go`** — `Delete()` method
    - Calls `gitops.DeleteWorktree()` for each repo
    - Calls `state.DeleteWorkspace()` to remove from state
 4. **`internal/operations/service.go`** — Applies the required `on_close` policy, then delegates hook execution to `internal/lifecycle/lifecycle.go`
@@ -318,7 +341,7 @@ gw rename feat-login --to login-v2
 ### Code Flow
 
 - **`cmd/rename.go`** — Parses the new name and calls `workspace.Service.Rename()`
-- **`internal/workspace/workspace.go`** — `Rename()` method
+- **`internal/workspace/rename.go`** — `Rename()` method
   - Renames the workspace directory on disk
   - Updates the `Workspace.Name` and all `RepoWorktree.WorktreePath` entries
   - Persists updated state


### PR DESCRIPTION
## Summary
- document the `gw reset` command and its `--discard` safety behavior
- update architecture and source maps for the split workspace package
- refresh OpenWiki metadata and testing guidance

## Validation
- `git diff --check -- openwiki`
- verified referenced source files exist

Docs-only change; code tests were not run.