### PR TITLE
fix: make add-repo and remove-repo inverse workspace operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- `gw add-repo` and `gw remove-repo` now share workspace resolution: omitted NAME uses the workspace containing cwd, and both fail with "not inside a workspace" otherwise. `--repos` completion is inverse: add lists discovered repos not already in the workspace; remove lists only repos already in it. Both return no candidates outside a workspace.
+
 ## v1.1.14
 
 ### Features

--- a/cmd/addrepo.go
+++ b/cmd/addrepo.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os"
 	"strings"
 
 	"github.com/nicksenap/grove/internal/config"
@@ -9,7 +8,6 @@ import (
 	"github.com/nicksenap/grove/internal/discover"
 	"github.com/nicksenap/grove/internal/gitops"
 	"github.com/nicksenap/grove/internal/picker"
-	"github.com/nicksenap/grove/internal/state"
 	"github.com/nicksenap/grove/internal/workspace"
 	"github.com/spf13/cobra"
 )
@@ -19,38 +17,16 @@ var addRepoRepos string
 var addRepoCmd = &cobra.Command{
 	Use:   "add-repo [NAME]",
 	Short: "Add repos to an existing workspace",
+	Long:  "Auto-detects workspace from cwd if name omitted.",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		var wsName string
+		name := ""
 		if len(args) > 0 {
-			wsName = args[0]
-		} else {
-			// Auto-detect workspace from cwd and use it as default.
-			if cwd, err := os.Getwd(); err == nil {
-				if currentWs, _ := state.FindWorkspaceByPath(cwd); currentWs != nil {
-					wsName = currentWs.Name
-					console.Infof("Using current workspace: %s", wsName)
-				}
-			}
-
-			if wsName == "" {
-				workspaces, err := state.Load()
-				if err != nil {
-					exitError(err.Error())
-				}
-				if len(workspaces) == 0 {
-					exitError("No workspaces")
-				}
-				choices := make([]string, len(workspaces))
-				for i, ws := range workspaces {
-					choices[i] = ws.Name
-				}
-				selected, err := picker.PickOne("Select workspace:", choices)
-				if err != nil {
-					exitOnPickerErr(err)
-				}
-				wsName = selected
-			}
+			name = args[0]
+		}
+		ws, err := workspace.ResolveWorkspace(name)
+		if err != nil {
+			exitError(err.Error())
 		}
 
 		cfg := config.RequireConfig()
@@ -59,38 +35,27 @@ var addRepoCmd = &cobra.Command{
 
 		var repoNames []string
 		if addRepoRepos != "" {
-			repoNames = strings.Split(addRepoRepos, ",")
-			for i := range repoNames {
-				repoNames[i] = strings.TrimSpace(repoNames[i])
-			}
+			repoNames = parseRepoFlag(addRepoRepos)
 			// Clone any remote URLs into the first repo_dir
-			for i, name := range repoNames {
-				if gitops.IsGitURL(name) {
+			for i, repoName := range repoNames {
+				if gitops.IsGitURL(repoName) {
 					if len(cfg.RepoDirs) == 0 {
 						exitError("No repo_dirs configured — cannot clone remote repo")
 					}
-					console.Infof("Cloning %s ...", name)
-					clonedPath, repoName, err := gitops.Clone(name, cfg.RepoDirs[0])
+					console.Infof("Cloning %s ...", repoName)
+					clonedPath, clonedName, err := gitops.Clone(repoName, cfg.RepoDirs[0])
 					if err != nil {
 						exitError(err.Error())
 					}
-					if existing, ok := repoMap[repoName]; ok && existing != clonedPath {
-						exitError("repo name conflict: " + repoName + " already exists locally at " + existing)
+					if existing, ok := repoMap[clonedName]; ok && existing != clonedPath {
+						exitError("repo name conflict: " + clonedName + " already exists locally at " + existing)
 					}
-					repoMap[repoName] = clonedPath
-					repoNames[i] = repoName
-					console.Successf("Cloned %s into %s", repoName, clonedPath)
+					repoMap[clonedName] = clonedPath
+					repoNames[i] = clonedName
+					console.Successf("Cloned %s into %s", clonedName, clonedPath)
 				}
 			}
 		} else {
-			// Interactive: show repos not already in workspace
-			ws, err := state.GetWorkspace(wsName)
-			if err != nil {
-				exitError(err.Error())
-			}
-			if ws == nil {
-				exitError("Workspace not found: " + wsName)
-			}
 			existing := make(map[string]bool)
 			for _, r := range ws.Repos {
 				existing[r.RepoName] = true
@@ -111,7 +76,7 @@ var addRepoCmd = &cobra.Command{
 			repoNames = selected
 		}
 
-		if err := workspace.NewService().AddRepos(wsName, repoNames, repoMap); err != nil {
+		if err := workspace.NewService().AddRepos(ws.Name, repoNames, repoMap); err != nil {
 			exitError(err.Error())
 		}
 	},
@@ -119,6 +84,14 @@ var addRepoCmd = &cobra.Command{
 
 func init() {
 	addRepoCmd.Flags().StringVarP(&addRepoRepos, "repos", "r", "", "Comma-separated repo names or git URLs")
-	addRepoCmd.RegisterFlagCompletionFunc("repos", completeRepoNames)
+	addRepoCmd.RegisterFlagCompletionFunc("repos", completeAddRepoNames)
 	addRepoCmd.ValidArgsFunction = completeWorkspaceNames
+}
+
+func parseRepoFlag(value string) []string {
+	parts := strings.Split(value, ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
 }

--- a/cmd/completions.go
+++ b/cmd/completions.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"github.com/nicksenap/grove/internal/config"
 	"github.com/nicksenap/grove/internal/discover"
+	"github.com/nicksenap/grove/internal/models"
 	"github.com/nicksenap/grove/internal/state"
+	"github.com/nicksenap/grove/internal/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +22,54 @@ func completeRepoNames(cmd *cobra.Command, args []string, toComplete string) ([]
 		names[i] = r.Name
 	}
 	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeAddRepoNames completes discovered repos that are not already in the workspace.
+func completeAddRepoNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cfg, err := config.Load()
+	if err != nil || cfg == nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	ws := resolveWorkspaceForCompletion(args)
+	if ws == nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	existing := make(map[string]bool, len(ws.Repos))
+	for _, r := range ws.Repos {
+		existing[r.RepoName] = true
+	}
+
+	repos := discover.UniqueByName(discover.DiscoverReposWithCache(cfg.RepoDirs))
+	names := make([]string, 0, len(repos))
+	for _, r := range repos {
+		if existing[r.Name] {
+			continue
+		}
+		names = append(names, r.Name)
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeRemoveRepoNames completes repos currently in the target workspace.
+func completeRemoveRepoNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	ws := resolveWorkspaceForCompletion(args)
+	if ws == nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return ws.RepoNames(), cobra.ShellCompDirectiveNoFileComp
+}
+
+func resolveWorkspaceForCompletion(args []string) *models.Workspace {
+	name := ""
+	if len(args) > 0 {
+		name = args[0]
+	}
+	ws, err := workspace.ResolveWorkspace(name)
+	if err != nil {
+		return nil
+	}
+	return ws
 }
 
 // completePresetNames provides shell completion for --preset flag.

--- a/cmd/removerepo.go
+++ b/cmd/removerepo.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/nicksenap/grove/internal/console"
 	"github.com/nicksenap/grove/internal/picker"
-	"github.com/nicksenap/grove/internal/state"
 	"github.com/nicksenap/grove/internal/workspace"
 	"github.com/spf13/cobra"
 )
@@ -19,50 +18,26 @@ var (
 var removeRepoCmd = &cobra.Command{
 	Use:   "remove-repo [NAME]",
 	Short: "Remove repos from a workspace",
+	Long:  "Auto-detects workspace from cwd if name omitted.",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		var wsName string
+		name := ""
 		if len(args) > 0 {
-			wsName = args[0]
-		} else {
-			workspaces, err := state.Load()
-			if err != nil {
-				exitError(err.Error())
-			}
-			if len(workspaces) == 0 {
-				exitError("No workspaces")
-			}
-			choices := make([]string, len(workspaces))
-			for i, ws := range workspaces {
-				choices[i] = ws.Name
-			}
-			selected, err := picker.PickOne("Select workspace:", choices)
-			if err != nil {
-				exitOnPickerErr(err)
-			}
-			wsName = selected
+			name = args[0]
+		}
+		ws, err := workspace.ResolveWorkspace(name)
+		if err != nil {
+			exitError(err.Error())
 		}
 
 		var repoNames []string
 		if removeRepoRepos != "" {
-			repoNames = strings.Split(removeRepoRepos, ",")
-			for i := range repoNames {
-				repoNames[i] = strings.TrimSpace(repoNames[i])
-			}
+			repoNames = parseRepoFlag(removeRepoRepos)
 		} else {
-			// Interactive: pick from repos in workspace
-			ws, err := state.GetWorkspace(wsName)
-			if err != nil {
-				exitError(err.Error())
-			}
-			if ws == nil {
-				exitError("Workspace not found: " + wsName)
-			}
 			if len(ws.Repos) == 0 {
 				exitError("No repos in workspace")
 			}
-			choices := ws.RepoNames()
-			selected, err := picker.PickMany("Select repos to remove:", choices)
+			selected, err := picker.PickMany("Select repos to remove:", ws.RepoNames())
 			if err != nil {
 				exitOnPickerErr(err)
 			}
@@ -70,12 +45,12 @@ var removeRepoCmd = &cobra.Command{
 		}
 
 		if !removeRepoForce {
-			if !console.Confirm(fmt.Sprintf("Remove %s from %s?", strings.Join(repoNames, ", "), wsName), false) {
+			if !console.Confirm(fmt.Sprintf("Remove %s from %s?", strings.Join(repoNames, ", "), ws.Name), false) {
 				return
 			}
 		}
 
-		if err := workspace.NewService().RemoveReposWithOptions(wsName, repoNames, workspace.RemoveOptions{Force: removeRepoForce}); err != nil {
+		if err := workspace.NewService().RemoveReposWithOptions(ws.Name, repoNames, workspace.RemoveOptions{Force: removeRepoForce}); err != nil {
 			exitError(err.Error())
 		}
 	},
@@ -84,6 +59,6 @@ var removeRepoCmd = &cobra.Command{
 func init() {
 	removeRepoCmd.Flags().StringVarP(&removeRepoRepos, "repos", "r", "", "Comma-separated repo names")
 	removeRepoCmd.Flags().BoolVarP(&removeRepoForce, "force", "f", false, "Skip worktree safety checks and confirmation")
-	removeRepoCmd.RegisterFlagCompletionFunc("repos", completeRepoNames)
+	removeRepoCmd.RegisterFlagCompletionFunc("repos", completeRemoveRepoNames)
 	removeRepoCmd.ValidArgsFunction = completeWorkspaceNames
 }

--- a/e2e/repositories_test.go
+++ b/e2e/repositories_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -170,6 +171,114 @@ func TestAddRepoCwdAutoDetect(t *testing.T) {
 	env.mustGWIn(env.worktree("test-ws", "svc-auth"), "add-repo", "--repos", "svc-gateway")
 	if got := len(env.showWorkspace("test-ws").Repos); got != 2 {
 		t.Fatalf("expected 2 repos from subdir detect, got %d", got)
+	}
+}
+
+func TestRemoveRepoCwdAutoDetect(t *testing.T) {
+	env := newEnv(t)
+	env.createRepo("svc-auth")
+	env.createRepo("svc-gateway")
+	env.createRepo("svc-api")
+	env.init()
+	env.mustGW("create", "test-ws", "--branch", "feat/e2e", "--repos", "svc-auth,svc-gateway")
+	// A second workspace keeps the picker from auto-selecting the only choice.
+	env.mustGW("create", "other-ws", "--branch", "feat/other", "--repos", "svc-api")
+
+	env.mustGWIn(env.workspacePath("test-ws"), "remove-repo", "--repos", "svc-gateway", "--force")
+	if got := len(env.showWorkspace("test-ws").Repos); got != 1 {
+		t.Fatalf("expected 1 repo after cwd-detected remove-repo, got %d", got)
+	}
+
+	env.mustGW("add-repo", "test-ws", "--repos", "svc-gateway")
+	env.mustGWIn(env.worktree("test-ws", "svc-auth"), "remove-repo", "--repos", "svc-gateway", "--force")
+	if got := len(env.showWorkspace("test-ws").Repos); got != 1 {
+		t.Fatalf("expected 1 repo from subdir detect, got %d", got)
+	}
+}
+
+func TestAddAndRemoveRepoRequireWorkspace(t *testing.T) {
+	env := newEnv(t)
+	env.createRepo("svc-auth")
+	env.createRepo("svc-gateway")
+	env.init()
+	env.mustGW("create", "test-ws", "--branch", "feat/e2e", "--repos", "svc-auth")
+	// A second workspace keeps the picker from auto-selecting the only choice.
+	env.mustGW("create", "other-ws", "--branch", "feat/other", "--repos", "svc-gateway")
+
+	add := env.gw("add-repo", "--repos", "svc-gateway")
+	add.mustFail(t)
+	env.requireContains(add.combined(), "not inside a workspace", "add-repo outside workspace")
+
+	remove := env.gw("remove-repo", "--repos", "svc-auth", "--force")
+	remove.mustFail(t)
+	env.requireContains(remove.combined(), "not inside a workspace", "remove-repo outside workspace")
+}
+
+func TestRemoveRepoCompletesWorkspaceReposOnly(t *testing.T) {
+	env := newEnv(t)
+	env.createRepo("svc-auth")
+	env.createRepo("svc-gateway")
+	env.init()
+	env.mustGW("create", "test-ws", "--branch", "feat/e2e", "--repos", "svc-auth")
+
+	res := env.mustGW("__complete", "remove-repo", "test-ws", "--repos", "")
+	out := res.combined()
+	env.requireContains(out, "svc-auth", "complete workspace repo")
+	if strings.Contains(out, "svc-gateway") {
+		t.Fatalf("remove-repo completion should not include repos outside the workspace:\n%s", out)
+	}
+}
+
+func TestAddRepoCompletesReposNotInWorkspace(t *testing.T) {
+	env := newEnv(t)
+	env.createRepo("svc-auth")
+	env.createRepo("svc-gateway")
+	env.init()
+	env.mustGW("create", "test-ws", "--branch", "feat/e2e", "--repos", "svc-auth")
+
+	res := env.mustGW("__complete", "add-repo", "test-ws", "--repos", "")
+	out := res.combined()
+	env.requireContains(out, "svc-gateway", "complete repo not in workspace")
+	if strings.Contains(out, "svc-auth") {
+		t.Fatalf("add-repo completion should not include repos already in the workspace:\n%s", out)
+	}
+}
+
+func TestAddAndRemoveRepoCompleteFromCwd(t *testing.T) {
+	env := newEnv(t)
+	env.createRepo("svc-auth")
+	env.createRepo("svc-gateway")
+	env.init()
+	env.mustGW("create", "test-ws", "--branch", "feat/e2e", "--repos", "svc-auth")
+
+	wsDir := env.workspacePath("test-ws")
+	add := env.mustGWIn(wsDir, "__complete", "add-repo", "--repos", "").combined()
+	env.requireContains(add, "svc-gateway", "cwd add-repo completion")
+	if strings.Contains(add, "svc-auth") {
+		t.Fatalf("cwd add-repo completion should not include repos already in the workspace:\n%s", add)
+	}
+
+	remove := env.mustGWIn(wsDir, "__complete", "remove-repo", "--repos", "").combined()
+	env.requireContains(remove, "svc-auth", "cwd remove-repo completion")
+	if strings.Contains(remove, "svc-gateway") {
+		t.Fatalf("cwd remove-repo completion should not include repos outside the workspace:\n%s", remove)
+	}
+}
+
+func TestAddAndRemoveRepoCompleteOutsideWorkspace(t *testing.T) {
+	env := newEnv(t)
+	env.createRepo("svc-auth")
+	env.createRepo("svc-gateway")
+	env.init()
+	env.mustGW("create", "test-ws", "--branch", "feat/e2e", "--repos", "svc-auth")
+
+	for _, name := range []string{"add-repo", "remove-repo"} {
+		out := env.mustGW("__complete", name, "--repos", "").combined()
+		for _, repo := range []string{"svc-auth", "svc-gateway"} {
+			if strings.Contains(out, repo) {
+				t.Fatalf("%s completion outside a workspace should not include %s:\n%s", name, repo, out)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- `gw add-repo` and `gw remove-repo` now share workspace resolution: omitted NAME uses the workspace containing cwd, and both fail with `not inside a workspace` otherwise.
- Interactive / `--repos` completion is inverse: add lists discovered repos not already in the workspace; remove lists only repos currently in it. Both return no candidates outside a workspace.
- URL cloning stays add-only; `--force` stays remove-only.

This replaces add-repo's workspace-picker fallback and remove-repo's "always pick a workspace" path, which made the pair feel unlike inverses and offered repos that were not in the current workspace.

## Testing

- [x] `just build`
- [x] `GW_BIN="$PWD/gw" go test ./e2e -count=1 -run 'TestAddRepoCwdAutoDetect|TestRemoveRepoCwdAutoDetect|TestAddAndRemoveRepoRequireWorkspace|TestRemoveRepoCompletesWorkspaceReposOnly|TestAddRepoCompletesReposNotInWorkspace|TestAddAndRemoveRepoCompleteFromCwd|TestAddAndRemoveRepoCompleteOutsideWorkspace'`
- [x] `go test ./cmd ./internal/workspace -count=1`
- [x] `go vet ./...`
- [x] `git diff --check`
