### PR TITLE
Quarantine workspace delete so large trees unlink in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `gw run` is no longer a builtin command. Install the first-party plugin with `gw plugin install nicksenap/gw-run`. Without it, `gw run` follows the normal unknown-command path. Core still parses `.grove.toml` `run` / `pre_run` / `post_run` keys (ownership decision tracked separately).
 
+### Improvements
+
+- Workspace deletion now quarantines the workspace with a same-filesystem rename, prunes Git worktree registrations, and unlinks the bytes in the background. `gw go -bd` and `gw delete` return as soon as the original path is free, so large `node_modules` trees no longer block navigation. Spawn failures fall back to a synchronous unlink; leftover trash is reported and removable with `gw doctor --fix`.
+
 ### Fixes
 
 - `gw add-repo` and `gw remove-repo` now share workspace resolution: omitted NAME uses the workspace containing cwd, and both fail with "not inside a workspace" otherwise. `--repos` completion is inverse: add lists discovered repos not already in the workspace; remove lists only repos already in it. Both return no candidates outside a workspace.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,7 @@ func init() {
 		removeDirCmd,
 		pluginCmd,
 		bugReportCmd,
+		unlinkTrashCmd,
 	)
 }
 

--- a/cmd/unlink_trash.go
+++ b/cmd/unlink_trash.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/nicksenap/grove/internal/logging"
+	"github.com/nicksenap/grove/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+var unlinkTrashCmd = &cobra.Command{
+	Use:    "unlink-trash PATH",
+	Short:  "Remove a quarantined workspace directory",
+	Hidden: true,
+	Args:   cobra.ExactArgs(1),
+	Annotations: map[string]string{
+		offlineCommandAnnotation: "true",
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		logging.Setup(false)
+		if err := workspace.UnlinkTrashPath(args[0]); err != nil {
+			logging.Warn("unlink-trash %s: %s", args[0], err)
+			exitError(err.Error())
+		}
+	},
+}

--- a/cmd/unlink_trash_test.go
+++ b/cmd/unlink_trash_test.go
@@ -1,0 +1,12 @@
+package cmd
+
+import "testing"
+
+func TestUnlinkTrashCommandIsHidden(t *testing.T) {
+	if !unlinkTrashCmd.Hidden {
+		t.Fatal("unlink-trash should be a hidden internal command")
+	}
+	if unlinkTrashCmd.Name() != "unlink-trash" {
+		t.Fatalf("command name = %q", unlinkTrashCmd.Name())
+	}
+}

--- a/internal/gitops/gitops.go
+++ b/internal/gitops/gitops.go
@@ -188,6 +188,12 @@ func WorktreeRemove(repo, path string, force bool) error {
 	return err
 }
 
+// WorktreePrune drops registrations for worktrees whose directories are gone.
+func WorktreePrune(repo string) error {
+	_, err := runGit(repo, "worktree", "prune", "--expire=now")
+	return err
+}
+
 // WorktreeRepair repairs worktree references.
 func WorktreeRepair(repo, path string) error {
 	_, err := runGit(repo, "worktree", "repair", path)

--- a/internal/gitops/gitops_test.go
+++ b/internal/gitops/gitops_test.go
@@ -157,6 +157,30 @@ func TestWorktreeAddAndRemove(t *testing.T) {
 	}
 }
 
+func TestWorktreePruneDropsMissingDirectory(t *testing.T) {
+	repo := initTestRepo(t)
+	CreateBranch(repo, "feat/prune-test", "")
+	wtPath := filepath.Join(t.TempDir(), "worktree")
+	if err := WorktreeAdd(repo, wtPath, "feat/prune-test"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := os.RemoveAll(wtPath); err != nil {
+		t.Fatalf("remove worktree dir: %v", err)
+	}
+	if err := WorktreePrune(repo); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	entries, err := WorktreeList(repo)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for _, e := range entries {
+		if e.Branch == "feat/prune-test" {
+			t.Fatal("pruned worktree should not remain registered")
+		}
+	}
+}
+
 func TestRemoteBranchExists(t *testing.T) {
 	repo := initTestRepo(t)
 

--- a/internal/workspace/doctor.go
+++ b/internal/workspace/doctor.go
@@ -139,6 +139,7 @@ func (s *Service) sweepLeftoverTrash(fix bool) ([]models.DoctorIssue, int) {
 	if err != nil {
 		workspaces = nil
 	}
+	ownedPrefixes := ownedTrashPrefixes(workspaces)
 	var issues []models.DoctorIssue
 	fixed := 0
 	for _, trashRoot := range leftoverTrashRoots(s, workspaces) {
@@ -148,6 +149,15 @@ func (s *Service) sweepLeftoverTrash(fix bool) ([]models.DoctorIssue, int) {
 		}
 		for _, entry := range entries {
 			item := filepath.Join(trashRoot, entry.Name())
+			if trashOwnedByWorkspace(entry.Name(), ownedPrefixes) {
+				issue := models.DoctorIssue{
+					Workspace:       entry.Name(),
+					Issue:           "leftover trash still belongs to a workspace",
+					SuggestedAction: "restore quarantined workspace or retry delete",
+				}
+				issues = append(issues, issue)
+				continue
+			}
 			issue := models.DoctorIssue{
 				Workspace:       entry.Name(),
 				Issue:           "leftover trash",
@@ -165,6 +175,23 @@ func (s *Service) sweepLeftoverTrash(fix bool) ([]models.DoctorIssue, int) {
 		}
 	}
 	return issues, fixed
+}
+
+func ownedTrashPrefixes(workspaces []models.Workspace) []string {
+	prefixes := make([]string, 0, len(workspaces))
+	for _, ws := range workspaces {
+		prefixes = append(prefixes, filepath.Base(ws.Path)+"-")
+	}
+	return prefixes
+}
+
+func trashOwnedByWorkspace(name string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func leftoverTrashRoots(s *Service, workspaces []models.Workspace) []string {
@@ -192,6 +219,15 @@ func (s *Service) checkWorkspaceExists(ws models.Workspace, fix bool) (int, []mo
 	if _, err := os.Stat(ws.Path); err == nil {
 		return 0, nil
 	}
+	if trashPath := matchingTrashItem(s, ws); trashPath != "" {
+		issue := models.DoctorIssue{
+			Workspace:       ws.Name,
+			Repo:            nil,
+			Issue:           "workspace directory missing; bytes remain in leftover trash",
+			SuggestedAction: "restore quarantined workspace or retry delete",
+		}
+		return 0, []models.DoctorIssue{issue}
+	}
 	issue := models.DoctorIssue{
 		Workspace:       ws.Name,
 		Repo:            nil,
@@ -203,6 +239,22 @@ func (s *Service) checkWorkspaceExists(ws models.Workspace, fix bool) (int, []mo
 		return 1, []models.DoctorIssue{issue}
 	}
 	return 0, []models.DoctorIssue{issue}
+}
+
+func matchingTrashItem(s *Service, ws models.Workspace) string {
+	prefix := filepath.Base(ws.Path) + "-"
+	for _, trashRoot := range leftoverTrashRoots(s, []models.Workspace{ws}) {
+		entries, err := os.ReadDir(trashRoot)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Name(), prefix) {
+				return filepath.Join(trashRoot, entry.Name())
+			}
+		}
+	}
+	return ""
 }
 
 func (s *Service) checkWorkspaceRepos(ws *models.Workspace, fix bool) (int, []models.DoctorIssue) {

--- a/internal/workspace/doctor.go
+++ b/internal/workspace/doctor.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -81,7 +82,12 @@ func (s *Service) AllWorkspacesSummary() ([]WorkspaceSummary, error) {
 // Doctor checks workspace health and returns issues.
 func (s *Service) Doctor(fix bool) ([]models.DoctorIssue, int, error) {
 	if !fix {
-		return s.doctor(false)
+		issues, _, err := s.doctor(false)
+		if err != nil {
+			return issues, 0, err
+		}
+		trashIssues, _ := s.sweepLeftoverTrash(false)
+		return append(issues, trashIssues...), 0, nil
 	}
 
 	var issues []models.DoctorIssue
@@ -91,7 +97,14 @@ func (s *Service) Doctor(fix bool) ([]models.DoctorIssue, int, error) {
 		issues, fixed, err = s.doctor(true)
 		return err
 	})
-	return issues, fixed, err
+	if err != nil {
+		return issues, fixed, err
+	}
+
+	// Unlink leftover trash outside the mutation lock so doctor --fix does not
+	// hold state.lock while walking large trees.
+	trashIssues, trashFixed := s.sweepLeftoverTrash(true)
+	return append(issues, trashIssues...), fixed + trashFixed, nil
 }
 
 func (s *Service) doctor(fix bool) ([]models.DoctorIssue, int, error) {
@@ -119,6 +132,60 @@ func (s *Service) doctor(fix bool) ([]models.DoctorIssue, int, error) {
 	}
 
 	return issues, fixed, nil
+}
+
+func (s *Service) sweepLeftoverTrash(fix bool) ([]models.DoctorIssue, int) {
+	workspaces, err := s.State.Load()
+	if err != nil {
+		workspaces = nil
+	}
+	var issues []models.DoctorIssue
+	fixed := 0
+	for _, trashRoot := range leftoverTrashRoots(s, workspaces) {
+		entries, err := os.ReadDir(trashRoot)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			item := filepath.Join(trashRoot, entry.Name())
+			issue := models.DoctorIssue{
+				Workspace:       entry.Name(),
+				Issue:           "leftover trash",
+				SuggestedAction: "remove quarantined workspace bytes",
+			}
+			if fix {
+				if err := UnlinkTrashPath(item); err != nil && !os.IsNotExist(err) {
+					issue.SuggestedAction = "remove quarantined workspace bytes (failed: " + err.Error() + ")"
+					issues = append(issues, issue)
+					continue
+				}
+				fixed++
+			}
+			issues = append(issues, issue)
+		}
+	}
+	return issues, fixed
+}
+
+func leftoverTrashRoots(s *Service, workspaces []models.Workspace) []string {
+	seen := map[string]struct{}{}
+	var roots []string
+	add := func(dir string) {
+		if dir == "" {
+			return
+		}
+		if _, ok := seen[dir]; ok {
+			return
+		}
+		seen[dir] = struct{}{}
+		roots = append(roots, filepath.Join(dir, trashDirName))
+	}
+	for _, ws := range workspaces {
+		add(filepath.Dir(ws.Path))
+	}
+	add(s.WorkspaceDir)
+	add(filepath.Join(filepath.Dir(s.State.Path), "workspaces"))
+	return roots
 }
 
 func (s *Service) checkWorkspaceExists(ws models.Workspace, fix bool) (int, []models.DoctorIssue) {

--- a/internal/workspace/doctor_test.go
+++ b/internal/workspace/doctor_test.go
@@ -86,6 +86,50 @@ func TestDoctorDetectsMissingWorkspaceDir(t *testing.T) {
 	}
 }
 
+func TestDoctorDetectsLeftoverTrash(t *testing.T) {
+	env := setupTestEnv(t)
+	item := filepath.Join(env.wsDir, ".trash", "old-ws-1")
+	if err := os.MkdirAll(item, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	issues, _, err := env.svc.Doctor(false)
+	if err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+	found := false
+	for _, issue := range issues {
+		if strings.Contains(issue.Issue, "leftover trash") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected leftover trash issue, got %+v", issues)
+	}
+	if _, err := os.Stat(item); err != nil {
+		t.Fatalf("doctor without --fix should leave trash: %v", err)
+	}
+}
+
+func TestDoctorFixRemovesLeftoverTrash(t *testing.T) {
+	env := setupTestEnv(t)
+	item := filepath.Join(env.wsDir, ".trash", "old-ws-1")
+	if err := os.MkdirAll(item, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, fixed, err := env.svc.Doctor(true)
+	if err != nil {
+		t.Fatalf("doctor fix: %v", err)
+	}
+	if fixed == 0 {
+		t.Fatal("expected leftover trash to be fixed")
+	}
+	if _, err := os.Stat(item); !os.IsNotExist(err) {
+		t.Fatalf("doctor --fix should remove leftover trash, got %v", err)
+	}
+}
+
 func TestAllWorkspacesSummaryEmpty(t *testing.T) {
 	env := setupTestEnv(t)
 	_ = env

--- a/internal/workspace/helpers_test.go
+++ b/internal/workspace/helpers_test.go
@@ -50,6 +50,7 @@ func setupTestEnv(t *testing.T) *testEnv {
 	svc := &Service{
 		State:        store,
 		Stats:        &stats.Tracker{StatsPath: filepath.Join(groveDir, "stats.json"), NowFn: time.Now},
+		WorkspaceDir: wsDir,
 		RunCmd:       prodRunCmd,
 		RunCmdSilent: prodRunCmdSilent,
 	}

--- a/internal/workspace/remove.go
+++ b/internal/workspace/remove.go
@@ -109,14 +109,14 @@ func (s *Service) deleteLocked(name string, opts RemoveOptions) (*models.Workspa
 		}
 	}
 	if len(pruneErrs) > 0 {
-		if restoreErr := restoreQuarantinedWorkspace(ws, trashPath); restoreErr != nil {
+		if restoreErr := s.restoreQuarantinedWorkspace(ws, trashPath); restoreErr != nil {
 			return nil, "", errors.Join(append(pruneErrs, restoreErr)...)
 		}
 		return nil, "", errors.Join(pruneErrs...)
 	}
 
 	if err := s.removeState(name); err != nil {
-		if restoreErr := restoreQuarantinedWorkspace(ws, trashPath); restoreErr != nil {
+		if restoreErr := s.restoreQuarantinedWorkspace(ws, trashPath); restoreErr != nil {
 			return nil, "", errors.Join(err, restoreErr)
 		}
 		return nil, "", err
@@ -128,14 +128,24 @@ func (s *Service) deleteLocked(name string, opts RemoveOptions) (*models.Workspa
 	return &original, trashPath, nil
 }
 
-func restoreQuarantinedWorkspace(ws *models.Workspace, trashPath string) error {
+func (s *Service) restoreQuarantinedWorkspace(ws *models.Workspace, trashPath string) error {
 	if renameErr := os.Rename(trashPath, ws.Path); renameErr != nil {
 		return fmt.Errorf("restoring workspace root %s: %w", ws.Path, renameErr)
 	}
+	var repairErrs []error
 	for _, repo := range ws.Repos {
-		_ = gitops.WorktreeRepair(repo.SourceRepo, repo.WorktreePath)
+		if err := s.repairWorktree(repo.SourceRepo, repo.WorktreePath); err != nil {
+			repairErrs = append(repairErrs, fmt.Errorf("%s: repairing worktree: %w", repo.RepoName, err))
+		}
 	}
-	return nil
+	return errors.Join(repairErrs...)
+}
+
+func (s *Service) repairWorktree(repo, path string) error {
+	if s.RepairWorktree != nil {
+		return s.RepairWorktree(repo, path)
+	}
+	return gitops.WorktreeRepair(repo, path)
 }
 
 func (s *Service) removeState(name string) error {

--- a/internal/workspace/remove.go
+++ b/internal/workspace/remove.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strconv"
+	"time"
 
 	"github.com/nicksenap/grove/internal/console"
 	"github.com/nicksenap/grove/internal/gitops"
@@ -45,12 +48,19 @@ func (s *Service) DeleteWithOptions(name string, opts RemoveOptions) error {
 	s.runTeardownHooks(ws.Repos)
 
 	var deleted *models.Workspace
+	var trashPath string
 	if err := s.State.WithLock(func() error {
 		var err error
-		deleted, err = s.deleteLocked(name, opts)
+		deleted, trashPath, err = s.deleteLocked(name, opts)
 		return err
 	}); err != nil {
 		return err
+	}
+
+	// Bytes in .trash are no longer on the workspace path. Unlink is best-effort
+	// and must not hold state.lock — leftover trash must not keep the workspace in state.
+	if trashPath != "" {
+		s.scheduleUnlink(trashPath)
 	}
 
 	s.Stats.RecordDeleted(*deleted)
@@ -69,58 +79,139 @@ func verifyExpectedWorkspace(ws *models.Workspace, opts RemoveOptions) error {
 	return nil
 }
 
-func (s *Service) deleteLocked(name string, opts RemoveOptions) (*models.Workspace, error) {
+func (s *Service) deleteLocked(name string, opts RemoveOptions) (*models.Workspace, string, error) {
 	ws, err := s.State.GetWorkspace(name)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if ws == nil {
-		return nil, fmt.Errorf("workspace %s not found", name)
+		return nil, "", fmt.Errorf("workspace %s not found", name)
 	}
 	if err := verifyExpectedWorkspace(ws, opts); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if err := preflightRemovals(ws.Repos, opts.Force); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	logging.Info("deleting workspace %q", name)
 	original := *ws
-	remaining := make([]models.RepoWorktree, 0, len(ws.Repos))
-	var cleanupErrs []error
 
+	trashPath, err := quarantineWorkspace(ws.Path)
+	if err != nil {
+		return nil, "", fmt.Errorf("quarantining workspace %s: %w", ws.Path, err)
+	}
+
+	var pruneErrs []error
 	for _, repo := range ws.Repos {
-		if err := s.removeWorktree(repo.SourceRepo, repo.WorktreePath, opts.Force); err != nil {
-			remaining = append(remaining, repo)
-			cleanupErrs = append(cleanupErrs, fmt.Errorf("%s: removing worktree: %w", repo.RepoName, err))
-			continue
+		if err := s.pruneWorktree(repo.SourceRepo); err != nil {
+			pruneErrs = append(pruneErrs, fmt.Errorf("%s: pruning worktree: %w", repo.RepoName, err))
 		}
+	}
+	if len(pruneErrs) > 0 {
+		if restoreErr := restoreQuarantinedWorkspace(ws, trashPath); restoreErr != nil {
+			return nil, "", errors.Join(append(pruneErrs, restoreErr)...)
+		}
+		return nil, "", errors.Join(pruneErrs...)
+	}
+
+	if err := s.removeState(name); err != nil {
+		if restoreErr := restoreQuarantinedWorkspace(ws, trashPath); restoreErr != nil {
+			return nil, "", errors.Join(err, restoreErr)
+		}
+		return nil, "", err
+	}
+
+	for _, repo := range original.Repos {
 		s.deleteBranch(repo, opts.Force)
 	}
+	return &original, trashPath, nil
+}
 
-	if len(remaining) > 0 {
-		ws.Repos = remaining
-		if err := s.State.UpdateWorkspace(*ws); err != nil {
-			cleanupErrs = append(cleanupErrs, fmt.Errorf("updating state: %w", err))
+func restoreQuarantinedWorkspace(ws *models.Workspace, trashPath string) error {
+	if renameErr := os.Rename(trashPath, ws.Path); renameErr != nil {
+		return fmt.Errorf("restoring workspace root %s: %w", ws.Path, renameErr)
+	}
+	for _, repo := range ws.Repos {
+		_ = gitops.WorktreeRepair(repo.SourceRepo, repo.WorktreePath)
+	}
+	return nil
+}
+
+func (s *Service) removeState(name string) error {
+	if s.RemoveState != nil {
+		return s.RemoveState(name)
+	}
+	return s.State.RemoveWorkspace(name)
+}
+
+const trashDirName = ".trash"
+
+// UnlinkTrashPath removes a quarantined workspace directory. Paths whose parent
+// is not .trash are rejected so a detached unlink process cannot delete arbitrary trees.
+func UnlinkTrashPath(path string) error {
+	cleaned := filepath.Clean(path)
+	if !isTrashItem(cleaned) {
+		return fmt.Errorf("refusing to unlink %s: not a grove trash item", path)
+	}
+	var err error
+	for i := 0; i < 10; i++ {
+		err = os.RemoveAll(cleaned)
+		if err == nil || os.IsNotExist(err) {
+			return nil
 		}
-		return nil, errors.Join(cleanupErrs...)
+		time.Sleep(50 * time.Millisecond)
 	}
+	return err
+}
 
-	// Once all registered worktrees are safely removed, everything remaining in
-	// this Grove-owned root is workspace metadata and must not block deletion.
-	if removeRootErr := os.RemoveAll(ws.Path); removeRootErr != nil && !os.IsNotExist(removeRootErr) {
-		ws.Repos = nil
-		cleanupErrs = append(cleanupErrs, fmt.Errorf("removing workspace root %s: %w", ws.Path, removeRootErr))
-		if stateErr := s.State.UpdateWorkspace(*ws); stateErr != nil {
-			cleanupErrs = append(cleanupErrs, fmt.Errorf("updating state: %w", stateErr))
+func isTrashItem(path string) bool {
+	parent := filepath.Base(filepath.Dir(path))
+	name := filepath.Base(path)
+	return parent == trashDirName && name != "" && name != "." && name != ".." && name != trashDirName
+}
+
+func quarantineWorkspace(path string) (string, error) {
+	trashRoot := filepath.Join(filepath.Dir(path), trashDirName)
+	if err := os.MkdirAll(trashRoot, 0o755); err != nil {
+		return "", err
+	}
+	dest := filepath.Join(trashRoot, filepath.Base(path)+"-"+strconv.FormatInt(time.Now().UnixNano(), 10))
+	if err := os.Rename(path, dest); err != nil {
+		return "", err
+	}
+	return dest, nil
+}
+
+func (s *Service) scheduleUnlink(path string) {
+	if s.StartUnlink != nil {
+		if err := s.StartUnlink(path); err != nil {
+			logging.Warn("failed to spawn unlink for %s: %s", path, err)
+			s.syncUnlink(path)
 		}
-		return nil, errors.Join(cleanupErrs...)
+		return
 	}
+	s.syncUnlink(path)
+}
 
-	if err := s.State.RemoveWorkspace(name); err != nil {
-		return nil, err
+func (s *Service) syncUnlink(path string) {
+	if err := s.unlinkTrash(path); err != nil && !os.IsNotExist(err) {
+		logging.Warn("failed to unlink quarantined workspace %s: %s", path, err)
 	}
-	return &original, nil
+}
+
+func (s *Service) unlinkTrash(path string) error {
+	if s.UnlinkTrash != nil {
+		return s.UnlinkTrash(path)
+	}
+	return UnlinkTrashPath(path)
+}
+
+func (s *Service) pruneWorktree(repo string) error {
+	if s.PruneWorktree != nil {
+		return s.PruneWorktree(repo)
+	}
+	return gitops.WorktreePrune(repo)
 }
 
 func (s *Service) runTeardownHooks(repos []models.RepoWorktree) {

--- a/internal/workspace/remove_test.go
+++ b/internal/workspace/remove_test.go
@@ -178,6 +178,53 @@ func TestDeleteStateRemovalFailureRestoresPath(t *testing.T) {
 	}
 }
 
+func TestDeleteRepairFailureIsReported(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	if err := env.createWorkspace("repair-ws", "feat/repair", []string{"api"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	env.svc.PruneWorktree = func(repo string) error {
+		return fmt.Errorf("simulated prune failure")
+	}
+	env.svc.RepairWorktree = func(repo, path string) error {
+		return fmt.Errorf("simulated repair failure")
+	}
+
+	err := env.svc.Delete("repair-ws")
+	if err == nil || !strings.Contains(err.Error(), "repair") {
+		t.Fatalf("expected repair failure to be reported, got %v", err)
+	}
+}
+
+func TestDoctorFixDoesNotDeleteTrashForMissingWorkspace(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	if err := env.createWorkspace("ghost-ws", "feat/ghost", []string{"api"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	ws, _ := env.svc.State.GetWorkspace("ghost-ws")
+	trashItem := filepath.Join(env.wsDir, ".trash", "ghost-ws-1")
+	if err := os.MkdirAll(filepath.Dir(trashItem), 0o755); err != nil {
+		t.Fatalf("create trash dir: %v", err)
+	}
+	if err := os.Rename(ws.Path, trashItem); err != nil {
+		t.Fatalf("quarantine fixture: %v", err)
+	}
+
+	_, _, err := env.svc.Doctor(true)
+	if err != nil {
+		t.Fatalf("doctor fix: %v", err)
+	}
+	if saved, _ := env.svc.State.GetWorkspace("ghost-ws"); saved == nil {
+		t.Fatal("doctor --fix should not drop state while workspace bytes sit in .trash")
+	}
+	if _, err := os.Stat(trashItem); err != nil {
+		t.Fatalf("doctor --fix should not unlink trash that may still belong to a workspace: %v", err)
+	}
+}
+
 func TestDeletePruneFailureRestoresPathAndState(t *testing.T) {
 	env := setupTestEnv(t)
 	env.createRepo("api")

--- a/internal/workspace/remove_test.go
+++ b/internal/workspace/remove_test.go
@@ -154,7 +154,31 @@ func TestDeleteForceRemovesDirtyWorktree(t *testing.T) {
 	}
 }
 
-func TestDeleteRemovalFailurePreservesPathAndState(t *testing.T) {
+func TestDeleteStateRemovalFailureRestoresPath(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	if err := env.createWorkspace("failed-state", "feat/failed-state", []string{"api"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	ws, _ := env.svc.State.GetWorkspace("failed-state")
+
+	env.svc.RemoveState = func(name string) error {
+		return fmt.Errorf("simulated state failure")
+	}
+
+	err := env.svc.Delete("failed-state")
+	if err == nil || !strings.Contains(err.Error(), "simulated state failure") {
+		t.Fatalf("expected state removal error, got %v", err)
+	}
+	if _, err := os.Stat(ws.Path); err != nil {
+		t.Fatalf("workspace path should be restored: %v", err)
+	}
+	if saved, _ := env.svc.State.GetWorkspace("failed-state"); saved == nil {
+		t.Fatal("workspace should remain in state")
+	}
+}
+
+func TestDeletePruneFailureRestoresPathAndState(t *testing.T) {
 	env := setupTestEnv(t)
 	env.createRepo("api")
 	if err := env.createWorkspace("failed-delete", "feat/failed-delete", []string{"api"}); err != nil {
@@ -162,16 +186,16 @@ func TestDeleteRemovalFailurePreservesPathAndState(t *testing.T) {
 	}
 
 	ws, _ := env.svc.State.GetWorkspace("failed-delete")
-	env.svc.RemoveWorktree = func(repo, path string, force bool) error {
-		return fmt.Errorf("simulated git failure")
+	env.svc.PruneWorktree = func(repo string) error {
+		return fmt.Errorf("simulated prune failure")
 	}
 
 	err := env.svc.Delete("failed-delete")
 	if err == nil || !strings.Contains(err.Error(), "api") {
-		t.Fatalf("expected repo-named removal error, got %v", err)
+		t.Fatalf("expected repo-named prune error, got %v", err)
 	}
 	if _, err := os.Stat(ws.Repos[0].WorktreePath); err != nil {
-		t.Fatalf("worktree path should remain: %v", err)
+		t.Fatalf("worktree path should be restored: %v", err)
 	}
 	if saved, _ := env.svc.State.GetWorkspace("failed-delete"); saved == nil || len(saved.Repos) != 1 {
 		t.Fatal("failed repo should remain in state")
@@ -327,5 +351,195 @@ func TestDeleteForceDeletesUnmergedBranch(t *testing.T) {
 	}
 	if gitops.BranchExists(env.repoMap["api"], "feat/force-unmerged") {
 		t.Error("force delete should remove an unmerged branch")
+	}
+}
+
+func TestDeleteDoesNotCallWorktreeRemove(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	if err := env.createWorkspace("del-ws", "feat/del", []string{"api"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	ws, _ := env.svc.State.GetWorkspace("del-ws")
+
+	env.svc.RemoveWorktree = func(repo, path string, force bool) error {
+		t.Fatal("git worktree remove should not run during workspace delete")
+		return nil
+	}
+
+	if err := env.svc.Delete("del-ws"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := os.Stat(ws.Path); !os.IsNotExist(err) {
+		t.Fatalf("original workspace path should be free, got %v", err)
+	}
+	if saved, _ := env.svc.State.GetWorkspace("del-ws"); saved != nil {
+		t.Fatal("workspace should be removed from state")
+	}
+}
+
+func TestDeleteFreesPathBeforeUnlink(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	if err := env.createWorkspace("del-ws", "feat/del", []string{"api"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	ws, _ := env.svc.State.GetWorkspace("del-ws")
+	marker := filepath.Join(ws.Repos[0].WorktreePath, "README.md")
+
+	env.svc.UnlinkTrash = func(path string) error {
+		return nil
+	}
+
+	if err := env.svc.Delete("del-ws"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := os.Stat(ws.Path); !os.IsNotExist(err) {
+		t.Fatalf("original workspace path should be free, got %v", err)
+	}
+	if saved, _ := env.svc.State.GetWorkspace("del-ws"); saved != nil {
+		t.Fatal("workspace should be removed from state")
+	}
+
+	matches, err := filepath.Glob(filepath.Join(env.wsDir, ".trash", "del-ws-*", "api", "README.md"))
+	if err != nil {
+		t.Fatalf("glob trash: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected quarantined worktree files, got %v", matches)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("original worktree path should be gone, got %v", err)
+	}
+}
+
+func TestDeleteUnlinksAfterRemovingState(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	if err := env.createWorkspace("del-ws", "feat/del", []string{"api"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	var seen *models.Workspace
+	env.svc.UnlinkTrash = func(path string) error {
+		seen, _ = env.svc.State.GetWorkspace("del-ws")
+		return nil
+	}
+
+	if err := env.svc.Delete("del-ws"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if seen != nil {
+		t.Fatal("unlink ran before workspace was removed from state")
+	}
+}
+
+func TestDeleteFallsBackToSyncUnlinkWhenSpawnFails(t *testing.T) {
+	readLog := setupLogging(t)
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	if err := env.createWorkspace("del-ws", "feat/del", []string{"api"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	env.svc.StartUnlink = func(path string) error {
+		return fmt.Errorf("spawn failed")
+	}
+
+	if err := env.svc.Delete("del-ws"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(env.wsDir, ".trash", "del-ws-*"))
+	if err != nil {
+		t.Fatalf("glob trash: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("spawn failure should fall back to sync unlink, leftover %v", matches)
+	}
+	if log := readLog(); !strings.Contains(log, "failed to spawn unlink") {
+		t.Errorf("log should mention spawn failure, got:\n%s", log)
+	}
+}
+
+func TestUnlinkTrashPathRejectsPathsOutsideTrash(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(dir, "not-trash")
+	if err := os.Mkdir(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := UnlinkTrashPath(outside); err == nil {
+		t.Fatal("expected rejection of path outside .trash")
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("non-trash path should remain: %v", err)
+	}
+}
+
+func TestUnlinkTrashPathRemovesTrashItem(t *testing.T) {
+	dir := t.TempDir()
+	item := filepath.Join(dir, ".trash", "ws-1")
+	if err := os.MkdirAll(filepath.Join(item, "api"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := UnlinkTrashPath(item); err != nil {
+		t.Fatalf("unlink trash: %v", err)
+	}
+	if _, err := os.Stat(item); !os.IsNotExist(err) {
+		t.Fatalf("trash item should be removed, got %v", err)
+	}
+}
+
+func TestDeleteSchedulesUnlinkWithoutWaiting(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	if err := env.createWorkspace("del-ws", "feat/del", []string{"api"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	var scheduled string
+	env.svc.StartUnlink = func(path string) error {
+		scheduled = path
+		return nil
+	}
+	env.svc.UnlinkTrash = func(path string) error {
+		t.Fatal("sync unlink should not run when background unlink starts")
+		return nil
+	}
+
+	if err := env.svc.Delete("del-ws"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if scheduled == "" {
+		t.Fatal("expected background unlink to be scheduled")
+	}
+	if !strings.Contains(scheduled, string(filepath.Separator)+".trash"+string(filepath.Separator)) {
+		t.Fatalf("scheduled unlink path %q is not in .trash", scheduled)
+	}
+	if _, err := os.Stat(scheduled); err != nil {
+		t.Fatalf("trash should still exist after delete returns: %v", err)
+	}
+}
+
+func TestDeleteAllowsRecreatingSameNameImmediately(t *testing.T) {
+	env := setupTestEnv(t)
+	env.createRepo("api")
+	if err := env.createWorkspace("reuse-ws", "feat/reuse", []string{"api"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	env.svc.UnlinkTrash = func(path string) error { return nil }
+	if err := env.svc.Delete("reuse-ws"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	if err := env.createWorkspace("reuse-ws", "feat/reuse", []string{"api"}); err != nil {
+		t.Fatalf("recreate: %v", err)
+	}
+	ws, _ := env.svc.State.GetWorkspace("reuse-ws")
+	if ws == nil {
+		t.Fatal("recreated workspace missing from state")
+	}
+	if _, err := os.Stat(filepath.Join(ws.Path, "api", "README.md")); err != nil {
+		t.Fatalf("recreated worktree missing: %v", err)
 	}
 }

--- a/internal/workspace/service.go
+++ b/internal/workspace/service.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/nicksenap/grove/internal/config"
 	"github.com/nicksenap/grove/internal/gitops"
@@ -14,19 +15,51 @@ import (
 type Service struct {
 	State          *state.Store
 	Stats          *stats.Tracker
+	WorkspaceDir   string
 	RunCmd         func(dir, cmd string) error
 	RunCmdSilent   func(dir, cmd string) error
 	RemoveWorktree func(repo, path string, force bool) error // optional test seam
+	PruneWorktree  func(repo string) error                   // optional test seam
+	UnlinkTrash    func(path string) error                   // optional test seam
+	StartUnlink    func(path string) error                   // optional test seam
+	RemoveState    func(name string) error                   // optional test seam
 }
 
 // NewService creates a Service with production dependencies.
 func NewService() *Service {
+	wsDir := config.DefaultWorkspaceDir
+	if cfg, err := config.Load(); err == nil && cfg != nil && cfg.WorkspaceDir != "" {
+		wsDir = cfg.WorkspaceDir
+	}
 	return &Service{
 		State:        state.NewStore(config.GroveDir),
 		Stats:        stats.NewTracker(config.GroveDir),
+		WorkspaceDir: wsDir,
 		RunCmd:       prodRunCmd,
 		RunCmdSilent: prodRunCmdSilent,
+		StartUnlink:  startUnlinkProcess,
 	}
+}
+
+var newUnlinkCommand = func(path string) *exec.Cmd {
+	exe, err := os.Executable()
+	if err != nil {
+		exe = "gw"
+	}
+	return exec.Command(exe, "unlink-trash", path)
+}
+
+func startUnlinkProcess(path string) error {
+	cmd := newUnlinkCommand(path)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Stdin = nil
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go cmd.Wait() //nolint:errcheck -- unlink failures are logged by the child
+	return nil
 }
 
 func (s *Service) removeWorktree(repo, path string, force bool) error {

--- a/internal/workspace/service.go
+++ b/internal/workspace/service.go
@@ -20,6 +20,7 @@ type Service struct {
 	RunCmdSilent   func(dir, cmd string) error
 	RemoveWorktree func(repo, path string, force bool) error // optional test seam
 	PruneWorktree  func(repo string) error                   // optional test seam
+	RepairWorktree func(repo, path string) error             // optional test seam
 	UnlinkTrash    func(path string) error                   // optional test seam
 	StartUnlink    func(path string) error                   // optional test seam
 	RemoveState    func(name string) error                   // optional test seam

--- a/internal/workspace/service_unlink_test.go
+++ b/internal/workspace/service_unlink_test.go
@@ -1,0 +1,20 @@
+package workspace
+
+import "testing"
+
+func TestNewUnlinkCommandInvokesUnlinkTrash(t *testing.T) {
+	cmd := newUnlinkCommand("/workspaces/.trash/foo-1")
+	found := false
+	for i, arg := range cmd.Args {
+		if arg != "unlink-trash" {
+			continue
+		}
+		if i+1 >= len(cmd.Args) || cmd.Args[i+1] != "/workspaces/.trash/foo-1" {
+			t.Fatalf("args = %v", cmd.Args)
+		}
+		found = true
+	}
+	if !found {
+		t.Fatalf("unlink-trash missing from %v", cmd.Args)
+	}
+}

--- a/openwiki/operations.md
+++ b/openwiki/operations.md
@@ -533,7 +533,7 @@ gw sync feat-login    # Runs git rebase in all repos concurrently
 Expected times for typical workspaces (5–10 repos):
 - `gw create` — 2–5 seconds (git clone, worktree setup)
 - `gw status` — 1–2 seconds (git status calls)
-- `gw delete` — <1 second (cleanup)
+- `gw delete` — <1 second for logical cleanup (path, git registrations, state); large trees unlink in the background
 
 ### Repo Discovery
 

--- a/openwiki/workflows.md
+++ b/openwiki/workflows.md
@@ -248,10 +248,11 @@ gw delete feat-login
 
 - Destructively removes the workspace without a confirmation prompt
 - Pre-delete hook fires (for example, `./scripts/workspace-closing {path}` to save external state); configure `on_failure = "abort"` to enforce deletion policy
+- Renames the workspace root into `<workspace-dir>/.trash/` so the original path is free immediately
 - For each repo in workspace:
-  - Calls `git worktree remove --force <path>` to remove the worktree
+  - Calls `git worktree prune --expire=now` to drop the relocated worktree registration
   - Calls `git branch -D <branch>` to delete the branch
-- Removes remaining Grove-owned workspace metadata and the workspace from state
+- Removes the workspace from state, then unlinks the quarantined bytes in the background
 - Optionally: runs the configured `on_close` hook (for example, a terminal-specific pane-closing script)
 
 ### Code Flow
@@ -259,8 +260,8 @@ gw delete feat-login
 1. **`cmd/delete.go`** — Runs `pre_delete` and orchestrates destructive deletion
 2. **`internal/lifecycle/lifecycle.go`** — Fires `pre_delete` hook with `{path}` placeholder
 3. **`internal/workspace/remove.go`** — `Delete()` method
-   - Calls `gitops.DeleteWorktree()` for each repo
-   - Calls `state.DeleteWorkspace()` to remove from state
+   - Quarantines the workspace root, prunes Git worktree registrations, and deletes branches
+   - Removes the workspace from state, then schedules a background unlink
 4. **`internal/operations/service.go`** — Applies the required `on_close` policy, then delegates hook execution to `internal/lifecycle/lifecycle.go`
 
 ### Key Decisions When Modifying


### PR DESCRIPTION
## Summary

- Make `gw delete` / `gw go -bd` return as soon as the workspace path is free, instead of walking `node_modules` under `git worktree remove` and `state.lock`.
- Quarantine the workspace with a same-filesystem rename into `<workspace-dir>/.trash/<name>-<id>/`, prune Git worktree registrations, delete branches, then drop Grove state.
- Unlink the quarantined bytes in a detached `gw unlink-trash` process. Spawn failure falls back to a synchronous unlink and is logged; leftover trash is reported and removable with `gw doctor --fix`.

## Why

`gw go -bd` currently waits for a full `gw delete` (PR #91). That wait is correct for *logical* cleanup — navigation must fail if state/git cleanup fails — but `git worktree remove --force` walks every file, so a fat JS workspace freezes the shell.

This keeps the #91 contract: `gw go` still waits for the logical delete. It only backgrounds the byte unlink.

## Verification

- `go test ./... -count=1`
- `go vet ./...`
- `gofmt -l .` clean
