### PR TITLE
feat: add gw prune --min-age to clean old workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- `gw prune [--min-age N]` lists workspaces created at least N days ago (default 7). Pass `--yes` to delete them with the same two-phase cleanup as `gw delete`: quarantine, prune git registrations, drop state, then unlink bytes in the background.
+
 ### Changed
 
 - `gw run` is no longer a builtin command. Install the first-party plugin with `gw plugin install nicksenap/gw-run`. Without it, `gw run` follows the normal unknown-command path. Core still parses `.grove.toml` `run` / `pre_run` / `post_run` keys (ownership decision tracked separately).

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ gw reset my-feature    # switch every repo back to the workspace branch, then sy
 
 # Clean up when done (destructive; use a pre_delete hook to enforce policy)
 gw delete my-feature   # removes worktrees, branches, and workspace files
+gw prune               # list workspaces older than 7 days
+gw prune --yes         # delete them (same two-phase cleanup as gw delete)
 ```
 
 Interactive menus support **type-to-search** filtering, arrow-key navigation (single-select), or arrow + tab (multi-select) with an `(all)` shortcut.

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/nicksenap/grove/internal/console"
+	"github.com/nicksenap/grove/internal/models"
+	"github.com/nicksenap/grove/internal/operations"
+	"github.com/nicksenap/grove/internal/state"
+	"github.com/nicksenap/grove/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+var (
+	pruneMinAge int
+	pruneYes    bool
+	pruneJSON   bool
+)
+
+var pruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "List or delete workspaces older than --min-age days",
+	Long:  "Checks workspaces whose created_at is at least --min-age days old (default 7). Pass --yes to delete them with the same two-phase cleanup as gw delete.",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runPrune(time.Now(), cmd.OutOrStdout()); err != nil {
+			exitError(err.Error())
+		}
+	},
+}
+
+func init() {
+	pruneCmd.Flags().IntVar(&pruneMinAge, "min-age", 7, "Minimum age in days")
+	pruneCmd.Flags().BoolVar(&pruneYes, "yes", false, "Delete matching workspaces")
+	pruneCmd.Flags().BoolVarP(&pruneJSON, "json", "j", false, "Output as JSON")
+}
+
+type pruneCandidate struct {
+	Name      string `json:"name"`
+	Branch    string `json:"branch"`
+	CreatedAt string `json:"created_at"`
+	AgeDays   int    `json:"age_days"`
+}
+
+func validatePruneMinAge(days int) error {
+	if days < 0 {
+		return fmt.Errorf("--min-age must be >= 0")
+	}
+	return nil
+}
+
+func pruneCandidates(workspaces []models.Workspace, minAgeDays int, now time.Time) []pruneCandidate {
+	old := workspace.OlderThan(workspaces, time.Duration(minAgeDays)*24*time.Hour, now)
+	out := make([]pruneCandidate, 0, len(old))
+	for _, ws := range old {
+		created, err := workspace.ParseCreatedAt(ws.CreatedAt, now.Location())
+		if err != nil {
+			continue
+		}
+		out = append(out, pruneCandidate{
+			Name:      ws.Name,
+			Branch:    ws.Branch,
+			CreatedAt: ws.CreatedAt,
+			AgeDays:   int(now.Sub(created) / (24 * time.Hour)),
+		})
+	}
+	return out
+}
+
+func writePrunePreview(candidates []pruneCandidate, minAgeDays int, jsonOutput, deleted bool, stdout io.Writer) error {
+	if jsonOutput {
+		if candidates == nil {
+			candidates = []pruneCandidate{}
+		}
+		data, err := json.MarshalIndent(candidates, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(stdout, string(data))
+		return nil
+	}
+
+	if len(candidates) == 0 {
+		console.Infof("No workspaces older than %d days.", minAgeDays)
+		return nil
+	}
+
+	table := console.NewTable(stdout, []string{"Name", "Branch", "Created", "Age"})
+	for _, c := range candidates {
+		created := c.CreatedAt
+		if len(created) > 10 {
+			created = created[:10]
+		}
+		table.AddRow([]string{c.Name, c.Branch, created, fmt.Sprintf("%dd", c.AgeDays)})
+	}
+	table.Render()
+	if !deleted {
+		console.Infof("Pass --yes to delete %d workspace(s) older than %d days.", len(candidates), minAgeDays)
+	}
+	return nil
+}
+
+func runPrune(now time.Time, stdout io.Writer) error {
+	if err := validatePruneMinAge(pruneMinAge); err != nil {
+		return err
+	}
+
+	workspaces, err := state.Load()
+	if err != nil {
+		return err
+	}
+
+	candidates := pruneCandidates(workspaces, pruneMinAge, now)
+	if !pruneYes {
+		return writePrunePreview(candidates, pruneMinAge, pruneJSON, false, stdout)
+	}
+
+	svc := operations.NewService()
+	for _, c := range candidates {
+		if _, err := svc.Delete(operations.DeleteRequest{
+			Name:    c.Name,
+			Options: workspace.RemoveOptions{Force: true},
+		}); err != nil {
+			return err
+		}
+	}
+	return writePrunePreview(candidates, pruneMinAge, pruneJSON, true, stdout)
+}

--- a/cmd/prune_test.go
+++ b/cmd/prune_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicksenap/grove/internal/models"
+)
+
+func TestPruneCommandDefaults(t *testing.T) {
+	if pruneCmd.Name() != "prune" {
+		t.Fatalf("command name = %q", pruneCmd.Name())
+	}
+	flag := pruneCmd.Flags().Lookup("min-age")
+	if flag == nil {
+		t.Fatal("missing --min-age flag")
+	}
+	if flag.DefValue != "7" {
+		t.Fatalf("--min-age default = %q, want 7", flag.DefValue)
+	}
+	yes := pruneCmd.Flags().Lookup("yes")
+	if yes == nil {
+		t.Fatal("missing --yes flag")
+	}
+	if yes.DefValue != "false" {
+		t.Fatalf("--yes default = %q, want false", yes.DefValue)
+	}
+}
+
+func TestPruneCandidatesReportsAgeDays(t *testing.T) {
+	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	ws := []models.Workspace{
+		{Name: "old", Branch: "feat/old", CreatedAt: now.Add(-10 * 24 * time.Hour).Format("2006-01-02T15:04:05.000000")},
+		{Name: "fresh", Branch: "feat/fresh", CreatedAt: now.Add(-2 * 24 * time.Hour).Format("2006-01-02T15:04:05.000000")},
+	}
+
+	got := pruneCandidates(ws, 7, now)
+	if len(got) != 1 {
+		t.Fatalf("got %+v, want only old", got)
+	}
+	if got[0].Name != "old" || got[0].Branch != "feat/old" || got[0].AgeDays != 10 {
+		t.Fatalf("candidate = %+v", got[0])
+	}
+}
+
+func TestWritePrunePreviewJSON(t *testing.T) {
+	var stdout bytes.Buffer
+	candidates := []pruneCandidate{{
+		Name:      "old",
+		Branch:    "feat/old",
+		CreatedAt: "2026-04-01T12:00:00.000000",
+		AgeDays:   9,
+	}}
+	if err := writePrunePreview(candidates, 7, true, false, &stdout); err != nil {
+		t.Fatal(err)
+	}
+	var decoded []pruneCandidate
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("json: %v\n%s", err, stdout.String())
+	}
+	if len(decoded) != 1 || decoded[0].Name != "old" || decoded[0].AgeDays != 9 {
+		t.Fatalf("decoded = %+v", decoded)
+	}
+}
+
+func TestWritePrunePreviewEmptyJSON(t *testing.T) {
+	var stdout bytes.Buffer
+	if err := writePrunePreview(nil, 7, true, false, &stdout); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(stdout.String()) != "[]" {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestValidatePruneMinAgeRejectsNegative(t *testing.T) {
+	if err := validatePruneMinAge(-1); err == nil {
+		t.Fatal("expected error for negative --min-age")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,7 @@ func init() {
 		listCmd,
 		wsCmd,
 		deleteCmd,
+		pruneCmd,
 		goCmd,
 		statusCmd,
 		addRepoCmd,

--- a/e2e/environment_test.go
+++ b/e2e/environment_test.go
@@ -123,7 +123,31 @@ func newEnv(t *testing.T) *env {
 	e.git(home, "config", "--global", "user.email", "e2e@grove.test")
 	e.git(home, "config", "--global", "user.name", "Grove E2E")
 	e.git(home, "config", "--global", "init.defaultBranch", "main")
+	// gw delete/prune spawn unlink-trash in the background. Wait for it before
+	// t.TempDir cleanup, otherwise Linux RemoveAll fails with ENOTEMPTY on .grove.
+	t.Cleanup(e.waitForBackgroundUnlink)
 	return e
+}
+
+func (e *env) waitForBackgroundUnlink() {
+	trash := filepath.Join(e.wsDir, ".trash")
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		entries, err := os.ReadDir(trash)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return
+			}
+			return
+		}
+		if len(entries) == 0 {
+			return
+		}
+		if !time.Now().Before(deadline) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }
 
 func (e *env) init() {

--- a/e2e/prune_test.go
+++ b/e2e/prune_test.go
@@ -1,0 +1,106 @@
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type pruneCandidateJSON struct {
+	Name      string `json:"name"`
+	Branch    string `json:"branch"`
+	CreatedAt string `json:"created_at"`
+	AgeDays   int    `json:"age_days"`
+}
+
+func TestPruneListsOldWorkspacesWithoutDeleting(t *testing.T) {
+	env := newEnv(t)
+	env.createRepo("svc-auth")
+	env.init()
+	env.mustGW("create", "old-ws", "--branch", "feat/old", "--repos", "svc-auth")
+	env.mustGW("create", "fresh-ws", "--branch", "feat/fresh", "--repos", "svc-auth")
+	env.backdateWorkspace("old-ws", 10*24*time.Hour)
+
+	res := env.mustGW("prune", "--json")
+	got := decodeJSON[[]pruneCandidateJSON](t, res.stdout)
+	if len(got) != 1 || got[0].Name != "old-ws" {
+		t.Fatalf("prune --json = %+v, want only old-ws", got)
+	}
+	if workspaceNamed(env.listWorkspaces(), "old-ws") == nil {
+		t.Fatal("dry-run prune deleted old-ws")
+	}
+	env.requireExists(env.workspacePath("old-ws"))
+}
+
+func TestPruneYesDeletesOldWorkspaces(t *testing.T) {
+	env := newEnv(t)
+	env.createRepo("svc-auth")
+	env.init()
+	env.mustGW("create", "old-ws", "--branch", "feat/old", "--repos", "svc-auth")
+	env.mustGW("create", "fresh-ws", "--branch", "feat/fresh", "--repos", "svc-auth")
+	env.backdateWorkspace("old-ws", 10*24*time.Hour)
+
+	env.mustGW("prune", "--yes")
+
+	if workspaceNamed(env.listWorkspaces(), "old-ws") != nil {
+		t.Fatal("old-ws still listed after prune --yes")
+	}
+	if workspaceNamed(env.listWorkspaces(), "fresh-ws") == nil {
+		t.Fatal("fresh-ws should be kept")
+	}
+	env.requireMissing(env.workspacePath("old-ws"))
+	env.requireExists(env.workspacePath("fresh-ws"))
+	if env.branchExists(filepath.Join(env.reposDir, "svc-auth"), "feat/old") {
+		t.Fatal("branch feat/old still present in source repo")
+	}
+}
+
+func TestPruneDefaultMinAgeKeepsRecentWorkspaces(t *testing.T) {
+	env := newEnv(t)
+	env.createRepo("svc-auth")
+	env.init()
+	env.mustGW("create", "fresh-ws", "--branch", "feat/fresh", "--repos", "svc-auth")
+
+	res := env.mustGW("prune", "--json")
+	got := decodeJSON[[]pruneCandidateJSON](t, res.stdout)
+	if len(got) != 0 {
+		t.Fatalf("default prune listed recent workspaces: %+v", got)
+	}
+}
+
+func (e *env) backdateWorkspace(name string, age time.Duration) {
+	e.t.Helper()
+	path := filepath.Join(e.groveDir, "state.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		e.t.Fatalf("read state: %v", err)
+	}
+	var workspaces []workspaceJSON
+	if err := json.Unmarshal(data, &workspaces); err != nil {
+		e.t.Fatalf("decode state: %v", err)
+	}
+	stamp := time.Now().Add(-age).Format("2006-01-02T15:04:05.000000")
+	found := false
+	for i := range workspaces {
+		if workspaces[i].Name == name {
+			workspaces[i].CreatedAt = stamp
+			found = true
+		}
+	}
+	if !found {
+		e.t.Fatalf("workspace %s not in state", name)
+	}
+	out, err := json.MarshalIndent(workspaces, "", "  ")
+	if err != nil {
+		e.t.Fatalf("encode state: %v", err)
+	}
+	if err := os.WriteFile(path, append(out, '\n'), 0o644); err != nil {
+		e.t.Fatalf("write state: %v", err)
+	}
+	if !strings.Contains(string(out), stamp) {
+		e.t.Fatalf("backdate did not persist created_at for %s", name)
+	}
+}

--- a/internal/workspace/prune.go
+++ b/internal/workspace/prune.go
@@ -1,0 +1,37 @@
+package workspace
+
+import (
+	"time"
+
+	"github.com/nicksenap/grove/internal/models"
+)
+
+const createdAtLayout = "2006-01-02T15:04:05.000000"
+
+// ParseCreatedAt parses a workspace created_at timestamp in loc so it matches
+// the local wall clock written by models.NewWorkspace.
+func ParseCreatedAt(value string, loc *time.Location) (time.Time, error) {
+	if loc == nil {
+		loc = time.UTC
+	}
+	if ts, err := time.ParseInLocation(createdAtLayout, value, loc); err == nil {
+		return ts, nil
+	}
+	return time.ParseInLocation("2006-01-02T15:04:05", value, loc)
+}
+
+// OlderThan returns workspaces whose created_at is at least minAge before now.
+// Workspaces with missing or unparseable created_at are skipped.
+func OlderThan(workspaces []models.Workspace, minAge time.Duration, now time.Time) []models.Workspace {
+	var out []models.Workspace
+	for _, ws := range workspaces {
+		created, err := ParseCreatedAt(ws.CreatedAt, now.Location())
+		if err != nil {
+			continue
+		}
+		if !created.After(now.Add(-minAge)) {
+			out = append(out, ws)
+		}
+	}
+	return out
+}

--- a/internal/workspace/prune_test.go
+++ b/internal/workspace/prune_test.go
@@ -1,0 +1,65 @@
+package workspace
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nicksenap/grove/internal/models"
+)
+
+func TestOlderThanIncludesWorkspacesAtLeastMinAge(t *testing.T) {
+	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	old := models.Workspace{Name: "old", CreatedAt: now.Add(-7 * 24 * time.Hour).Format("2006-01-02T15:04:05.000000")}
+	fresh := models.Workspace{Name: "fresh", CreatedAt: now.Add(-6 * 24 * time.Hour).Format("2006-01-02T15:04:05.000000")}
+
+	got := OlderThan([]models.Workspace{old, fresh}, 7*24*time.Hour, now)
+	if len(got) != 1 || got[0].Name != "old" {
+		t.Fatalf("got %+v, want only old", got)
+	}
+}
+
+func TestOlderThanIncludesExactBoundary(t *testing.T) {
+	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	ws := models.Workspace{Name: "boundary", CreatedAt: now.Add(-7 * 24 * time.Hour).Format("2006-01-02T15:04:05.000000")}
+
+	got := OlderThan([]models.Workspace{ws}, 7*24*time.Hour, now)
+	if len(got) != 1 {
+		t.Fatalf("workspace exactly min-age should be included, got %+v", got)
+	}
+}
+
+func TestOlderThanSkipsUnparseableCreatedAt(t *testing.T) {
+	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	got := OlderThan([]models.Workspace{
+		{Name: "empty", CreatedAt: ""},
+		{Name: "bad", CreatedAt: "not-a-date"},
+	}, time.Hour, now)
+	if len(got) != 0 {
+		t.Fatalf("unparseable created_at should be skipped, got %+v", got)
+	}
+}
+
+func TestParseCreatedAtUsesLocation(t *testing.T) {
+	loc := time.FixedZone("test", -7*3600)
+	ts, err := ParseCreatedAt("2026-04-10T12:00:00.000000", loc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ts.Location() != loc {
+		t.Fatalf("location = %v, want %v", ts.Location(), loc)
+	}
+	if ts.Hour() != 12 {
+		t.Fatalf("hour = %d, want 12 (wall clock in given location)", ts.Hour())
+	}
+}
+
+func TestOlderThanPreservesInputOrder(t *testing.T) {
+	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	first := models.Workspace{Name: "first", CreatedAt: now.Add(-10 * 24 * time.Hour).Format("2006-01-02T15:04:05.000000")}
+	second := models.Workspace{Name: "second", CreatedAt: now.Add(-8 * 24 * time.Hour).Format("2006-01-02T15:04:05.000000")}
+
+	got := OlderThan([]models.Workspace{first, second}, 7*24*time.Hour, now)
+	if len(got) != 2 || got[0].Name != "first" || got[1].Name != "second" {
+		t.Fatalf("got %+v", got)
+	}
+}

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -125,6 +125,7 @@ setup = ["npm install", "npm run build"]  # run after worktree creation
 | `gw run <name>` | Plugin: run `.grove.toml` processes (`gw plugin install nicksenap/gw-run`) |
 | `gw rename <name> --to <new>` | Rename a workspace |
 | `gw delete <name>` | Clean up workspace (worktrees + branches) |
+| `gw prune [--min-age N] [--yes]` | List or delete workspaces older than N days (default 7) |
 | `gw plugin install <repo>` | Install a plugin from GitHub |
 | `gw doctor` | Diagnose workspace issues |
 

--- a/openwiki/workflows.md
+++ b/openwiki/workflows.md
@@ -255,14 +255,28 @@ gw delete feat-login
 - Removes the workspace from state, then unlinks the quarantined bytes in the background
 - Optionally: runs the configured `on_close` hook (for example, a terminal-specific pane-closing script)
 
+### Prune Command
+
+```bash
+gw prune
+gw prune --min-age 14
+gw prune --yes
+```
+
+- Lists workspaces whose `created_at` is at least `--min-age` days old (default 7)
+- Does not delete unless `--yes` is passed
+- `--yes` deletes matching workspaces through the same two-phase path as `gw delete` (quarantine, prune git registrations, drop state, background unlink)
+- Age is based on workspace creation time, not last use (`gw go` is not recorded)
+
 ### Code Flow
 
 1. **`cmd/delete.go`** — Runs `pre_delete` and orchestrates destructive deletion
-2. **`internal/lifecycle/lifecycle.go`** — Fires `pre_delete` hook with `{path}` placeholder
-3. **`internal/workspace/remove.go`** — `Delete()` method
+2. **`cmd/prune.go`** — Filters workspaces by `created_at` age; `--yes` calls the same delete operation as `gw delete`
+3. **`internal/lifecycle/lifecycle.go`** — Fires `pre_delete` hook with `{path}` placeholder
+4. **`internal/workspace/remove.go`** — `Delete()` method
    - Quarantines the workspace root, prunes Git worktree registrations, and deletes branches
    - Removes the workspace from state, then schedules a background unlink
-4. **`internal/operations/service.go`** — Applies the required `on_close` policy, then delegates hook execution to `internal/lifecycle/lifecycle.go`
+5. **`internal/operations/service.go`** — Applies the required `on_close` policy, then delegates hook execution to `internal/lifecycle/lifecycle.go`
 
 ### Key Decisions When Modifying
 


### PR DESCRIPTION
## Summary
- Adds `gw prune [--min-age N]` (default 7 days) to list workspaces whose `created_at` is at least N days old.
- Pass `--yes` to delete matching workspaces through the same two-phase path as `gw delete`: quarantine, prune git registrations, drop state, then unlink bytes in the background.
- Dry-run is the default. `--json` prints candidates for agents.

## Usage
```bash
gw prune
gw prune --min-age 14
gw prune --yes
gw prune --json
```

Age is workspace creation time, not last use (`gw go` is not recorded).

## Test plan
- [x] `go test ./internal/workspace -run 'TestOlderThan|TestParseCreatedAt'`
- [x] `go test ./cmd -run TestPrune`
- [x] `go test ./e2e -run TestPrune`
- [x] `go test ./...`